### PR TITLE
🐛(attachments) reject the whole drag&drop if unsupported formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to
 ### Fixed
 
 - 🐛(front) fix mobile source
+- 🐛(attachments) reject the whole drag&drop if unsupported formats #123
 
 
 ## [0.0.3] - 2025-10-21


### PR DESCRIPTION
## Purpose

In production, users can upload any file format because the drag and drop feature does not check their type... This first implementation is to prevent users to have a bad experience on this.


## Proposal

- [x] add a check on file type in the drag and drop component 
- [x] reject the whole drop if any file is not accepted


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved file drag-and-drop handling by rejecting unsupported formats at upload
  * Added visual indicators and messaging when attempting to drag incompatible files
  * Enhanced feedback to clearly display which file types are not supported for attachment

<!-- end of auto-generated comment: release notes by coderabbit.ai -->