### PR TITLE
⚰️(RAG) remove old `RAG_WEB_SEARCH_BACKEND` setting

### DIFF
--- a/src/backend/chat/tests/views/chat/conversations/test_conversation.py
+++ b/src/backend/chat/tests/views/chat/conversations/test_conversation.py
@@ -35,9 +35,6 @@ def ai_settings(settings):
     settings.AI_API_KEY = "test-api-key"
     settings.AI_MODEL = "test-model"
 
-    # Disable web search backend for tests
-    settings.RAG_WEB_SEARCH_BACKEND = None
-
     return settings
 
 

--- a/src/backend/chat/tests/views/chat/conversations/test_conversation_with_history.py
+++ b/src/backend/chat/tests/views/chat/conversations/test_conversation_with_history.py
@@ -32,9 +32,6 @@ def ai_settings(settings):
     settings.AI_API_KEY = "test-api-key"
     settings.AI_MODEL = "test-model"
 
-    # Disable web search backend for tests
-    settings.RAG_WEB_SEARCH_BACKEND = None
-
     return settings
 
 

--- a/src/backend/conversations/settings.py
+++ b/src/backend/conversations/settings.py
@@ -566,12 +566,6 @@ class Base(BraveSettings, Configuration):
     )
 
     # Web search
-    RAG_WEB_SEARCH_BACKEND = values.Value(
-        # "chat.agent_rag.web_search.albert_api.AlbertWebSearchManager",
-        "chat.agent_rag.web_search.mocked.MockedWebSearchManager",
-        environ_name="RAG_WEB_SEARCH_BACKEND",
-        environ_prefix=None,
-    )
     RAG_WEB_SEARCH_PROMPT_UPDATE = values.Value(
         """
 You are a subject-matter expert assistant. 
@@ -794,12 +788,7 @@ USER QUESTION:
             }
         )
 
-        # Sanity check to ensure that the RAG_WEB_SEARCH_BACKEND and RAG_DOCUMENT_SEARCH_BACKEND
-        if features.web_search and not self.RAG_WEB_SEARCH_BACKEND:
-            raise RuntimeError(
-                "RAG_WEB_SEARCH_BACKEND is not set, but web_search feature flag is enabled."
-            )
-
+        # Sanity check to ensure that if document upload is enabled, a backend is set
         if features.document_upload and not self.RAG_DOCUMENT_SEARCH_BACKEND:
             raise RuntimeError(
                 "RAG_DOCUMENT_SEARCH_BACKEND is not set, "


### PR DESCRIPTION
## Purpose

This settings has been removed when we switched to tool calls.


## Proposal

- [x] remove `RAG_WEB_SEARCH_BACKEND ` in code



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Simplified web search configuration by removing the explicit backend setting; the system now relies on the default backend.
  - Streamlined feature flag validation to ensure document upload requires a configured document search backend.

- Tests
  - Updated test setup to no longer disable web search, aligning tests with the default configuration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->