### PR TITLE
⚗️(users) allow to enable analytics by default

### DIFF
--- a/src/backend/conversations/settings.py
+++ b/src/backend/conversations/settings.py
@@ -481,6 +481,11 @@ class Base(Configuration):
         environ_name="FAKE_STREAMING_DELAY",
         environ_prefix=None,  # 25ms
     )
+    DEFAULT_ALLOW_CONVERSATION_ANALYTICS = values.BooleanValue(
+        default=False,
+        environ_name="DEFAULT_ALLOW_CONVERSATION_ANALYTICS",
+        environ_prefix=None,
+    )
 
     # These settings are default values used in the default LLM_CONFIGURATIONS
     # They allow a deployment with only one model without a specific configuration file

--- a/src/backend/core/authentication/backends.py
+++ b/src/backend/core/authentication/backends.py
@@ -57,3 +57,16 @@ class OIDCAuthenticationBackend(LaSuiteOIDCAuthenticationBackend):
             return self.UserModel.objects.get_user_by_sub_or_email(sub, email)
         except DuplicateEmailError as err:
             raise SuspiciousOperation(err.message) from err
+
+    def create_user(self, claims):
+        """
+        Create a new user with the given claims.
+
+        This is the only place where we create users, so we set the default value
+        for allow_conversation_analytics here.
+        This allows to enable analytics by default during the alpha version and get
+        more information about the usage of the application.
+        """
+        return super().create_user(
+            claims | {"allow_conversation_analytics": settings.DEFAULT_ALLOW_CONVERSATION_ANALYTICS}
+        )


### PR DESCRIPTION
## Purpose

This will be helpful to have analytics during the alpha deployment.


## Proposal

- [x] add specific setting for user creation
- [ ] add tests
