### PR TITLE
✨(activation-codes) allow code customization

### DIFF
--- a/src/backend/activation_codes/admin.py
+++ b/src/backend/activation_codes/admin.py
@@ -33,7 +33,6 @@ class ActivationCodeAdmin(admin.ModelAdmin):
 
     readonly_fields = (
         "id",
-        "code",
         "current_uses",
         "created_at",
         "updated_at",
@@ -78,6 +77,19 @@ class ActivationCodeAdmin(admin.ModelAdmin):
     )
 
     actions = ["recompute_current_uses"]
+
+    def get_readonly_fields(self, request, obj=None):
+        """Make `code` readonly when editing an existing ActivationCode.
+
+        When obj is None (creation form), `code` remains editable. When obj is
+        provided (editing), add `code` to readonly fields so it cannot be
+        changed after creation.
+        """
+        # Start from the configured readonly_fields to preserve other read-only fields
+        ro_fields = list(self.readonly_fields)
+        if obj is not None:
+            ro_fields.append("code")
+        return tuple(ro_fields)
 
     def usage_display(self, obj):
         """Display usage statistics."""

--- a/src/backend/activation_codes/migrations/0001_initial.py
+++ b/src/backend/activation_codes/migrations/0001_initial.py
@@ -54,6 +54,12 @@ class Migration(migrations.Migration):
                         help_text="The activation code that users will enter",
                         max_length=50,
                         unique=True,
+                        validators=[
+                            django.core.validators.RegexValidator(
+                                message="Code must be alphanumeric and contain no spaces or special characters",
+                                regex="^[A-Z0-9]+$",
+                            )
+                        ],
                         verbose_name="activation code",
                     ),
                 ),

--- a/src/backend/activation_codes/models.py
+++ b/src/backend/activation_codes/models.py
@@ -7,6 +7,7 @@ import secrets
 import string
 
 from django.core.exceptions import ValidationError
+from django.core.validators import RegexValidator
 from django.db import IntegrityError, models, transaction
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
@@ -37,6 +38,12 @@ class ActivationCode(BaseModel):
         max_length=50,
         unique=True,
         default=generate_activation_code,
+        validators=[
+            RegexValidator(
+                regex=r"^[A-Z0-9]+$",
+                message=_("Code must be alphanumeric and contain no spaces or special characters"),
+            )
+        ],
     )
 
     max_uses = models.PositiveIntegerField(


### PR DESCRIPTION
## Purpose

The activation codes can be fully customized on creation and not edited afterward.

- Code must be only composed of upper case letters and digits, like `AWESOMECODE123`.
- When the user enters the code, spaces and hyphens will be removed and the case will be forced to upper case, hence the code we give to the use can be `AWESOME-CODE-123` or `Awesome-Code-123` (even `AwesSome CoDe-123` is OK, you got the idea)


## Proposal

- [x] allow initial code edition
- [x] add a regex validation to prevent unusable code from being defined 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Activation codes now validated to enforce uppercase alphanumeric format (A-Z, 0-9 only, no spaces or special characters).

* **Improvements**
  * Admin interface refined: activation codes remain editable during creation but become read-only when editing existing codes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->