### PR TITLE
🚑️(drag-drop) fix the rejection display on Safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- 🚑️(drag-drop) fix the rejection display on Safari #127
+
+
 ## [0.0.4] - 2025-10-27
 
 ### Added

--- a/src/frontend/apps/conversations/src/features/chat/components/InputChat.tsx
+++ b/src/frontend/apps/conversations/src/features/chat/components/InputChat.tsx
@@ -184,7 +184,7 @@ export const InputChat = ({
     const handleDragOver = (e: DragEvent) => {
       e.preventDefault();
 
-      // Check for rejected files during drag over
+      // Check for rejected files during drag over (does not work on Safari)
       if (e.dataTransfer?.items) {
         const items = Array.from(e.dataTransfer.items);
         const hasInvalidFile = items.some((item) => {
@@ -214,7 +214,13 @@ export const InputChat = ({
       if (droppedFiles && droppedFiles.length > 0) {
         // Check if all files are accepted
         if (!areAllFilesAccepted(droppedFiles)) {
-          // Do nothing if there are rejected files
+          // Display rejection for 2 seconds (mandatory for Safari)
+          setIsDragActive(true);
+          setIsDragRejected(true);
+          setTimeout(() => {
+            setIsDragActive(false);
+            setIsDragRejected(false);
+          }, 2000);
           return;
         }
 


### PR DESCRIPTION
## Purpose

Safari does not fill the file information during drag so we cannot check "accept" on the fly, we add a fallback.


## Proposal

- [x] display rejection message for 2s after drop


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed file rejection display on Safari - users now receive visual feedback when attempting to drop unsupported files, improving the drag-and-drop experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->