### PR TITLE
✨(web-search) add Brave search tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to
 - ✨(chat) enforce response in user language #24
 - 📈(langfuse) add light instrumentation #26
 - 🚑️(agent) allow Mistral w/ vLLM & tools #36
+- ✨(web-search) add Brave search tool #47
 
 
 [unreleased]: https://github.com/numerique-gouv/conversations/compare/HEAD...main

--- a/src/backend/chat/tests/tools/test_web_search_brave.py
+++ b/src/backend/chat/tests/tools/test_web_search_brave.py
@@ -1,0 +1,179 @@
+"""Tests for the Brave web search tool."""
+
+from unittest.mock import patch
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+import responses
+
+from chat.tools.web_search_brave import web_search_brave
+
+BRAVE_URL = "https://api.search.brave.com/res/v1/web/search"
+
+
+@pytest.fixture(autouse=True)
+def brave_settings(settings):
+    """Define Brave settings for tests."""
+    settings.BRAVE_API_KEY = "test_brave_api_key"
+    settings.BRAVE_API_TIMEOUT = 5
+    settings.BRAVE_SEARCH_COUNTRY = "US"
+    settings.BRAVE_SEARCH_LANG = "en"
+    settings.BRAVE_MAX_RESULTS = 3
+    settings.BRAVE_SEARCH_SAFE_SEARCH = "moderate"
+    settings.BRAVE_SEARCH_SPELLCHECK = True
+    settings.BRAVE_SEARCH_EXTRA_SNIPPETS = True
+
+
+@responses.activate
+def test_agent_web_search_brave_success_with_extra_snippets():
+    """Test when the Brave search returns results with extra_snippets."""
+    responses.add(
+        responses.GET,
+        BRAVE_URL,
+        json={
+            "web": {
+                "results": [
+                    {
+                        "url": "https://example.com/a",
+                        "title": "Result A",
+                        "extra_snippets": ["Snippet A1", "Snippet A2"],
+                    },
+                    {
+                        "url": "https://example.com/b",
+                        "title": "Result B",
+                        "extra_snippets": ["Snippet B1"],
+                    },
+                ]
+            }
+        },
+        status=200,
+    )
+
+    with patch("chat.tools.web_search_brave.fetch_url") as mock_fetch:
+        # Fetch should not be called since extra_snippets are provided
+        mock_fetch.side_effect = Exception("fetch_url should not be called")
+        tool_return = web_search_brave("test query")
+
+    assert hasattr(tool_return, "return_value")
+    assert tool_return.return_value == [
+        {
+            "link": "https://example.com/a",
+            "title": "Result A",
+            "extra_snippets": ["Snippet A1", "Snippet A2"],
+        },
+        {
+            "link": "https://example.com/b",
+            "title": "Result B",
+            "extra_snippets": ["Snippet B1"],
+        },
+    ]
+    assert tool_return.metadata["sources"] == {"https://example.com/a", "https://example.com/b"}
+
+    # Check request parameters
+    brave_request = responses.calls[0].request
+    parsed = urlparse(brave_request.url)
+    qs = parse_qs(parsed.query)
+    assert qs["q"] == ["test query"]
+    assert qs["count"] == ["3"]
+    assert qs["search_lang"] == ["en"]
+    assert qs["country"] == ["US"]
+    assert qs["safesearch"] == ["moderate"]
+    assert qs["spellcheck"] == ["True"]
+    assert qs["extra_snippets"] == ["True"]
+    assert qs["result_filter"] == ["web,faq,query"]
+
+
+@responses.activate
+def test_agent_web_search_brave_success_without_extra_snippets():
+    """Test when the Brave search returns results without extra_snippets."""
+    responses.add(
+        responses.GET,
+        BRAVE_URL,
+        json={
+            "web": {
+                "results": [
+                    {"url": "https://example.com/c", "title": "Result C"},  # pas d'extra_snippets
+                ]
+            }
+        },
+        status=200,
+    )
+
+    with patch("chat.tools.web_search_brave.fetch_url") as mock_fetch:
+        # Fetch should not be called since extra_snippets are provided
+        mock_fetch.return_value = (
+            '<html><body>Extracted Content C<a href="url">link</a></body></html>'
+        )
+        tool_return = web_search_brave("test query")
+
+    assert tool_return.return_value == [
+        {
+            "link": "https://example.com/c",
+            "title": "Result C",
+            "extra_snippets": ["Extracted Content C\nlink"],
+        }
+    ]
+    assert tool_return.metadata["sources"] == {"https://example.com/c"}
+
+
+@responses.activate
+def test_agent_web_search_brave_empty_results():
+    """Test when the Brave search returns no results."""
+    responses.add(
+        responses.GET,
+        BRAVE_URL,
+        json={"web": {"results": []}},
+        status=200,
+    )
+    tool_return = web_search_brave("empty query")
+    assert tool_return.return_value == []
+    assert tool_return.metadata["sources"] == set()
+
+
+@responses.activate
+def test_agent_web_search_brave_http_error():
+    """Test handling of HTTP errors from Brave API."""
+    responses.add(
+        responses.GET,
+        BRAVE_URL,
+        status=500,
+        json={"error": "Internal Server Error"},
+    )
+    with pytest.raises(Exception) as exc:
+        web_search_brave("error query")
+    assert "500" in str(exc.value) or "Internal Server Error" in str(exc.value)
+
+
+@responses.activate
+def test_agent_web_search_brave_params_exclude_none(settings):
+    """Check that None parameters are excluded from the request."""
+    settings.BRAVE_SEARCH_COUNTRY = None
+    settings.BRAVE_SEARCH_LANG = None
+
+    responses.add(
+        responses.GET,
+        BRAVE_URL,
+        json={"web": {"results": []}},
+        status=200,
+    )
+    web_search_brave("none params")
+
+    brave_request = responses.calls[0].request
+    parsed = urlparse(brave_request.url)
+    qs = parse_qs(parsed.query)
+
+    # Mandatory params
+    assert qs["q"] == ["none params"]
+    assert qs["count"] == ["3"]
+
+    # None params missing
+    assert "country" not in qs
+    assert "search_lang" not in qs
+
+    # Defined params present
+    assert qs["safesearch"] == ["moderate"]
+    assert qs["spellcheck"] == ["True"]
+    assert qs["extra_snippets"] == ["True"]
+
+    # Empty body for GET request
+    assert not brave_request.body

