### PR TITLE
🌐(i18n) add dutch language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- 🌐(i18n) add dutch language #117
+
+
 ## [0.0.3] - 2025-10-21
 
 ### Fixed

--- a/src/backend/conversations/settings.py
+++ b/src/backend/conversations/settings.py
@@ -267,7 +267,7 @@ class Base(BraveSettings, Configuration):
             ("en-us", "English"),
             ("fr-fr", "Français"),
             # ("de-de", "Deutsch"),
-            # ("nl-nl", "Nederlands"),
+            ("nl-nl", "Nederlands"),
             # ("es-es", "Español"),
         )
     )

--- a/src/frontend/apps/e2e/__tests__/app-conversations/common.ts
+++ b/src/frontend/apps/e2e/__tests__/app-conversations/common.ts
@@ -16,7 +16,7 @@ export const CONFIG = {
     ['en-us', 'English'],
     ['fr-fr', 'Français'],
     // ['de-de', 'Deutsch'],
-    // ['nl-nl', 'Nederlands'],
+    ['nl-nl', 'Nederlands'],
     // ['es-es', 'Español'],
   ],
   LANGUAGE_CODE: 'en-us',


### PR DESCRIPTION
## Purpose

Added the dutch translations in crowdin and added nl-nl in the codebase. When testing the translations with make it did not show correctly. I expect that the the translations are not downloaded from crowdin

## Proposal
Accept PR 

## External contributions

Thank you for your contribution! 🎉  

Please ensure the following items are checked before submitting your pull request:
- [X] I have read and followed the [contributing guidelines](https://github.com/suitenumerique/conversations/blob/main/CONTRIBUTING.md)
- [X] I have read and agreed to the [Code of Conduct](https://github.com/suitenumerique/conversations/blob/main/CODE_OF_CONDUCT.md)
- [X] I have signed off my commits with `git commit --signoff` (DCO compliance)
- [X] I have signed my commits with my SSH or GPG key (`git commit -S`)
- [X] My commit messages follow the required format: `<gitmoji>(type) title description`
- [X] I have added a changelog entry under `## [Unreleased]` section (if noticeable change)
- [X} I have added corresponding tests for new features or bug fixes (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dutch (Nederlands) interface language is now enabled across the app. Users can select Nederlands; language selection, priority and fallback now include Dutch where applicable.

* **Tests**
  * End-to-end tests updated to include the nl-nl language option.

* **Documentation**
  * Changelog updated to note the addition of Dutch (Nederlands).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->