### PR TITLE
💬(wording) error page wording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to
 ### Changed
 
 - 🐛(front) code activation fix session end #93
+- 💬(wording) error page wording #102
 
 
 ## [0.0.1] - 2025-10-19

--- a/src/frontend/apps/conversations/src/pages/401.tsx
+++ b/src/frontend/apps/conversations/src/pages/401.tsx
@@ -40,7 +40,7 @@ const Page: NextPageWithLayout = () => {
 
       <Box $align="center" $gap="0.8rem">
         <Text as="p" $textAlign="center" $maxWidth="350px" $theme="primary">
-          {t('Log in to access the document.')}
+          {t('Log in to access this page.')}
         </Text>
 
         <Button onClick={() => gotoLogin(false)} aria-label={t('Login')}>

--- a/src/frontend/apps/conversations/src/pages/403.tsx
+++ b/src/frontend/apps/conversations/src/pages/403.tsx
@@ -48,7 +48,7 @@ const Page: NextPageWithLayout = () => {
 
         <Box $align="center" $gap="0.8rem">
           <Text as="p" $textAlign="center" $maxWidth="350px" $theme="primary">
-            {t('You do not have permission to view this document.')}
+            {t('You do not have permission to view this page.')}
           </Text>
 
           <StyledLink href="/">


### PR DESCRIPTION
change error page wording

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated error page messaging on authentication (401) and permissions (403) pages for improved clarity: "Log in to access this page" and "You do not have permission to view this page."
  * Added an Unreleased changelog entry noting the error page wording update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->