### PR TITLE
🚑️(posthog) pass str instead of UUID for user PK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- 🚑️(posthog) pass str instead of UUID for user PK #134
+
+
 ## [0.0.7] - 2025-10-28
 
 ### Fixed

--- a/src/backend/chat/views.py
+++ b/src/backend/chat/views.py
@@ -425,7 +425,7 @@ class ChatConversationAttachmentViewSet(
         if settings.POSTHOG_KEY:
             posthog.capture(
                 "item_uploaded",
-                distinct_id=request.user.pk,  # same as set by the frontend
+                distinct_id=str(request.user.pk),  # same as set by the frontend
                 properties={
                     "id": attachment.pk,
                     "file_name": attachment.file_name,

--- a/src/backend/core/feature_flags/helpers.py
+++ b/src/backend/core/feature_flags/helpers.py
@@ -38,7 +38,7 @@ def is_feature_enabled(
     if posthog is not None:
         return posthog.feature_enabled(
             frontend_feature_name(feature_name),
-            user.pk,  # same as set by the frontend
+            str(user.pk),  # same as set by the frontend
         )
 
     # No feature flag manager


### PR DESCRIPTION
## Purpose

The serialization before sending the request to Posthog was failing because of UUID.


## Proposal

- [x] pass an `str` for the user distinct ID in the feature flag request


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed user identifier format for PostHog integration to ensure proper event tracking and feature flag evaluation.

* **Tests**
  * Enhanced feature flag tests with improved validation of PostHog payload data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->