### PR TITLE
⚡️(web-search) allow to override returned chunks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to
 
 - 🐛(front) code activation fix session end #93
 - 💬(wording) error page wording #102
+- ⚡️(web-search) allow to override returned chunks #107
 
 
 ## [0.0.1] - 2025-10-19

--- a/src/backend/chat/agent_rag/document_search/albert_api.py
+++ b/src/backend/chat/agent_rag/document_search/albert_api.py
@@ -169,11 +169,12 @@ class AlbertRagDocumentSearch:
         self._store_document(name, document_content)
         return document_content
 
-    def search(self, query):
+    def search(self, query, results_count: int = 4) -> RAGWebResults:
         """
         Perform a search using the Albert API based on the provided query.
 
         :param query: The search query string.
+        :param results_count: The number of results to return.
         :return: Search results from the Albert API.
         """
         response = requests.post(
@@ -183,6 +184,7 @@ class AlbertRagDocumentSearch:
                 "collections": [self.collection_id],
                 "prompt": query,
                 "score_threshold": 0.6,
+                "k": results_count,  # Number of chunks to return from the search
             },
             timeout=settings.ALBERT_API_TIMEOUT,
         )

--- a/src/backend/chat/tools/web_search_brave.py
+++ b/src/backend/chat/tools/web_search_brave.py
@@ -210,7 +210,10 @@ def web_search_brave_with_document_backend(ctx: RunContext, query: str) -> ToolR
                     except Exception as e:  # pylint: disable=broad-except
                         logger.exception("Error fetching/storing document: %s", e)
 
-        rag_results = document_store.search(query)
+        rag_results = document_store.search(
+            query,
+            results_count=settings.BRAVE_RAG_WEB_SEARCH_CHUNK_NUMBER,
+        )
 
         ctx.usage += RunUsage(
             input_tokens=rag_results.usage.prompt_tokens,

--- a/src/backend/conversations/brave_settings.py
+++ b/src/backend/conversations/brave_settings.py
@@ -23,6 +23,13 @@ class BraveSettings:
         environ_prefix=None,
     )
 
+    # For web_search_brave_with_document_backend: number of chunks to retrieve RAG search
+    BRAVE_RAG_WEB_SEARCH_CHUNK_NUMBER = values.IntegerValue(
+        default=10,
+        environ_name="BRAVE_RAG_WEB_SEARCH_CHUNK_NUMBER",
+        environ_prefix=None,
+    )
+
     # For optimal performance, BRAVE_MAX_WORKERS should be equal to BRAVE_MAX_RESULTS
     # also considering the number of concurrent requests your server can handle.
     BRAVE_MAX_WORKERS = values.IntegerValue(


### PR DESCRIPTION
## Purpose

When using the document vector storage, we want to be able to return more chunks.


## Proposal

- [x] add a parameter in the `search` method
- [x] add a specific setting for the value for web search


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to configure the number of search result chunks returned from web search operations. New setting with a default value of 10 allows users to customize RAG retrieval behavior based on their needs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->