### PR TITLE
📌(pylint) pylint-django does not support pylint >=4 yet

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -22,6 +22,12 @@
       "allowedVersions": "==0.0.2"
     },
     {
+      "groupName": "ignore recent pylint versions not supported by pylint-django",
+      "matchManagers": ["pep621"],
+      "matchPackageNames": ["pylint"],
+      "allowedVersions": "<4"
+    },
+    {
       "enabled": false,
       "groupName": "ignored js dependencies",
       "matchManagers": ["npm"],


### PR DESCRIPTION
## Purpose

https://github.com/pylint-dev/pylint-django/issues/467


## Proposal

- [x] restrict pylint to version below 4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated dependency automation rules to constrain updates for a specific linter package within PEP 621–managed projects.
  - Added a grouping identifier for the new rule to simplify maintenance.
  - Ensures dependency update behavior remains predictable across affected projects.
  - No user-facing changes; application features, UI, and performance remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->