### PR TITLE
🐛(activation-codes) create contact in brevo before add to list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to
 - 🐛(front) code activation fix session end #93
 - 💬(wording) error page wording #102
 - ⚡️(web-search) allow to override returned chunks #107
+- 🐛(activation-codes) create contact in brevo before add to list #108
 
 
 ## [0.0.1] - 2025-10-19

--- a/src/backend/activation_codes/tests/test_models.py
+++ b/src/backend/activation_codes/tests/test_models.py
@@ -293,6 +293,11 @@ def test_activation_code_use_success_notify_brevo(settings):
         status=201,
     )
 
+    brevo_create_contact = responses.post(
+        "https://api.brevo.com/v3/contacts",
+        status=200,
+    )
+
     brevo_add_mock = responses.post(
         "https://api.brevo.com/v3/contacts/lists/test_followup_list_name/contacts/add",
         json={"message": "Contacts added successfully"},
@@ -310,6 +315,13 @@ def test_activation_code_use_success_notify_brevo(settings):
     assert len(brevo_remove_mock.calls) == 1
     assert brevo_remove_mock.calls[0].request.headers["api-key"] == "test_brevo_api_key"
     assert json.loads(brevo_remove_mock.calls[0].request.body) == {"emails": [user.email]}
+
+    assert len(brevo_create_contact.calls) == 1
+    assert brevo_create_contact.calls[0].request.headers["api-key"] == "test_brevo_api_key"
+    assert json.loads(brevo_create_contact.calls[0].request.body) == {
+        "email": user.email,
+        "updateEnabled": True,
+    }
 
     assert len(brevo_add_mock.calls) == 1
     assert brevo_add_mock.calls[0].request.headers["api-key"] == "test_brevo_api_key"

--- a/src/backend/core/brevo.py
+++ b/src/backend/core/brevo.py
@@ -10,6 +10,47 @@ import requests
 logger = logging.getLogger(__name__)
 
 
+def create_contact_in_brevo(email: str) -> bool:
+    """
+    Create a contact in Brevo.
+
+    Args:
+        email (str): The email address of the user.
+
+    """
+    api_key = settings.BREVO_API_KEY
+    if not api_key:
+        logger.info("Brevo API key not configured: skipping creating contact")
+        return False
+
+    url = "https://api.brevo.com/v3/contacts"
+    headers = {
+        "accept": "application/json",
+        "api-key": api_key,
+        "content-type": "application/json",
+    }
+    payload = {
+        "email": email,
+        "updateEnabled": True,
+    }
+    try:
+        response = requests.post(url, json=payload, headers=headers, timeout=5)
+    except requests.RequestException as e:
+        logger.exception(e)
+        return False
+
+    if not response.ok:
+        logger.error(
+            "Error creating contact in Brevo %s: (%s) %s",
+            email,
+            response.status_code,
+            response.text,
+        )
+        return False
+
+    return True
+
+
 def add_user_to_brevo_list(emails: List[str], list_id: Optional[str]) -> None:
     """
     Add email list to a Brevo list.
@@ -23,6 +64,13 @@ def add_user_to_brevo_list(emails: List[str], list_id: Optional[str]) -> None:
     if not api_key or not list_id:
         logger.info("Brevo API key or list ID not configured: skipping adding contact")
         return
+
+    for email in emails:
+        # Ensure the contact exists before adding to the list
+        # `emails` contains several emails only when used from the admin interface bulk action
+        if not create_contact_in_brevo(email):
+            logger.error("Failed to create contact %s in Brevo, skipping adding to list", email)
+            return
 
     url = f"https://api.brevo.com/v3/contacts/lists/{list_id}/contacts/add"
     headers = {


### PR DESCRIPTION
## Purpose

Brevo requires the contact to exist before being added to a list.


## Proposal

- [x] force contact creation before


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Backend Improvements**
  * Strengthened email service integration for user registration, ensuring contacts are properly created before being added to follow-up lists.
  * Enhanced error handling for email service operations to better manage failures during registration and activation flows.

* **Tests**
  * Expanded test coverage to verify email service contact creation and list management during user registration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->