### PR TITLE
🐛(posthog) add missing configuration

### DIFF
--- a/src/frontend/apps/conversations/src/services/PosthogAnalytic.tsx
+++ b/src/frontend/apps/conversations/src/services/PosthogAnalytic.tsx
@@ -60,6 +60,7 @@ export function PostHogProvider({
       },
       capture_pageview: false,
       capture_pageleave: true,
+      __add_tracing_headers: true,
     });
 
     const handleRouteChange = () => posthog?.capture('$pageview');


### PR DESCRIPTION
## Purpose

This should fix the issue of "$host" being unknown when checking for feature flag.


## Proposal

- [x] add Posthog middleware
- [x] ignore exception catching by default (use Sentry)
- [x] disable some URLs
