### PR TITLE
🚑️(web-search) fix missing argument in RAG backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- 🚑️(web-search) fix missing argument in RAG backend #116
+
+
 ## [0.0.2] - 2025-10-21
 
 ### Added

--- a/src/backend/chat/agent_rag/document_rag_backends/albert_rag_backend.py
+++ b/src/backend/chat/agent_rag/document_rag_backends/albert_rag_backend.py
@@ -150,12 +150,13 @@ class AlbertRagBackend(BaseRagBackend):  # pylint: disable=too-many-instance-att
         logger.debug(response.json())
         response.raise_for_status()
 
-    def search(self, query) -> RAGWebResults:
+    def search(self, query, results_count: int = 4) -> RAGWebResults:
         """
         Perform a search using the Albert API based on the provided query.
 
         Args:
             query (str): The search query.
+            results_count (int): The number of results to return.
 
         Returns:
             RAGWebResults: The search results.
@@ -167,6 +168,7 @@ class AlbertRagBackend(BaseRagBackend):  # pylint: disable=too-many-instance-att
                 "collections": [int(self.collection_id)],
                 "prompt": query,
                 "score_threshold": 0.6,
+                "k": results_count,  # Number of chunks to return from the search
             },
             timeout=settings.ALBERT_API_TIMEOUT,
         )

--- a/src/backend/chat/agent_rag/document_rag_backends/base_rag_backend.py
+++ b/src/backend/chat/agent_rag/document_rag_backends/base_rag_backend.py
@@ -75,7 +75,7 @@ class BaseRagBackend:
         """
         raise NotImplementedError("Must be implemented in subclass.")
 
-    def search(self, query) -> RAGWebResults:
+    def search(self, query, results_count: int = 4) -> RAGWebResults:
         """
         Search the collection for the given query.
         """


### PR DESCRIPTION
## Purpose

The wrong RAG backend (not the one used in production) was updated in a previous commit...


## Proposal

- [x] fix the document RAG backend
- [ ] add tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed missing argument in RAG backend web search functionality
  * Search results now support configurable result count parameter

<!-- end of auto-generated comment: release notes by coderabbit.ai -->