--- a/src/backend/chat/tools/__init__.py
+++ b/src/backend/chat/tools/__init__.py
@@ -4,6 +4,7 @@ from pydantic_ai import Tool, ToolDefinition
 
 from .fake_current_weather import get_current_weather
 from .web_seach_albert_rag import web_search_albert_rag
+from .web_search_brave import web_search_brave
 from .web_search_tavily import web_search_tavily
 
 
@@ -16,6 +17,9 @@ def get_pydantic_tools_by_name(name: str) -> Tool:
     """Get a tool by its name."""
     tool_dict = {
         "get_current_weather": Tool(get_current_weather, takes_ctx=False),
+        "web_search_brave": Tool(
+            web_search_brave, takes_ctx=False, prepare=only_if_web_search_enabled
+        ),
         "web_search_tavily": Tool(
             web_search_tavily, takes_ctx=False, prepare=only_if_web_search_enabled
         ),

--- a/src/backend/chat/tools/web_search_brave.py
+++ b/src/backend/chat/tools/web_search_brave.py
@@ -1,0 +1,60 @@
+"""Web search tool using Brave for the chat agent."""
+
+from django.conf import settings
+
+import requests
+from pydantic_ai.messages import ToolReturn
+from trafilatura import extract, fetch_url
+from trafilatura.meta import reset_caches
+
+
+def web_search_brave(query: str) -> ToolReturn:
+    """
+    Search the web for up-to-date information
+
+    Args:
+        query (str): The query to search for.
+    """
+    url = "https://api.search.brave.com/res/v1/web/search"
+    headers = {
+        "Accept": "application/json",
+        "X-Subscription-Token": settings.BRAVE_API_KEY,
+    }
+    data = {
+        "q": query,
+        "country": settings.BRAVE_SEARCH_COUNTRY,
+        "search_lang": settings.BRAVE_SEARCH_LANG,
+        "count": settings.BRAVE_MAX_RESULTS,
+        "safesearch": settings.BRAVE_SEARCH_SAFE_SEARCH,
+        "spellcheck": settings.BRAVE_SEARCH_SPELLCHECK,
+        "result_filter": "web,faq,query",
+        "extra_snippets": settings.BRAVE_SEARCH_EXTRA_SNIPPETS,
+    }
+    params = {k: v for k, v in data.items() if v is not None}
+    response = requests.get(url, headers=headers, params=params, timeout=settings.BRAVE_API_TIMEOUT)
+    response.raise_for_status()
+
+    json_response = response.json()
+
+    raw_search_results = json_response.get("web", {}).get("results", [])
+
+    # See https://api-dashboard.search.brave.com/app/documentation/web-search/responses#Result
+    # & https://api-dashboard.search.brave.com/app/documentation/web-search/responses#SearchResult
+
+    reset_caches()
+    for result in raw_search_results:
+        if not result.get("extra_snippets"):
+            document = extract(fetch_url(result["url"]), include_comments=False, no_fallback=True)
+            result["extra_snippets"] = [document] if document else []
+
+    return ToolReturn(
+        return_value=[
+            {
+                "link": result["url"],
+                "title": result["title"],
+                "extra_snippets": result.get("extra_snippets", []),
+            }
+            for result in raw_search_results
+        ],
+        metadata={"sources": {result["url"] for result in raw_search_results}},
+    )

--- a/src/backend/conversations/brave_settings.py
+++ b/src/backend/conversations/brave_settings.py
@@ -1,0 +1,50 @@
+"""Django configuration mixin for Brave settings."""
+
+from configurations import values
+
+
+class BraveSettings:
+    """Brave settings for web_search_brave tool."""
+
+    BRAVE_API_KEY = values.Value(
+        default=None,
+        environ_name="BRAVE_API_KEY",
+        environ_prefix=None,
+    )
+    BRAVE_API_TIMEOUT = values.IntegerValue(
+        default=5,
+        environ_name="BRAVE_API_TIMEOUT",
+        environ_prefix=None,
+    )
+
+    # Search
+    BRAVE_SEARCH_COUNTRY = values.Value(
+        default=None,
+        environ_name="BRAVE_SEARCH_COUNTRY",
+        environ_prefix=None,
+    )
+    BRAVE_SEARCH_LANG = values.Value(
+        default=None,
+        environ_name="BRAVE_SEARCH_LANG",
+        environ_prefix=None,
+    )
+    BRAVE_MAX_RESULTS = values.IntegerValue(
+        default=10,
+        environ_name="BRAVE_MAX_RESULTS",
+        environ_prefix=None,
+    )
+    BRAVE_SEARCH_SAFE_SEARCH = values.Value(
+        default="moderate",
+        environ_name="BRAVE_SEARCH_SAFE_SEARCH",
+        environ_prefix=None,
+    )  # off, moderate, strict
+    BRAVE_SEARCH_SPELLCHECK = values.BooleanValue(
+        default=True,
+        environ_name="BRAVE_SEARCH_SPELLCHECK",
+        environ_prefix=None,
+    )
+    BRAVE_SEARCH_EXTRA_SNIPPETS = values.BooleanValue(
+        default=True,
+        environ_name="BRAVE_SEARCH_EXTRA_SNIPPETS",
+        environ_prefix=None,
+    )

--- a/src/backend/conversations/settings.py
+++ b/src/backend/conversations/settings.py
@@ -28,6 +28,7 @@ from sentry_sdk.integrations.logging import ignore_logger
 from core.feature_flags.flags import FeatureFlags, FeatureToggle
 
 from chat.llm_configuration import cached_load_llm_configuration, load_llm_configuration
+from conversations.brave_settings import BraveSettings
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -46,7 +47,7 @@ def get_release():
         return "NA"  # Default: not available
 
 
-class Base(Configuration):
+class Base(BraveSettings, Configuration):
     """
     This is the base configuration every configuration (aka environment) should inherit from. It
     is recommended to configure third-party applications by creating a configuration mixins in

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
     "gunicorn==23.0.0",
     "jsonschema==4.25.1",
     "langfuse==3.5.0",
-    "lxml==6.0.2",
+    "lxml==5.4.0",
     "markdown==3.9",
     "markitdown==0.0.2",
     "mozilla-django-oidc==4.0.1",
@@ -62,6 +62,7 @@ dependencies = [
     "redis<6.0.0",
     "requests==2.32.5",
     "sentry-sdk==2.38.0",
+    "trafilatura==2.0.0",
     "whitenoise==6.11.0",
 ]
 


### PR DESCRIPTION
## Purpose

This allows to use Brave as a web search engine in a tool.

=> https://api-dashboard.search.brave.com/app/documentation/web-search/get-started


## Proposal

- [x] add Brave search web tool
