### PR TITLE
📈(posthog) add sub field to tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to
 ### Added
 
 - ✨(activation-codes) register users also on Brevo #98
+- 📈(posthog) add `sub` field to tracking #95
 
 ### Changed
 

--- a/src/backend/core/api/serializers.py
+++ b/src/backend/core/api/serializers.py
@@ -17,8 +17,9 @@ class UserSerializer(serializers.ModelSerializer):
             "full_name",
             "short_name",
             "language",
+            "sub",
         ]
-        read_only_fields = ["id", "email", "full_name", "short_name"]
+        read_only_fields = ["id", "email", "full_name", "short_name", "sub"]
 
 
 class UserLightSerializer(UserSerializer):

--- a/src/backend/core/tests/test_api_users.py
+++ b/src/backend/core/tests/test_api_users.py
@@ -229,6 +229,7 @@ def test_api_users_retrieve_me_authenticated():
         "full_name": user.full_name,
         "language": user.language,
         "short_name": user.short_name,
+        "sub": user.sub,
     }
 
 

--- a/src/frontend/apps/conversations/src/features/auth/api/types.ts
+++ b/src/frontend/apps/conversations/src/features/auth/api/types.ts
@@ -5,6 +5,7 @@
  * @property {string} email - The email of the user.
  * @property {string} name - The name of the user.
  * @property {string} language - The language of the user. e.g. 'en-us', 'fr-fr', 'de-de'.
+ * @property {string} sub - The identity provider sub.
  */
 export interface User {
   id: string;
@@ -13,4 +14,5 @@ export interface User {
   short_name: string;
   language?: string;
   allow_conversation_analytics: boolean;
+  sub?: string;
 }

--- a/src/frontend/apps/conversations/src/features/auth/hooks/__tests__/useAuth.test.tsx
+++ b/src/frontend/apps/conversations/src/features/auth/hooks/__tests__/useAuth.test.tsx
@@ -39,7 +39,7 @@ jest.mock('next/router', () => ({
   }),
 }));
 
-const dummyUser = { id: '123', email: 'test@example.com' };
+const dummyUser = { id: '123', email: 'test@example.com', sub: 'test-sub' };
 
 describe('useAuth hook - trackEvent effect', () => {
   beforeEach(() => {
@@ -63,6 +63,7 @@ describe('useAuth hook - trackEvent effect', () => {
         eventName: 'user',
         id: dummyUser.id,
         email: dummyUser.email,
+        sub: dummyUser.sub,
       });
     });
   });

--- a/src/frontend/apps/conversations/src/features/auth/hooks/useAuth.tsx
+++ b/src/frontend/apps/conversations/src/features/auth/hooks/useAuth.tsx
@@ -31,6 +31,7 @@ export const useAuth = () => {
         eventName: 'user',
         id: user?.id || '',
         email: user?.email || '',
+        sub: user?.sub,
       });
       setHasTracked(true);
     }

--- a/src/frontend/apps/conversations/src/libs/Analytics.tsx
+++ b/src/frontend/apps/conversations/src/libs/Analytics.tsx
@@ -7,6 +7,7 @@ type AnalyticEventUser = {
   eventName: 'user';
   id: string;
   email: string;
+  sub?: string;
 };
 
 export type AnalyticEvent = AnalyticEventClick | AnalyticEventUser;

--- a/src/frontend/apps/conversations/src/services/PosthogAnalytic.tsx
+++ b/src/frontend/apps/conversations/src/services/PosthogAnalytic.tsx
@@ -21,6 +21,9 @@ export class PostHogAnalytic extends AbstractAnalytic {
   public trackEvent(evt: AnalyticEvent): void {
     if (evt.eventName === 'user') {
       posthog.identify(evt.id, { email: evt.email });
+      if (evt.sub) {
+        posthog.alias(evt.sub, evt.id);
+      }
     }
   }
 


### PR DESCRIPTION
## Purpose

Right now, we track users in posthog using internal user.id. However, this id is not shared amongst other analytics tools or external dependencies, resulting in inconsistent tracking. This PR will then allow to merge analytics from posthog and langfuse.


## Proposal

- Allow posthog identification using IdP sub.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Current-user API now exposes a new public "sub" identifier.
  * Analytics events include the "sub" identifier and use it for aliasing/identification to improve tracking.

* **Tests**
  * Updated tests and fixtures to expect the new "sub" field.

* **Documentation**
  * API types/JSDoc updated to document the optional "sub" property.

* **Chores**
  * Changelog updated with the tracking/`sub` addition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->