### PR TITLE
🐛(chat) fix the file format restriction for upload

### DIFF
--- a/src/frontend/apps/conversations/src/features/chat/components/InputChat.tsx
+++ b/src/frontend/apps/conversations/src/features/chat/components/InputChat.tsx
@@ -315,6 +315,7 @@ export const InputChat = ({
             )}
 
             <input
+              accept={conf?.chat_upload_accept}
               type="file"
               multiple
               ref={fileInputRef}


### PR DESCRIPTION
## Purpose

Restore the `accept` attribute which allows to restrict which kind of file the user can upload.
This attribute is driven by the backend.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * File upload filtering in chat is now configurable, restricting selectable file types based on system configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->