### PR TITLE
✨(activation-codes) register users also on Brevo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,14 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- ✨(activation-codes) register users also on Brevo #98
+
+### Changed
+
 - 🐛(front) code activation fix session end #93
+
 
 ## [0.0.1] - 2025-10-19
 

--- a/src/backend/activation_codes/viewsets.py
+++ b/src/backend/activation_codes/viewsets.py
@@ -10,6 +10,7 @@ from rest_framework import status, viewsets
 from rest_framework.decorators import action
 from rest_framework.response import Response
 
+from core.brevo import add_user_to_brevo_list
 from core.permissions import IsAuthenticated
 
 from . import models, serializers
@@ -136,6 +137,10 @@ class ActivationViewSet(viewsets.GenericViewSet):
                 {"code": "registration-successful"},
                 status=status.HTTP_200_OK,
             )
+
+        add_user_to_brevo_list(
+            [serializer.validated_data["user"].email], settings.BREVO_WAITING_LIST_ID
+        )
 
         logger.info(
             "Registered email %s for activation notifications",

--- a/src/backend/conversations/settings.py
+++ b/src/backend/conversations/settings.py
@@ -602,6 +602,22 @@ class Base(BraveSettings, Configuration):
         default=False, environ_name="ACTIVATION_REQUIRED", environ_prefix=None
     )
 
+    BREVO_API_KEY = values.Value(
+        default=None,
+        environ_name="BREVO_API_KEY",
+        environ_prefix=None,
+    )
+    BREVO_FOLLOWUP_LIST_ID = values.Value(
+        default=None,
+        environ_name="BREVO_FOLLOWUP_LIST_ID",
+        environ_prefix=None,
+    )
+    BREVO_WAITING_LIST_ID = values.Value(
+        default=None,
+        environ_name="BREVO_WAITING_LIST_ID",
+        environ_prefix=None,
+    )
+
     # AI service
     _llm_configuration_file_path = values.Value(
         os.path.join(BASE_DIR, "conversations/configuration/llm/default.json"),

--- a/src/backend/core/brevo.py
+++ b/src/backend/core/brevo.py
@@ -1,0 +1,87 @@
+"""Functions for interacting with Brevo API to manage contacts in a waiting list."""
+
+import logging
+from typing import List, Optional
+
+from django.conf import settings
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+def add_user_to_brevo_list(emails: List[str], list_id: Optional[str]) -> None:
+    """
+    Add email list to a Brevo list.
+
+    Args:
+        emails (List[str]): The email address(es) of the user(s).
+        list_id (str): The Brevo waiting list ID, can be None if not configured.
+
+    """
+    api_key = settings.BREVO_API_KEY
+    if not api_key or not list_id:
+        logger.info("Brevo API key or list ID not configured: skipping adding contact")
+        return
+
+    url = f"https://api.brevo.com/v3/contacts/lists/{list_id}/contacts/add"
+    headers = {
+        "accept": "application/json",
+        "api-key": api_key,
+        "content-type": "application/json",
+    }
+    payload = {
+        "emails": emails,
+    }
+    try:
+        response = requests.post(url, json=payload, headers=headers, timeout=5)
+    except requests.RequestException as e:
+        logger.exception(e)
+        return
+
+    if response.status_code != 201:
+        logger.error(
+            "Error adding contacts to Brevo (%s) %s: (%s) %s",
+            list_id,
+            emails,
+            response.status_code,
+            response.text,
+        )
+
+
+def remove_user_from_brevo_list(emails: List[str], list_id: Optional[str]) -> None:
+    """
+    Remove email list from a Brevo list.
+
+    Args:
+        emails (List[str]): The email address(es) of the user(s).
+        list_id (str): The Brevo waiting list ID, can be None if not configured.
+
+    """
+    api_key = settings.BREVO_API_KEY
+    if not api_key or not list_id:
+        logger.info("Brevo API key or list ID not configured: skipping removing contact")
+        return
+
+    url = f"https://api.brevo.com/v3/contacts/lists/{list_id}/contacts/remove"
+    headers = {
+        "accept": "application/json",
+        "api-key": api_key,
+        "content-type": "application/json",
+    }
+    payload = {
+        "emails": emails,
+    }
+    try:
+        response = requests.post(url, json=payload, headers=headers, timeout=5)
+    except requests.RequestException as e:
+        logger.exception(e)
+        return
+    if response.status_code != 201:
+        logger.error(
+            "Error removing contacts from Brevo (%s) %s: (%s) %s",
+            list_id,
+            emails,
+            response.status_code,
+            response.text,
+        )


### PR DESCRIPTION
## Purpose

This provides a way to store the users on Brevo directly for later product opening mail campaign.


## Proposal

- [x] add best-effort Brevo contact add/remove from specific list



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Registrations, activation use, and logins now subscribe users to a configurable Brevo follow-up list and remove them from a Brevo waiting list when applicable.

* **Admin**
  * Admins can add or remove registration requests from the Brevo waiting list via new admin actions.

* **Configuration**
  * New Brevo settings to configure API key and list IDs.

* **Tests**
  * Added integration tests covering Brevo notification, idempotency, and failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->