### PR TITLE
⚡️(web-search) keep running when tool call fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to
 
 - 🐛(front) fix target blank links in chat #103
 - 🚑️(posthog) pass str instead of UUID for user PK #134
+- ⚡️(web-search) keep running when tool call fails #137
 
 
 ## [0.0.7] - 2025-10-28

--- a/src/backend/chat/tests/tools/test_utils.py
+++ b/src/backend/chat/tests/tools/test_utils.py
@@ -1,0 +1,154 @@
+"""Tests for chat tool utilities."""
+
+import inspect
+from typing import get_type_hints
+
+import pytest
+from pydantic_ai import ModelRetry, RunContext
+
+from chat.tools.exceptions import ModelCannotRetry
+from chat.tools.utils import last_model_retry_soft_fail
+
+
+def test_last_model_retry_soft_fail_preserves_function_metadata():
+    """Test that the decorator preserves function metadata for schema generation."""
+
+    @last_model_retry_soft_fail
+    async def example_tool(ctx: RunContext, query: str, limit: int = 10) -> str:  # pylint: disable=unused-argument
+        """
+        Example tool function.
+
+        Args:
+            ctx: The run context.
+            query: The search query.
+            limit: Maximum number of results.
+
+        Returns:
+            The search results.
+        """
+        return f"Results for {query} (limit: {limit})"
+
+    # Check that function name is preserved
+    assert example_tool.__name__ == "example_tool"
+
+    # Check that docstring is preserved
+    assert example_tool.__doc__ is not None
+    assert "Example tool function" in example_tool.__doc__
+
+    # Check that signature is preserved
+    sig = inspect.signature(example_tool)
+    assert "ctx" in sig.parameters
+    assert "query" in sig.parameters
+    assert "limit" in sig.parameters
+    assert sig.parameters["limit"].default == 10
+
+    # Check that type hints are preserved
+    type_hints = get_type_hints(example_tool)
+    assert "query" in type_hints
+    assert type_hints["query"] == str
+    assert "limit" in type_hints
+    assert type_hints["limit"] == int
+    assert type_hints["return"] == str
+
+
+@pytest.mark.asyncio
+async def test_last_model_retry_soft_fail_normal_execution():
+    """Test that the decorator doesn't interfere with normal execution."""
+
+    @last_model_retry_soft_fail
+    async def example_tool(_ctx: RunContext, value: str) -> str:
+        """Example tool."""
+        return f"Result: {value}"
+
+    # Create a mock context
+    class MockContext:
+        """Fake context for testing."""
+
+        max_retries = 3
+        retries = {}
+        tool_name = "example_tool"
+
+    ctx = MockContext()
+    result = await example_tool(ctx, "test")
+    assert result == "Result: test"
+
+
+@pytest.mark.asyncio
+async def test_last_model_retry_soft_fail_handles_retry_exception():
+    """Test that the decorator handles ModelRetry exceptions correctly."""
+
+    @last_model_retry_soft_fail
+    async def failing_tool(_ctx: RunContext, should_fail: bool) -> str:
+        """Tool that can raise ModelRetry."""
+        if should_fail:
+            raise ModelRetry("Please retry with different parameters")
+        return "Success"
+
+    # Create a mock context
+    class MockContext:
+        """Fake context for testing."""
+
+        max_retries = 3
+        retries = {}
+        tool_name = "failing_tool"
+
+    ctx = MockContext()
+
+    # Test when retries haven't been exhausted - should re-raise
+    with pytest.raises(ModelRetry):
+        await failing_tool(ctx, should_fail=True)
+
+
+@pytest.mark.asyncio
+async def test_last_model_retry_soft_fail_returns_message_when_max_retries_reached():
+    """Test that the decorator returns the error message when max retries is reached."""
+
+    @last_model_retry_soft_fail
+    async def failing_tool(_ctx: RunContext, should_fail: bool) -> str:
+        """Tool that can raise ModelRetry."""
+        if should_fail:
+            raise ModelRetry("Please retry with different parameters.")
+        return "Success"
+
+    # Create a mock context with max retries already reached
+    class MockContext:
+        """Fake context for testing."""
+
+        max_retries = 3
+        retries = {"failing_tool": 3}
+        tool_name = "failing_tool"
+
+    ctx = MockContext()
+
+    # Test when retries have been exhausted - should return message
+    result = await failing_tool(ctx, should_fail=True)
+    assert result == (
+        "Please retry with different parameters. "
+        "You must explain this to the user and not try to answer based on your knowledge."
+    )
+
+
+@pytest.mark.asyncio
+async def test_last_model_retry_soft_fail_returns_message_when_model_cannot_retry():
+    """Test that the decorator returns the error message when ModelCannotRetry is raised."""
+
+    @last_model_retry_soft_fail
+    async def failing_tool(_ctx: RunContext, should_fail: bool) -> str:
+        """Tool that can raise ModelRetry."""
+        if should_fail:
+            raise ModelCannotRetry("This is broken duh.")
+        return "Success"
+
+    # Create a mock context with max retries already reached
+    class MockContext:
+        """Fake context for testing."""
+
+        max_retries = 3
+        retries = {"failing_tool": 3}
+        tool_name = "failing_tool"
+
+    ctx = MockContext()
+
+    # Test when retries have been exhausted - should return message
+    result = await failing_tool(ctx, should_fail=True)
+    assert result == "This is broken duh."

--- a/src/backend/chat/tests/tools/test_web_search_brave.py
+++ b/src/backend/chat/tests/tools/test_web_search_brave.py
@@ -1,17 +1,23 @@
 """Tests for the Brave web search tool."""
 
-from unittest.mock import MagicMock, Mock, patch
-from urllib.parse import parse_qs, urlparse
+# pylint: disable=too-many-lines
 
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+from urllib.parse import parse_qs
+
+import httpx
 import pytest
-import responses
-from pydantic_ai import RunContext, RunUsage
+import respx
+from pydantic_ai import ModelRetry, RunContext, RunUsage
 
+from chat.tools.exceptions import ModelCannotRetry
 from chat.tools.web_search_brave import (
-    _extract_and_summarize_snippets,
-    _fetch_and_extract,
-    _fetch_and_store,
-    _query_brave_api,
+    DocumentFetchError,
+    _extract_and_summarize_snippets_async,
+    _fetch_and_extract_async,
+    _fetch_and_store_async,
+    _query_brave_api_async,
+    format_tool_return,
     web_search_brave,
     web_search_brave_with_document_backend,
 )
@@ -31,42 +37,53 @@ def brave_settings(settings):
     settings.BRAVE_SEARCH_SPELLCHECK = True
     settings.BRAVE_SEARCH_EXTRA_SNIPPETS = True
     settings.BRAVE_SUMMARIZATION_ENABLED = False
-    settings.BRAVE_MAX_WORKERS = 2
     settings.BRAVE_CACHE_TTL = 3600
     settings.RAG_DOCUMENT_SEARCH_BACKEND = (
         "chat.agent_rag.document_rag_backends.albert_rag_backend.AlbertRagBackend"
     )
+    settings.BRAVE_RAG_WEB_SEARCH_CHUNK_NUMBER = 5
 
 
-@responses.activate
-def test_agent_web_search_brave_success_with_extra_snippets():
+@pytest.fixture(name="mocked_context")
+def fixture_mocked_context():
+    """Fixture for a mocked RunContext."""
+    mock_ctx = Mock(spec=RunContext)
+    mock_ctx.usage = RunUsage(input_tokens=0, output_tokens=0)
+    mock_ctx.max_retries = 2
+    mock_ctx.retries = {}
+    return mock_ctx
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_agent_web_search_brave_success_with_extra_snippets(mocked_context):
     """Test when the Brave search returns results with extra_snippets."""
-    responses.add(
-        responses.GET,
-        BRAVE_URL,
-        json={
-            "web": {
-                "results": [
-                    {
-                        "url": "https://example.com/a",
-                        "title": "Result A",
-                        "extra_snippets": ["Snippet A1", "Snippet A2"],
-                    },
-                    {
-                        "url": "https://example.com/b",
-                        "title": "Result B",
-                        "extra_snippets": ["Snippet B1"],
-                    },
-                ]
-            }
-        },
-        status=200,
+    respx.get(BRAVE_URL).mock(
+        return_value=httpx.Response(
+            status_code=200,
+            json={
+                "web": {
+                    "results": [
+                        {
+                            "url": "https://example.com/a",
+                            "title": "Result A",
+                            "extra_snippets": ["Snippet A1", "Snippet A2"],
+                        },
+                        {
+                            "url": "https://example.com/b",
+                            "title": "Result B",
+                            "extra_snippets": ["Snippet B1"],
+                        },
+                    ]
+                }
+            },
+        )
     )
 
-    with patch("chat.tools.web_search_brave.fetch_url") as mock_fetch:
+    with patch("chat.tools.web_search_brave._fetch_url_async") as mock_fetch:
         # Fetch should not be called since extra_snippets are provided
         mock_fetch.side_effect = Exception("fetch_url should not be called")
-        tool_return = web_search_brave("test query")
+        tool_return = await web_search_brave(mocked_context, "test query")
 
     assert hasattr(tool_return, "return_value")
     assert tool_return.return_value == {
@@ -80,41 +97,49 @@ def test_agent_web_search_brave_success_with_extra_snippets():
     assert tool_return.metadata["sources"] == {"https://example.com/a", "https://example.com/b"}
 
     # Check request parameters
-    brave_request = responses.calls[0].request
-    parsed = urlparse(brave_request.url)
-    qs = parse_qs(parsed.query)
+    brave_request = respx.calls[0].request
+    qs = parse_qs(brave_request.url.query.decode("utf-8"))
     assert qs["q"] == ["test query"]
     assert qs["count"] == ["3"]
     assert qs["search_lang"] == ["en"]
     assert qs["country"] == ["US"]
     assert qs["safesearch"] == ["moderate"]
-    assert qs["spellcheck"] == ["True"]
-    assert qs["extra_snippets"] == ["True"]
+    assert qs["spellcheck"] == ["true"]
+    assert qs["extra_snippets"] == ["true"]
     assert qs["result_filter"] == ["web,faq,query"]
 
 
-@responses.activate
-def test_agent_web_search_brave_success_without_extra_snippets():
+@pytest.mark.asyncio
+@respx.mock
+async def test_agent_web_search_brave_success_without_extra_snippets(mocked_context):
     """Test when the Brave search returns results without extra_snippets."""
-    responses.add(
-        responses.GET,
-        BRAVE_URL,
-        json={
-            "web": {
-                "results": [
-                    {"url": "https://example.com/c", "title": "Result C"},  # pas d'extra_snippets
-                ]
-            }
-        },
-        status=200,
+    respx.get(BRAVE_URL).mock(
+        return_value=httpx.Response(
+            status_code=200,
+            json={
+                "web": {
+                    "results": [
+                        {"url": "https://example.com/c", "title": "Result C"},  # no extra_snippets
+                    ]
+                }
+            },
+        )
     )
 
-    with patch("chat.tools.web_search_brave.fetch_url") as mock_fetch:
-        # Fetch should not be called since extra_snippets are provided
-        mock_fetch.return_value = (
-            '<html><body>Extracted Content C<a href="url">link</a></body></html>'
-        )
-        tool_return = web_search_brave("test query")
+    with patch(
+        "chat.tools.web_search_brave._fetch_url_async", new_callable=AsyncMock
+    ) as mock_fetch:
+        with patch("chat.tools.web_search_brave.extract") as mock_extract:
+            mock_fetch.return_value = (
+                '<html><body>Extracted Content C<a href="url">link</a></body></html>'
+            )
+            mock_extract.return_value = "Extracted Content C\nlink"
+
+            with patch("chat.tools.web_search_brave.cache") as mock_cache:
+                mock_cache.aget = AsyncMock(return_value=None)
+                mock_cache.aset = AsyncMock()
+
+                tool_return = await web_search_brave(mocked_context, "test query")
 
     assert tool_return.return_value == {
         "0": {
@@ -126,34 +151,47 @@ def test_agent_web_search_brave_success_without_extra_snippets():
     assert tool_return.metadata["sources"] == {"https://example.com/c"}
 
 
-@responses.activate
-def test_agent_web_search_brave_success_without_extra_snippets_summarization(settings):
-    """Test when the Brave search returns results without extra_snippets."""
+@pytest.mark.asyncio
+@respx.mock
+async def test_agent_web_search_brave_success_without_extra_snippets_summarization(
+    settings, mocked_context
+):
+    """Test when the Brave search returns results without extra_snippets with summarization."""
     settings.BRAVE_SUMMARIZATION_ENABLED = True
 
-    responses.add(
-        responses.GET,
-        BRAVE_URL,
-        json={
-            "web": {
-                "results": [
-                    {"url": "https://example.com/c", "title": "Result C"},  # pas d'extra_snippets
-                ]
-            }
-        },
-        status=200,
+    respx.get(BRAVE_URL).mock(
+        return_value=httpx.Response(
+            status_code=200,
+            json={
+                "web": {
+                    "results": [
+                        {"url": "https://example.com/c", "title": "Result C"},  # no extra_snippets
+                    ]
+                }
+            },
+        )
     )
 
-    with patch("chat.tools.web_search_brave.fetch_url") as mock_fetch:
-        with patch("chat.tools.web_search_brave.llm_summarize") as mock_llm_summarize:
-            # Fetch should not be called since extra_snippets are provided
-            mock_fetch.return_value = (
-                '<html><body>Extracted Content C<a href="url">link</a></body></html>'
-            )
-            mock_llm_summarize.return_value = "Summarized extracted Content C\nlink"
-            tool_return = web_search_brave("test query")
+    with patch(
+        "chat.tools.web_search_brave._fetch_url_async", new_callable=AsyncMock
+    ) as mock_fetch:
+        with patch("chat.tools.web_search_brave.extract") as mock_extract:
+            with patch(
+                "chat.tools.web_search_brave.llm_summarize_async", new_callable=AsyncMock
+            ) as mock_summarize:
+                mock_fetch.return_value = (
+                    '<html><body>Extracted Content C<a href="url">link</a></body></html>'
+                )
+                mock_extract.return_value = "Extracted Content C\nlink"
+                mock_summarize.return_value = "Summarized extracted Content C\nlink"
 
-            mock_llm_summarize.assert_called_with("test query", "Extracted Content C\nlink")
+                with patch("chat.tools.web_search_brave.cache") as mock_cache:
+                    mock_cache.aget = AsyncMock(return_value=None)
+                    mock_cache.aset = AsyncMock()
+
+                    tool_return = await web_search_brave(mocked_context, "test query")
+
+                mock_summarize.assert_called_with("test query", "Extracted Content C\nlink")
 
     assert tool_return.return_value == {
         "0": {
@@ -165,51 +203,62 @@ def test_agent_web_search_brave_success_without_extra_snippets_summarization(set
     assert tool_return.metadata["sources"] == {"https://example.com/c"}
 
 
-@responses.activate
-def test_agent_web_search_brave_empty_results():
+@pytest.mark.asyncio
+@respx.mock
+async def test_agent_web_search_brave_empty_results(mocked_context):
     """Test when the Brave search returns no results."""
-    responses.add(
-        responses.GET,
-        BRAVE_URL,
-        json={"web": {"results": []}},
-        status=200,
+    respx.get(BRAVE_URL).mock(
+        return_value=httpx.Response(
+            status_code=200,
+            json={"web": {"results": []}},
+        ),
     )
-    tool_return = web_search_brave("empty query")
-    assert tool_return.return_value == {}
-    assert tool_return.metadata["sources"] == set()
+
+    with pytest.raises(ModelRetry) as exc:
+        await web_search_brave(mocked_context, "empty query")
+
+    assert "No valid search results" in str(exc.value)
 
 
-@responses.activate
-def test_agent_web_search_brave_http_error():
+@pytest.mark.asyncio
+@respx.mock
+async def test_agent_web_search_brave_http_error(mocked_context):
     """Test handling of HTTP errors from Brave API."""
-    responses.add(
-        responses.GET,
-        BRAVE_URL,
-        status=500,
-        json={"error": "Internal Server Error"},
+    respx.get(BRAVE_URL).mock(
+        return_value=httpx.Response(
+            status_code=500,
+            json={"error": "Internal Server Error"},
+        )
     )
-    with pytest.raises(Exception) as exc:
-        web_search_brave("error query")
-    assert "500" in str(exc.value) or "Internal Server Error" in str(exc.value)
+
+    with pytest.raises(ModelRetry) as exc:
+        await web_search_brave(mocked_context, "error query")
+
+    assert (
+        "server error" in str(exc.value).lower()
+        or "temporarily unavailable" in str(exc.value).lower()
+    )
 
 
-@responses.activate
-def test_agent_web_search_brave_params_exclude_none(settings):
+@pytest.mark.asyncio
+@respx.mock
+async def test_agent_web_search_brave_params_exclude_none(settings, mocked_context):
     """Check that None parameters are excluded from the request."""
     settings.BRAVE_SEARCH_COUNTRY = None
     settings.BRAVE_SEARCH_LANG = None
 
-    responses.add(
-        responses.GET,
-        BRAVE_URL,
-        json={"web": {"results": []}},
-        status=200,
+    respx.get(BRAVE_URL).mock(
+        return_value=httpx.Response(
+            status_code=200,
+            json={"web": {"results": []}},
+        ),
     )
-    web_search_brave("none params")
 
-    brave_request = responses.calls[0].request
-    parsed = urlparse(brave_request.url)
-    qs = parse_qs(parsed.query)
+    with pytest.raises(ModelRetry):  # Will raise due to empty results
+        await web_search_brave(mocked_context, "none params")
+
+    brave_request = respx.calls[0].request
+    qs = parse_qs(brave_request.url.query.decode("utf-8"))
 
     # Mandatory params
     assert qs["q"] == ["none params"]
@@ -221,137 +270,141 @@ def test_agent_web_search_brave_params_exclude_none(settings):
 
     # Defined params present
     assert qs["safesearch"] == ["moderate"]
-    assert qs["spellcheck"] == ["True"]
-    assert qs["extra_snippets"] == ["True"]
+    assert qs["spellcheck"] == ["true"]
+    assert qs["extra_snippets"] == ["true"]
 
     # Empty body for GET request
-    assert not brave_request.body
+    assert not brave_request.content
 
 
-@responses.activate
-def test_agent_web_search_brave_parallel_processing(settings):
-    """Test parallel processing with multiple workers."""
-    settings.BRAVE_MAX_WORKERS = 2
-
-    responses.add(
-        responses.GET,
-        BRAVE_URL,
-        json={
-            "web": {
-                "results": [
-                    {"url": "https://example.com/1", "title": "Result 1"},
-                    {"url": "https://example.com/2", "title": "Result 2"},
-                ]
-            }
-        },
-        status=200,
+@pytest.mark.asyncio
+@respx.mock
+async def test_agent_web_search_brave_concurrent_processing(mocked_context):
+    """Test concurrent processing with asyncio.gather."""
+    respx.get(BRAVE_URL).mock(
+        return_value=httpx.Response(
+            status_code=200,
+            json={
+                "web": {
+                    "results": [
+                        {"url": "https://example.com/1", "title": "Result 1"},
+                        {"url": "https://example.com/2", "title": "Result 2"},
+                    ]
+                }
+            },
+        )
     )
 
-    with patch("chat.tools.web_search_brave.fetch_url") as mock_fetch:
-        mock_fetch.return_value = "<html><body>Content</body></html>"
-        tool_return = web_search_brave("parallel query")
+    with patch(
+        "chat.tools.web_search_brave._fetch_url_async", new_callable=AsyncMock
+    ) as mock_fetch:
+        with patch("chat.tools.web_search_brave.extract") as mock_extract:
+            mock_fetch.return_value = "<html><body>Content</body></html>"
+            mock_extract.return_value = "Content"
+
+            with patch("chat.tools.web_search_brave.cache") as mock_cache:
+                mock_cache.aget = AsyncMock(return_value=None)
+                mock_cache.aset = AsyncMock()
+
+                tool_return = await web_search_brave(mocked_context, "parallel query")
 
     assert len(tool_return.return_value) == 2
     assert mock_fetch.call_count == 2
 
 
-@responses.activate
-def test_agent_web_search_brave_single_worker(settings):
-    """Test processing with single worker (no ThreadPoolExecutor overhead)."""
-    settings.BRAVE_MAX_WORKERS = 1
-
-    responses.add(
-        responses.GET,
-        BRAVE_URL,
-        json={
-            "web": {
-                "results": [
-                    {"url": "https://example.com/single", "title": "Single Result"},
-                ]
-            }
-        },
-        status=200,
-    )
-
-    with patch("chat.tools.web_search_brave.fetch_url") as mock_fetch:
-        mock_fetch.return_value = "<html><body>Single Content</body></html>"
-        tool_return = web_search_brave("single worker query")
-
-    assert len(tool_return.return_value) == 1
-    assert tool_return.return_value["0"]["snippets"] == ["Single Content"]
-
-
-@responses.activate
-def test_fetch_and_extract_with_cache():
-    """Test caching mechanism in _fetch_and_extract."""
+@pytest.mark.asyncio
+async def test_fetch_and_extract_with_cache():
+    """Test caching mechanism in _fetch_and_extract_async."""
     with patch("chat.tools.web_search_brave.cache") as mock_cache:
-        with patch("chat.tools.web_search_brave.fetch_url") as mock_fetch:
-            # First call - cache miss
-            mock_cache.get.return_value = None
-            mock_fetch.return_value = "<html><body>Cached Content</body></html>"
+        with patch(
+            "chat.tools.web_search_brave._fetch_url_async", new_callable=AsyncMock
+        ) as mock_fetch:
+            with patch("chat.tools.web_search_brave.extract") as mock_extract:
+                # First call - cache miss
+                mock_cache.aget = AsyncMock(return_value=None)
+                mock_cache.aset = AsyncMock()
+                mock_fetch.return_value = "<html><body>Cached Content</body></html>"
+                mock_extract.return_value = "Cached Content"
 
-            result1 = _fetch_and_extract("https://example.com/cache")
+                result1 = await _fetch_and_extract_async("https://example.com/cache")
 
-            assert result1 == "Cached Content"
-            mock_cache.get.assert_called_once()
-            mock_cache.set.assert_called_once()
+                assert result1 == "Cached Content"
+                mock_cache.aget.assert_called_once()
+                mock_cache.aset.assert_called_once()
 
-            # Second call - cache hit
-            mock_cache.get.return_value = "Cached Content"
-            result2 = _fetch_and_extract("https://example.com/cache")
+                # Second call - cache hit
+                mock_cache.aget = AsyncMock(return_value="Cached Content")
+                result2 = await _fetch_and_extract_async("https://example.com/cache")
 
-            assert result2 == "Cached Content"
-            # fetch_url should still be called only once (from first call)
-            assert mock_fetch.call_count == 1
+                assert result2 == "Cached Content"
+                # fetch_url should still be called only once (from first call)
+                assert mock_fetch.call_count == 1
 
 
-@responses.activate
-def test_extract_and_summarize_snippets_empty_document():
-    """Test _extract_and_summarize_snippets when extraction returns empty string."""
-    with patch("chat.tools.web_search_brave.fetch_url") as mock_fetch:
+@pytest.mark.asyncio
+async def test_extract_and_summarize_snippets_empty_document():
+    """Test _extract_and_summarize_snippets_async when extraction returns empty string."""
+    with patch(
+        "chat.tools.web_search_brave._fetch_url_async", new_callable=AsyncMock
+    ) as mock_fetch:
         with patch("chat.tools.web_search_brave.extract") as mock_extract:
-            mock_fetch.return_value = "<html><body></body></html>"
-            mock_extract.return_value = ""
+            with patch("chat.tools.web_search_brave.cache") as mock_cache:
+                mock_cache.aget = AsyncMock(return_value=None)
+                mock_cache.aset = AsyncMock()
+                mock_fetch.return_value = "<html><body></body></html>"
+                mock_extract.return_value = ""
 
-            result = _extract_and_summarize_snippets("query", "https://example.com/empty")
+                result = await _extract_and_summarize_snippets_async(
+                    "query", "https://example.com/empty"
+                )
 
-            assert not result
+                assert not result
 
 
-@responses.activate
-def test_extract_and_summarize_snippets_summarization_failure(settings):
-    """Test _extract_and_summarize_snippets when summarization fails."""
+@pytest.mark.asyncio
+async def test_extract_and_summarize_snippets_summarization_failure(settings):
+    """Test _extract_and_summarize_snippets_async when summarization fails."""
     settings.BRAVE_SUMMARIZATION_ENABLED = True
 
-    with patch("chat.tools.web_search_brave.fetch_url") as mock_fetch:
-        with patch("chat.tools.web_search_brave.llm_summarize") as mock_summarize:
-            mock_fetch.return_value = "<html><body>Content</body></html>"
-            mock_summarize.side_effect = Exception("Summarization error")
+    with patch(
+        "chat.tools.web_search_brave._fetch_url_async", new_callable=AsyncMock
+    ) as mock_fetch:
+        with patch("chat.tools.web_search_brave.extract") as mock_extract:
+            with patch(
+                "chat.tools.web_search_brave.llm_summarize_async", new_callable=AsyncMock
+            ) as mock_summarize:
+                with patch("chat.tools.web_search_brave.cache") as mock_cache:
+                    mock_cache.aget = AsyncMock(return_value=None)
+                    mock_cache.aset = AsyncMock()
+                    mock_fetch.return_value = "<html><body>Content</body></html>"
+                    mock_extract.return_value = "Content"
+                    mock_summarize.side_effect = Exception("Summarization error")
 
-            result = _extract_and_summarize_snippets("query", "https://example.com/error")
+                    result = await _extract_and_summarize_snippets_async(
+                        "query", "https://example.com/error"
+                    )
 
-            assert not result
+                    # Should return raw document as fallback
+                    assert result == ["Content"]
 
 
-@responses.activate
-def test_web_search_brave_with_document_backend_success():
+@pytest.mark.asyncio
+@respx.mock
+async def test_web_search_brave_with_document_backend_success(mocked_context):
     """Test web_search_brave_with_document_backend with successful RAG search."""
-    responses.add(
-        responses.GET,
-        BRAVE_URL,
-        json={
-            "web": {
-                "results": [
-                    {"url": "https://example.com/doc1", "title": "Document 1"},
-                    {"url": "https://example.com/doc2", "title": "Document 2"},
-                ]
-            }
-        },
-        status=200,
+    respx.get(BRAVE_URL).mock(
+        return_value=httpx.Response(
+            status_code=200,
+            json={
+                "web": {
+                    "results": [
+                        {"url": "https://example.com/doc1", "title": "Document 1"},
+                        {"url": "https://example.com/doc2", "title": "Document 2"},
+                    ],
+                },
+            },
+        )
     )
-
-    mock_ctx = Mock(spec=RunContext)
-    mock_ctx.usage = RunUsage(input_tokens=0, output_tokens=0)
 
     mock_document_store = MagicMock()
     mock_rag_result1 = Mock(url="https://example.com/doc1", content="RAG Content 1")
@@ -359,18 +412,17 @@ def test_web_search_brave_with_document_backend_success():
     mock_rag_results = Mock(
         data=[mock_rag_result1, mock_rag_result2], usage=Mock(prompt_tokens=10, completion_tokens=5)
     )
-    mock_document_store.search.return_value = mock_rag_results
+    mock_document_store.asearch = AsyncMock(return_value=mock_rag_results)
 
     mock_backend_class = MagicMock()
-    mock_backend_class.temporary_collection.return_value.__enter__.return_value = (
-        mock_document_store
+    mock_backend_class.temporary_collection_async.return_value.__aenter__ = AsyncMock(
+        return_value=mock_document_store
     )
+    mock_backend_class.temporary_collection_async.return_value.__aexit__ = AsyncMock()
 
     with patch("chat.tools.web_search_brave.import_string", return_value=mock_backend_class):
-        with patch("chat.tools.web_search_brave.fetch_url") as mock_fetch:
-            mock_fetch.return_value = "<html><body>Document content</body></html>"
-
-            tool_return = web_search_brave_with_document_backend(mock_ctx, "rag query")
+        with patch("chat.tools.web_search_brave._fetch_and_store_async", new_callable=AsyncMock):
+            tool_return = await web_search_brave_with_document_backend(mocked_context, "rag query")
 
     assert len(tool_return.return_value) == 2
     assert tool_return.return_value["0"]["url"] == "https://example.com/doc1"
@@ -383,115 +435,69 @@ def test_web_search_brave_with_document_backend_success():
     }
 
     # Verify usage was updated
-    assert mock_ctx.usage.input_tokens == 10
-    assert mock_ctx.usage.output_tokens == 5
+    assert mocked_context.usage.input_tokens == 10
+    assert mocked_context.usage.output_tokens == 5
 
 
-@responses.activate
-def test_web_search_brave_with_document_backend_single_worker(settings):
-    """Test web_search_brave_with_document_backend with single worker."""
-    settings.BRAVE_MAX_WORKERS = 1
-
-    responses.add(
-        responses.GET,
-        BRAVE_URL,
-        json={
-            "web": {
-                "results": [
-                    {"url": "https://example.com/single", "title": "Single Doc"},
-                ]
-            }
-        },
-        status=200,
+@pytest.mark.asyncio
+@respx.mock
+async def test_web_search_brave_with_document_backend_fetch_error(mocked_context):
+    """Test web_search_brave_with_document_backend when document fetching fails."""
+    respx.get(BRAVE_URL).mock(
+        return_value=httpx.Response(
+            status_code=200,
+            json={
+                "web": {
+                    "results": [
+                        {"url": "https://example.com/error", "title": "Error Doc"},
+                        {"url": "https://example.com/ok", "title": "OK Doc"},
+                    ]
+                }
+            },
+        )
     )
-
-    mock_ctx = Mock(spec=RunContext)
-    mock_ctx.usage = RunUsage(input_tokens=0, output_tokens=0)
-
-    mock_document_store = MagicMock()
-    mock_rag_result = Mock(url="https://example.com/single", content="Single Content")
-    mock_rag_results = Mock(
-        data=[mock_rag_result], usage=Mock(prompt_tokens=5, completion_tokens=3)
-    )
-    mock_document_store.search.return_value = mock_rag_results
-
-    mock_backend_class = MagicMock()
-    mock_backend_class.temporary_collection.return_value.__enter__.return_value = (
-        mock_document_store
-    )
-
-    with patch("chat.tools.web_search_brave.import_string", return_value=mock_backend_class):
-        with patch("chat.tools.web_search_brave._fetch_and_store") as mock_store:
-            tool_return = web_search_brave_with_document_backend(mock_ctx, "single query")
-
-    assert len(tool_return.return_value) == 1
-    mock_store.assert_called_once()
-
-
-@responses.activate
-def test_web_search_brave_with_document_backend_fetch_error(settings):
-    """Test web_search_brave_with_document_backend when document fetching fails (multi-worker)."""
-    settings.BRAVE_MAX_WORKERS = 2
-
-    responses.add(
-        responses.GET,
-        BRAVE_URL,
-        json={
-            "web": {
-                "results": [
-                    {"url": "https://example.com/error", "title": "Error Doc"},
-                    {"url": "https://example.com/ok", "title": "OK Doc"},
-                ]
-            }
-        },
-        status=200,
-    )
-
-    mock_ctx = Mock(spec=RunContext)
-    mock_ctx.usage = RunUsage(input_tokens=0, output_tokens=0)
 
     mock_document_store = MagicMock()
     mock_rag_results = Mock(data=[], usage=Mock(prompt_tokens=0, completion_tokens=0))
-    mock_document_store.search.return_value = mock_rag_results
+    mock_document_store.asearch = AsyncMock(return_value=mock_rag_results)
 
     mock_backend_class = MagicMock()
-    mock_backend_class.temporary_collection.return_value.__enter__.return_value = (
-        mock_document_store
+    mock_backend_class.temporary_collection_async.return_value.__aenter__ = AsyncMock(
+        return_value=mock_document_store
     )
+    mock_backend_class.temporary_collection_async.return_value.__aexit__ = AsyncMock()
 
     with patch("chat.tools.web_search_brave.import_string", return_value=mock_backend_class):
-        with patch("chat.tools.web_search_brave._fetch_and_store") as mock_store:
+        with patch(
+            "chat.tools.web_search_brave._fetch_and_store_async", new_callable=AsyncMock
+        ) as mock_store:
             # First call fails, second succeeds
             mock_store.side_effect = [Exception("Fetch error"), None]
 
-            tool_return = web_search_brave_with_document_backend(mock_ctx, "error query")
-
-    # Should complete despite error (error is caught and logged in multi-worker path)
-    assert tool_return.return_value == {}
+            with pytest.raises(ModelRetry):
+                await web_search_brave_with_document_backend(mocked_context, "error query")
 
 
-@responses.activate
-def test_web_search_brave_with_document_backend_no_matching_rag_results():
+@pytest.mark.asyncio
+@respx.mock
+async def test_web_search_brave_with_document_backend_no_matching_rag_results(mocked_context):
     """
     Test when RAG returns results that don't match any search results.
 
     This is actually a problematic scenario, but we want to ensure graceful handling.
     """
-    responses.add(
-        responses.GET,
-        BRAVE_URL,
-        json={
-            "web": {
-                "results": [
-                    {"url": "https://example.com/doc1", "title": "Document 1"},
-                ]
-            }
-        },
-        status=200,
+    respx.get(BRAVE_URL).mock(
+        return_value=httpx.Response(
+            status_code=200,
+            json={
+                "web": {
+                    "results": [
+                        {"url": "https://example.com/doc1", "title": "Document 1"},
+                    ]
+                }
+            },
+        )
     )
-
-    mock_ctx = Mock(spec=RunContext)
-    mock_ctx.usage = RunUsage(input_tokens=0, output_tokens=0)
 
     mock_document_store = MagicMock()
     # RAG result with different URL
@@ -499,75 +505,592 @@ def test_web_search_brave_with_document_backend_no_matching_rag_results():
     mock_rag_results = Mock(
         data=[mock_rag_result], usage=Mock(prompt_tokens=5, completion_tokens=3)
     )
-    mock_document_store.search.return_value = mock_rag_results
+    mock_document_store.asearch = AsyncMock(return_value=mock_rag_results)
 
     mock_backend_class = MagicMock()
-    mock_backend_class.temporary_collection.return_value.__enter__.return_value = (
-        mock_document_store
+    mock_backend_class.temporary_collection_async.return_value.__aenter__ = AsyncMock(
+        return_value=mock_document_store
     )
+    mock_backend_class.temporary_collection_async.return_value.__aexit__ = AsyncMock()
 
     with patch("chat.tools.web_search_brave.import_string", return_value=mock_backend_class):
-        with patch("chat.tools.web_search_brave.fetch_url") as mock_fetch:
-            mock_fetch.return_value = "<html><body>Content</body></html>"
-
-            tool_return = web_search_brave_with_document_backend(mock_ctx, "query")
-
-    # No results should be returned since RAG URL doesn't match search results
-    assert tool_return.return_value == {}
-    assert tool_return.metadata["sources"] == set()
+        with patch("chat.tools.web_search_brave._fetch_and_store_async", new_callable=AsyncMock):
+            with pytest.raises(ModelRetry):
+                await web_search_brave_with_document_backend(mocked_context, "query")
 
 
-def test_fetch_and_store():
-    """Test _fetch_and_store function."""
-    mock_document_store = MagicMock()
+@pytest.mark.asyncio
+async def test_fetch_and_store():
+    """Test _fetch_and_store_async function."""
+    mock_document_store = AsyncMock()
 
-    with patch("chat.tools.web_search_brave._fetch_and_extract") as mock_extract:
+    with patch(
+        "chat.tools.web_search_brave._fetch_and_extract_async", new_callable=AsyncMock
+    ) as mock_extract:
         mock_extract.return_value = "Extracted document content"
 
-        _fetch_and_store("https://example.com/doc", mock_document_store)
+        await _fetch_and_store_async("https://example.com/doc", mock_document_store)
 
         mock_extract.assert_called_once_with("https://example.com/doc")
-        mock_document_store.store_document.assert_called_once_with(
+        mock_document_store.astore_document.assert_called_once_with(
             "https://example.com/doc", "Extracted document content"
         )
 
 
-def test_fetch_and_store_empty_document():
-    """Test _fetch_and_store when extraction returns empty document."""
+@pytest.mark.asyncio
+async def test_fetch_and_store_empty_document():
+    """Test _fetch_and_store_async when extraction returns empty document."""
     mock_document_store = MagicMock()
 
-    with patch("chat.tools.web_search_brave._fetch_and_extract") as mock_extract:
+    with patch(
+        "chat.tools.web_search_brave._fetch_and_extract_async", new_callable=AsyncMock
+    ) as mock_extract:
         mock_extract.return_value = ""
 
-        _fetch_and_store("https://example.com/empty", mock_document_store)
+        await _fetch_and_store_async("https://example.com/empty", mock_document_store)
 
         # Should not store empty document
         mock_document_store.store_document.assert_not_called()
 
 
-@responses.activate
-def test_query_brave_api_missing_web_key():
-    """Test _query_brave_api when response doesn't contain 'web' key."""
-    responses.add(
-        responses.GET,
-        BRAVE_URL,
-        json={"error": "no web results"},
-        status=200,
+@pytest.mark.asyncio
+@respx.mock
+async def test_query_brave_api_missing_web_key():
+    """Test _query_brave_api_async when response doesn't contain 'web' key."""
+    respx.get(BRAVE_URL).mock(
+        return_value=httpx.Response(
+            status_code=200,
+            json={"error": "no web results"},
+        )
     )
 
-    result = _query_brave_api("query")
+    result = await _query_brave_api_async("query")
     assert not result
 
 
-@responses.activate
-def test_query_brave_api_missing_results_key():
-    """Test _query_brave_api when 'web' exists but 'results' is missing."""
-    responses.add(
-        responses.GET,
-        BRAVE_URL,
-        json={"web": {}},
-        status=200,
+@pytest.mark.asyncio
+@respx.mock
+async def test_query_brave_api_missing_results_key():
+    """Test _query_brave_api_async when 'web' exists but 'results' is missing."""
+    respx.get(BRAVE_URL).mock(
+        return_value=httpx.Response(
+            status_code=200,
+            json={"web": {}},
+        )
+    )
+    result = await _query_brave_api_async("query")
+    assert not result
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_query_brave_api_rate_limit():
+    """Test _query_brave_api_async handles 429 rate limit errors."""
+    respx.get(BRAVE_URL).mock(
+        return_value=httpx.Response(
+            status_code=429,
+            json={"error": "Rate limit exceeded"},
+        )
     )
 
-    result = _query_brave_api("query")
-    assert not result
+    with pytest.raises(ModelRetry) as exc:
+        await _query_brave_api_async("query")
+
+    assert "rate limited" in str(exc.value).lower()
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_query_brave_api_client_error():
+    """Test _query_brave_api_async handles 4xx client errors."""
+    respx.get(BRAVE_URL).mock(
+        return_value=httpx.Response(
+            status_code=400,
+            json={"error": "Bad request"},
+        )
+    )
+
+    with pytest.raises(ModelCannotRetry) as exc:
+        await _query_brave_api_async("query")
+
+    assert "client error" in str(exc.value).lower()
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_query_brave_api_timeout():
+    """Test _query_brave_api_async handles timeout errors."""
+    respx.get(BRAVE_URL).mock(side_effect=httpx.TimeoutException("Request timed out"))
+
+    with pytest.raises(ModelRetry) as exc:
+        await _query_brave_api_async("query")
+
+    assert "timed out" in str(exc.value).lower()
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_query_brave_api_generic_http_error():
+    """Test _query_brave_api_async handles generic HTTP errors."""
+    respx.get(BRAVE_URL).mock(side_effect=httpx.ConnectError("Connection failed"))
+
+    with pytest.raises(ModelRetry) as exc:
+        await _query_brave_api_async("query")
+
+    assert "connection error" in str(exc.value).lower()
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_query_brave_api_unexpected_error():
+    """Test _query_brave_api_async handles unexpected errors."""
+    respx.get(BRAVE_URL).mock(side_effect=ValueError("Unexpected value error"))
+
+    with pytest.raises(ModelCannotRetry) as exc:
+        await _query_brave_api_async("query")
+
+    assert "unexpected error" in str(exc.value).lower()
+
+
+@pytest.mark.asyncio
+async def test_fetch_and_extract_extraction_returns_none():
+    """Test _fetch_and_extract_async when extract returns None."""
+    with patch("chat.tools.web_search_brave.cache") as mock_cache:
+        with patch(
+            "chat.tools.web_search_brave._fetch_url_async", new_callable=AsyncMock
+        ) as mock_fetch:
+            with patch("chat.tools.web_search_brave.extract") as mock_extract:
+                mock_cache.aget = AsyncMock(return_value=None)
+                mock_cache.aset = AsyncMock()
+                mock_fetch.return_value = "<html><body>Content</body></html>"
+                mock_extract.return_value = None
+
+                result = await _fetch_and_extract_async("https://example.com/none")
+
+                assert result is None
+                mock_cache.aset.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_fetch_and_extract_http_error():
+    """Test _fetch_and_extract_async when HTTP fetch fails."""
+    with patch("chat.tools.web_search_brave.cache") as mock_cache:
+        with patch(
+            "chat.tools.web_search_brave._fetch_url_async", new_callable=AsyncMock
+        ) as mock_fetch:
+            mock_cache.aget = AsyncMock(return_value=None)
+            mock_fetch.side_effect = httpx.HTTPError("Network error")
+            with pytest.raises(DocumentFetchError):
+                await _fetch_and_extract_async("https://example.com/error")
+
+
+@pytest.mark.asyncio
+async def test_fetch_and_extract_extraction_exception():
+    """Test _fetch_and_extract_async when extract raises an exception."""
+    with patch("chat.tools.web_search_brave.cache") as mock_cache:
+        with patch(
+            "chat.tools.web_search_brave._fetch_url_async", new_callable=AsyncMock
+        ) as mock_fetch:
+            with patch("chat.tools.web_search_brave.extract") as mock_extract:
+                mock_cache.aget = AsyncMock(return_value=None)
+                mock_fetch.return_value = "<html><body>Content</body></html>"
+                mock_extract.side_effect = Exception("Extraction failed")
+
+                with pytest.raises(DocumentFetchError):
+                    await _fetch_and_extract_async("https://example.com/extract-error")
+
+
+@pytest.mark.asyncio
+async def test_extract_and_summarize_snippets_fetch_error():
+    """Test _extract_and_summarize_snippets_async when document fetch fails."""
+    with patch(
+        "chat.tools.web_search_brave._fetch_and_extract_async", new_callable=AsyncMock
+    ) as mock_extract:
+        mock_extract.side_effect = DocumentFetchError("Failed to fetch")
+
+        result = await _extract_and_summarize_snippets_async("query", "https://example.com/error")
+
+        assert result == []
+
+
+@pytest.mark.asyncio
+async def test_extract_and_summarize_snippets_summarization_returns_empty(settings):
+    """Test _extract_and_summarize_snippets_async when summarization returns empty string."""
+    settings.BRAVE_SUMMARIZATION_ENABLED = True
+
+    with patch(
+        "chat.tools.web_search_brave._fetch_url_async", new_callable=AsyncMock
+    ) as mock_fetch:
+        with patch("chat.tools.web_search_brave.extract") as mock_extract:
+            with patch(
+                "chat.tools.web_search_brave.llm_summarize_async", new_callable=AsyncMock
+            ) as mock_summarize:
+                with patch("chat.tools.web_search_brave.cache") as mock_cache:
+                    mock_cache.aget = AsyncMock(return_value=None)
+                    mock_cache.aset = AsyncMock()
+                    mock_fetch.return_value = "<html><body>Content</body></html>"
+                    mock_extract.return_value = "Content"
+                    mock_summarize.return_value = ""
+
+                    result = await _extract_and_summarize_snippets_async(
+                        "query", "https://example.com/empty-summary"
+                    )
+
+                    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_fetch_and_store_extraction_error():
+    """Test _fetch_and_store_async when extraction fails."""
+    mock_document_store = MagicMock()
+
+    with patch(
+        "chat.tools.web_search_brave._fetch_and_extract_async", new_callable=AsyncMock
+    ) as mock_extract:
+        mock_extract.side_effect = DocumentFetchError("Extraction failed")
+
+        # Should not raise, just log warning
+        await _fetch_and_store_async("https://example.com/error", mock_document_store)
+
+        mock_document_store.store_document.assert_not_called()
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_web_search_brave_mixed_results(mocked_context):
+    """Test web_search_brave with mixed results (some with snippets, some without)."""
+    respx.get(BRAVE_URL).mock(
+        return_value=httpx.Response(
+            status_code=200,
+            json={
+                "web": {
+                    "results": [
+                        {
+                            "url": "https://example.com/with",
+                            "title": "With Snippets",
+                            "extra_snippets": ["Snippet 1"],
+                        },
+                        {
+                            "url": "https://example.com/without",
+                            "title": "Without Snippets",
+                        },
+                    ]
+                }
+            },
+        )
+    )
+
+    with patch(
+        "chat.tools.web_search_brave._fetch_url_async", new_callable=AsyncMock
+    ) as mock_fetch:
+        with patch("chat.tools.web_search_brave.extract") as mock_extract:
+            with patch("chat.tools.web_search_brave.cache") as mock_cache:
+                mock_cache.aget = AsyncMock(return_value=None)
+                mock_cache.aset = AsyncMock()
+                mock_fetch.return_value = "<html><body>Extracted</body></html>"
+                mock_extract.return_value = "Extracted"
+
+                tool_return = await web_search_brave(mocked_context, "mixed query")
+
+    assert len(tool_return.return_value) == 2
+    assert tool_return.return_value["0"]["snippets"] == ["Snippet 1"]
+    assert tool_return.return_value["1"]["snippets"] == ["Extracted"]
+    # Only one fetch should have happened (for the one without snippets)
+    assert mock_fetch.call_count == 1
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_web_search_brave_extraction_fails_for_all(mocked_context):
+    """Test web_search_brave when extraction fails for all results without snippets."""
+    respx.get(BRAVE_URL).mock(
+        return_value=httpx.Response(
+            status_code=200,
+            json={
+                "web": {
+                    "results": [
+                        {"url": "https://example.com/fail1", "title": "Fail 1"},
+                        {"url": "https://example.com/fail2", "title": "Fail 2"},
+                    ]
+                }
+            },
+        )
+    )
+
+    with patch(
+        "chat.tools.web_search_brave._fetch_url_async", new_callable=AsyncMock
+    ) as mock_fetch:
+        with patch("chat.tools.web_search_brave.extract") as mock_extract:
+            with patch("chat.tools.web_search_brave.cache") as mock_cache:
+                mock_cache.aget = AsyncMock(return_value=None)
+                mock_fetch.side_effect = httpx.HTTPError("Failed")
+                mock_extract.return_value = ""
+
+                with pytest.raises(ModelRetry) as exc:
+                    await web_search_brave(mocked_context, "fail query")
+
+                assert "no valid search results" in str(exc.value).lower()
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_web_search_brave_model_cannot_retry_exception(mocked_context):
+    """Test web_search_brave handling of ModelCannotRetry from API."""
+    respx.get(BRAVE_URL).mock(
+        return_value=httpx.Response(
+            status_code=403,
+            json={"error": "Forbidden"},
+        )
+    )
+
+    result = await web_search_brave(mocked_context, "forbidden query")
+    assert result == (
+        "Web search failed with a client error (status 403). "
+        "You must explain this to the user and not try to answer based on your knowledge."
+    )
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_web_search_brave_unexpected_exception(mocked_context):
+    """Test web_search_brave handling of unexpected exceptions."""
+    respx.get(BRAVE_URL).mock(
+        return_value=httpx.Response(
+            status_code=200,
+            json={
+                "web": {
+                    "results": [
+                        {
+                            "url": "https://example.com/ok",
+                            "title": "OK",
+                            "extra_snippets": ["snippet"],
+                        },
+                    ]
+                }
+            },
+        )
+    )
+
+    with patch("chat.tools.web_search_brave.format_tool_return") as mock_format:
+        mock_format.side_effect = RuntimeError("Unexpected error")
+
+        result = await web_search_brave(mocked_context, "error query")
+        assert result == (
+            "An unexpected error occurred during web search: RuntimeError. You must "
+            "explain this to the user and not try to answer based on your knowledge."
+        )
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_web_search_brave_with_document_backend_empty_rag_results(mocked_context):
+    """Test web_search_brave_with_document_backend when RAG search returns empty results."""
+    respx.get(BRAVE_URL).mock(
+        return_value=httpx.Response(
+            status_code=200,
+            json={
+                "web": {
+                    "results": [
+                        {"url": "https://example.com/doc1", "title": "Document 1"},
+                    ]
+                }
+            },
+        )
+    )
+
+    mock_document_store = MagicMock()
+    mock_rag_results = Mock(data=[], usage=Mock(prompt_tokens=0, completion_tokens=0))
+    mock_document_store.asearch = AsyncMock(return_value=mock_rag_results)
+
+    mock_backend_class = MagicMock()
+    mock_backend_class.temporary_collection_async.return_value.__aenter__ = AsyncMock(
+        return_value=mock_document_store
+    )
+    mock_backend_class.temporary_collection_async.return_value.__aexit__ = AsyncMock()
+
+    with patch("chat.tools.web_search_brave.import_string", return_value=mock_backend_class):
+        with patch("chat.tools.web_search_brave._fetch_and_store_async", new_callable=AsyncMock):
+            with pytest.raises(ModelRetry) as exc:
+                await web_search_brave_with_document_backend(mocked_context, "empty query")
+
+            assert "no valid search results" in str(exc.value).lower()
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_web_search_brave_with_document_backend_store_exception(mocked_context):
+    """Test web_search_brave_with_document_backend when document store raises exception."""
+    respx.get(BRAVE_URL).mock(
+        return_value=httpx.Response(
+            status_code=200,
+            json={
+                "web": {
+                    "results": [
+                        {"url": "https://example.com/doc1", "title": "Document 1"},
+                    ]
+                }
+            },
+        )
+    )
+
+    mock_backend_class = MagicMock()
+    mock_backend_class.temporary_collection_async.return_value.__aenter__ = AsyncMock(
+        side_effect=Exception("Store initialization failed")
+    )
+
+    with patch("chat.tools.web_search_brave.import_string", return_value=mock_backend_class):
+        with pytest.raises(ModelRetry) as exc:
+            await web_search_brave_with_document_backend(mocked_context, "store error query")
+
+        assert "document storage temporarily failed" in str(exc.value).lower()
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_web_search_brave_with_document_backend_unexpected_exception(mocked_context):
+    """Test web_search_brave_with_document_backend handling of unexpected exceptions."""
+    respx.get(BRAVE_URL).mock(side_effect=TypeError("Unexpected type error"))
+
+    result = await web_search_brave_with_document_backend(mocked_context, "error query")
+    assert result == (
+        "An unexpected error occurred with the search service: TypeError. You must "
+        "explain this to the user and not try to answer based on your knowledge."
+    )
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_web_search_brave_with_document_backend_model_cannot_retry(mocked_context):
+    """Test web_search_brave_with_document_backend handling of ModelCannotRetry."""
+    respx.get(BRAVE_URL).mock(
+        return_value=httpx.Response(
+            status_code=401,
+            json={"error": "Unauthorized"},
+        )
+    )
+
+    result = await web_search_brave_with_document_backend(mocked_context, "unauthorized query")
+    assert result == (
+        "Web search failed with a client error (status 401). You must explain this to "
+        "the user and not try to answer based on your knowledge."
+    )
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_web_search_brave_with_document_backend_rag_search_params(mocked_context):
+    """Test web_search_brave_with_document_backend passes correct parameters to RAG search."""
+    respx.get(BRAVE_URL).mock(
+        return_value=httpx.Response(
+            status_code=200,
+            json={
+                "web": {
+                    "results": [
+                        {"url": "https://example.com/doc1", "title": "Document 1"},
+                    ]
+                }
+            },
+        )
+    )
+
+    mock_document_store = MagicMock()
+    mock_rag_result = Mock(url="https://example.com/doc1", content="RAG Content")
+    mock_rag_results = Mock(
+        data=[mock_rag_result], usage=Mock(prompt_tokens=10, completion_tokens=5)
+    )
+    mock_document_store.asearch = AsyncMock(return_value=mock_rag_results)
+
+    mock_backend_class = MagicMock()
+    mock_backend_class.temporary_collection_async.return_value.__aenter__ = AsyncMock(
+        return_value=mock_document_store
+    )
+    mock_backend_class.temporary_collection_async.return_value.__aexit__ = AsyncMock()
+
+    with patch("chat.tools.web_search_brave.import_string", return_value=mock_backend_class):
+        with patch("chat.tools.web_search_brave._fetch_and_store_async", new_callable=AsyncMock):
+            await web_search_brave_with_document_backend(mocked_context, "test query")
+
+    # Verify RAG search was called with correct parameters
+    mock_document_store.asearch.assert_called_once_with("test query", results_count=5)
+
+
+@pytest.mark.asyncio
+async def test_fetch_and_store_none_document():
+    """Test _fetch_and_store_async when extraction returns None instead of empty string."""
+    mock_document_store = MagicMock()
+
+    with patch(
+        "chat.tools.web_search_brave._fetch_and_extract_async", new_callable=AsyncMock
+    ) as mock_extract:
+        mock_extract.return_value = None
+
+        await _fetch_and_store_async("https://example.com/none", mock_document_store)
+
+        # Should not store None document
+        mock_document_store.store_document.assert_not_called()
+
+
+def test_format_tool_return():
+    """Test format_tool_return function directly."""
+
+    raw_results = [
+        {
+            "url": "https://example.com/1",
+            "title": "Result 1",
+            "extra_snippets": ["Snippet 1A", "Snippet 1B"],
+        },
+        {
+            "url": "https://example.com/2",
+            "title": "Result 2",
+            "extra_snippets": ["Snippet 2A"],
+        },
+        {
+            "url": "https://example.com/3",
+            "title": "Result 3",
+            # No extra_snippets
+        },
+    ]
+
+    tool_return = format_tool_return(raw_results)
+
+    # Result without snippets should be excluded
+    assert len(tool_return.return_value) == 2
+    assert tool_return.return_value["0"]["url"] == "https://example.com/1"
+    assert tool_return.return_value["0"]["title"] == "Result 1"
+    assert tool_return.return_value["0"]["snippets"] == ["Snippet 1A", "Snippet 1B"]
+    assert tool_return.return_value["1"]["url"] == "https://example.com/2"
+    assert tool_return.return_value["1"]["title"] == "Result 2"
+    assert tool_return.return_value["1"]["snippets"] == ["Snippet 2A"]
+
+    # Sources should only include URLs with snippets
+    assert tool_return.metadata["sources"] == {
+        "https://example.com/1",
+        "https://example.com/2",
+    }
+
+
+def test_format_tool_return_empty_snippets():
+    """Test format_tool_return with results that have empty snippet arrays."""
+
+    raw_results = [
+        {
+            "url": "https://example.com/1",
+            "title": "Result 1",
+            "extra_snippets": [],  # Empty array
+        },
+    ]
+
+    tool_return = format_tool_return(raw_results)
+
+    # Result with empty snippets should be excluded
+    assert len(tool_return.return_value) == 0
+    assert len(tool_return.metadata["sources"]) == 0
+
+
+def test_format_tool_return_no_results():
+    """Test format_tool_return with empty results list."""
+
+    tool_return = format_tool_return([])
+
+    assert len(tool_return.return_value) == 0
+    assert len(tool_return.metadata["sources"]) == 0

--- a/src/backend/chat/tools/__init__.py
+++ b/src/backend/chat/tools/__init__.py
@@ -18,18 +18,28 @@ def get_pydantic_tools_by_name(name: str) -> Tool:
     tool_dict = {
         "get_current_weather": Tool(get_current_weather, takes_ctx=False),
         "web_search_brave": Tool(
-            web_search_brave, takes_ctx=False, prepare=only_if_web_search_enabled
+            web_search_brave,
+            takes_ctx=True,
+            prepare=only_if_web_search_enabled,
+            max_retries=2,
         ),
         "web_search_brave_with_document_backend": Tool(
             web_search_brave_with_document_backend,
             takes_ctx=True,
             prepare=only_if_web_search_enabled,
+            max_retries=2,
         ),
         "web_search_tavily": Tool(
-            web_search_tavily, takes_ctx=False, prepare=only_if_web_search_enabled
+            web_search_tavily,
+            takes_ctx=False,
+            prepare=only_if_web_search_enabled,
+            max_retries=2,
         ),
         "web_search_albert_rag": Tool(
-            web_search_albert_rag, takes_ctx=True, prepare=only_if_web_search_enabled
+            web_search_albert_rag,
+            takes_ctx=True,
+            prepare=only_if_web_search_enabled,
+            max_retries=2,
         ),
     }
 

--- a/src/backend/chat/tools/exceptions.py
+++ b/src/backend/chat/tools/exceptions.py
@@ -1,0 +1,23 @@
+"""Exceptions for tool function retries."""
+
+from pydantic_ai import ModelRetry
+
+
+class ModelRetryLast(ModelRetry):
+    """
+    Same as ModelRetry but also holds the last retry message to return when all attempts failed.
+    """
+
+    def __init__(self, message: str, last_retry_message: str):
+        """Initialize ModelRetryLast with message and last retry message."""
+        self.last_retry_message = last_retry_message
+        super().__init__(message)
+
+
+class ModelCannotRetry(ModelRetry):
+    """
+    Exception to raise when a tool function cannot be retried.
+
+    We use this exception to signal that the model should not attempt to retry
+    the tool call, typically because the error is not transient or recoverable.
+    """

--- a/src/backend/chat/tools/utils.py
+++ b/src/backend/chat/tools/utils.py
@@ -1,0 +1,50 @@
+"""Tool calling utilities for the chat agent."""
+
+import functools
+import logging
+from typing import Any, Callable
+
+from pydantic_ai import ModelRetry, RunContext
+
+from chat.tools.exceptions import ModelCannotRetry
+
+logger = logging.getLogger(__name__)
+
+
+def last_model_retry_soft_fail(
+    tool_func: Callable[..., Any],
+) -> Callable[..., Any]:
+    """
+    Wrap a tool function to handle ModelRetry exceptions.
+
+    If the tool function raises ModelRetry and the maximum number of retries
+    has been reached, a ModelCannotRetry exception is raised instead.
+
+    Args:
+        tool_func: The original tool function to wrap.
+
+    Returns:
+        A wrapped tool function with retry handling.
+    """
+
+    @functools.wraps(tool_func)
+    async def wrapper(ctx: RunContext, *args, **kwargs) -> Any:
+        try:
+            return await tool_func(ctx, *args, **kwargs)
+        except ModelCannotRetry as exc:
+            return str(exc.message)
+        except ModelRetry as exc:
+            logger.error("Tool '%s' raised ModelRetry: %s", ctx, exc.message)
+            if (ctx.retries.get(ctx.tool_name, 0) + 1) >= ctx.max_retries:
+                logger.error("Max retries reached for tool '%s'.", ctx.tool_name)
+                # A bit of a hack to signal that we cannot retry here, while preventing
+                # the LLM to generate an outdated answer.
+                # We may define a more specific exception later base on ModelRetry which
+                # adds a specific message for this case.
+                return (
+                    f"{exc.message} You must explain this to the user and "
+                    "not try to answer based on your knowledge."
+                )
+            raise  # Re-raise to allow retrying
+
+    return wrapper

--- a/src/backend/chat/tools/web_search_brave.py
+++ b/src/backend/chat/tools/web_search_brave.py
@@ -1,24 +1,42 @@
 """Web search tool using Brave for the chat agent."""
 
+import asyncio
 import logging
 import uuid
-from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import List
 
 from django.conf import settings
 from django.core.cache import cache
 from django.utils.module_loading import import_string
+from django.utils.text import slugify
 
-import requests
+import httpx
+from asgiref.sync import sync_to_async
 from pydantic_ai import RunContext, RunUsage
+from pydantic_ai.exceptions import ModelRetry
 from pydantic_ai.messages import ToolReturn
-from trafilatura import extract, fetch_url
+from trafilatura import extract
 from trafilatura.meta import reset_caches
+
+from chat.tools.exceptions import ModelCannotRetry
+from chat.tools.utils import last_model_retry_soft_fail
 
 logger = logging.getLogger(__name__)
 
 
-def llm_summarize(query: str, text: str) -> str:
+class WebSearchError(Exception):
+    """Base exception for web search errors."""
+
+
+class BraveAPIError(WebSearchError):
+    """Error when calling Brave API."""
+
+
+class DocumentFetchError(WebSearchError):
+    """Error when fetching or extracting documents."""
+
+
+async def llm_summarize_async(query: str, text: str) -> str:
     """
     Summarize the text using the LLM summarization agent.
 
@@ -33,7 +51,7 @@ def llm_summarize(query: str, text: str) -> str:
     prompt = f"""
 Based on the following request, summarize the following text in a concise manner, 
 focusing on the key points regarding the user request. 
-he result should be up to 30 lines long.
+The result should be up to 30 lines long.
 
 <user request>
 {query}
@@ -44,54 +62,87 @@ he result should be up to 30 lines long.
 </text to summarize>
 """
 
-    result = summarization_agent.run_sync(prompt)
+    result = await summarization_agent.run(prompt)
     return result.output
 
 
-def _fetch_and_extract(url: str) -> str:
-    """Fetch and extract text content from the URL."""
-    cache_key = f"web_search_brave:extract:{url}"
+async def _fetch_url_async(url: str, timeout: int = 30) -> str:
+    """Fetch URL content asynchronously."""
+    async with httpx.AsyncClient(timeout=timeout, follow_redirects=True) as client:
+        response = await client.get(url)
+        response.raise_for_status()
+        return response.text
 
-    if (document := cache.get(cache_key)) is not None:
+
+async def _fetch_and_extract_async(url: str) -> str:
+    """Fetch and extract text content from the URL asynchronously."""
+    cache_key = f"web_search_brave:extract:{slugify(url)}"
+
+    # Check cache first
+    if (document := await cache.aget(cache_key)) is not None:
         return document
 
-    html = fetch_url(url)
-    document = extract(html, include_comments=False, no_fallback=True) or ""
-    cache.set(cache_key, document, settings.BRAVE_CACHE_TTL)
+    try:
+        # Fetch HTML
+        html = await _fetch_url_async(url, timeout=settings.BRAVE_API_TIMEOUT)
 
-    return document
+        # Extract text in thread pool (trafilatura is CPU-bound)
+        document = await sync_to_async(extract)(html, include_comments=False, no_fallback=True)
+
+        # Cache the result
+        await cache.aset(cache_key, document, settings.BRAVE_CACHE_TTL)
+        return document
+
+    except httpx.HTTPError as e:
+        logger.warning("HTTP error fetching %s: %s", url, e, exc_info=True)
+        raise DocumentFetchError(f"Failed to fetch {url}: {e}") from e
+    except Exception as e:
+        logger.warning("Error extracting content from %s: %s", url, e, exc_info=True)
+        raise DocumentFetchError(f"Failed to extract content from {url}: {e}") from e
 
 
-def _extract_and_summarize_snippets(query: str, url: str) -> List[str]:
+async def _extract_and_summarize_snippets_async(query: str, url: str) -> List[str]:
     """Fetch, extract and summarize text content from the URL.
 
     Returns a list of snippets (0 or 1 element, preserving existing behavior).
     """
-    # Cache by URL to avoid repeated fetch/extract across calls
-    document = _fetch_and_extract(url)
-    if not document:
+    try:
+        document = await _fetch_and_extract_async(url)
+        if not document:
+            return []
+
+        if not settings.BRAVE_SUMMARIZATION_ENABLED:
+            return [document]
+
+        try:
+            snippet = await llm_summarize_async(query, document)
+            return [snippet] if snippet else []
+        except Exception as e:  # pylint: disable=broad-except
+            logger.exception("Summarization failed for %s: %s", url, e)
+            # Fallback to raw document if summarization fails
+            return [document]
+
+    except DocumentFetchError:
+        # Document fetch failed, return empty
         return []
 
-    if not settings.BRAVE_SUMMARIZATION_ENABLED:
-        return [document]
+
+async def _fetch_and_store_async(url: str, document_store) -> None:
+    """Fetch, extract and store text content from the URL in the document store."""
 
     try:
-        snippet = llm_summarize(query, document)
-    except Exception as e:  # pylint: disable=broad-except
-        logger.exception("Summarization failed for %s: %s", url, e)
-        snippet = None
+        document = await _fetch_and_extract_async(url)
 
-    return [snippet] if snippet else []
+        logger.debug("Fetched document: %s", document)
 
-
-def _fetch_and_store(url: str, document_store) -> None:
-    """Fetch, extract and store text content from the URL in the document store."""
-    document = _fetch_and_extract(url)
-    if document:
-        document_store.store_document(url, document)
+        if document:
+            await document_store.astore_document(url, document)
+    except DocumentFetchError as e:
+        logger.warning("Failed to fetch and store %s: %s", url, e)
+        # Continue with other documents
 
 
-def _query_brave_api(query: str) -> List[dict]:
+async def _query_brave_api_async(query: str) -> List[dict]:
     """Query the Brave Search API and return the raw results."""
     url = "https://api.search.brave.com/res/v1/web/search"
     headers = {
@@ -109,14 +160,53 @@ def _query_brave_api(query: str) -> List[dict]:
         "extra_snippets": settings.BRAVE_SEARCH_EXTRA_SNIPPETS,
     }
     params = {k: v for k, v in data.items() if v is not None}
-    response = requests.get(url, headers=headers, params=params, timeout=settings.BRAVE_API_TIMEOUT)
-    response.raise_for_status()
 
-    json_response = response.json()
+    try:
+        async with httpx.AsyncClient(timeout=settings.BRAVE_API_TIMEOUT) as client:
+            response = await client.get(url, headers=headers, params=params)
+            response.raise_for_status()
+            json_response = response.json()
 
-    # See https://api-dashboard.search.brave.com/app/documentation/web-search/responses#Result
-    # & https://api-dashboard.search.brave.com/app/documentation/web-search/responses#SearchResult
-    return json_response.get("web", {}).get("results", [])
+            # https://api-dashboard.search.brave.com/app/documentation/web-search/responses#Result
+            return json_response.get("web", {}).get("results", [])
+
+    except httpx.HTTPStatusError as e:
+        if e.response.status_code == 429:
+            # Rate limit - retryable
+            logger.warning("Brave API rate limited: %s", e)
+            raise ModelRetry(
+                "The search API is rate limited. Please wait a moment and try again."
+            ) from e
+        if e.response.status_code >= 500:
+            # Server error - retryable
+            logger.warning("Brave API error: %s", e)
+            raise ModelRetry(
+                "The search service is temporarily unavailable due to a server error. Retrying..."
+            ) from e
+
+        # Client error (4xx) - not retryable, stop and inform user
+        logger.error("Brave API client error: %s", e)
+        raise ModelCannotRetry(
+            f"Web search failed with a client error (status {e.response.status_code}). "
+            "You must explain this to the user and not try to answer based on your knowledge."
+        ) from e
+    except httpx.TimeoutException as e:
+        # Timeout - retryable
+        logger.warning("Brave API timeout: %s", e)
+        raise ModelRetry("The search request timed out. Retrying with a fresh attempt...") from e
+    except httpx.HTTPError as e:
+        # Other HTTP errors - retryable
+        logger.warning("Brave API connection error: %s", e)
+        raise ModelRetry(
+            f"Connection error while searching the web: {type(e).__name__}. Retrying..."
+        ) from e
+    except Exception as e:
+        # Unexpected errors - not retryable, stop completely
+        logger.exception("Unexpected error querying Brave API: %s", e)
+        raise ModelCannotRetry(
+            f"An unexpected error occurred with the search service: {type(e).__name__}. "
+            "You must explain this to the user and not try to answer based on your knowledge."
+        ) from e
 
 
 def format_tool_return(raw_search_results: List[dict]) -> ToolReturn:
@@ -140,92 +230,132 @@ def format_tool_return(raw_search_results: List[dict]) -> ToolReturn:
     )
 
 
-def web_search_brave(query: str) -> ToolReturn:
+@last_model_retry_soft_fail
+async def web_search_brave(_ctx: RunContext, query: str) -> ToolReturn:
     """
     Search the web for up-to-date information
 
     Args:
+        _ctx (RunContext): The run context, used by the wrapper.
         query (str): The query to search for.
     """
-    raw_search_results = _query_brave_api(query)
+    try:
+        raw_search_results = await _query_brave_api_async(query)
 
-    reset_caches()  # Clear trafilatura caches to avoid memory bloat/leaks
+        await sync_to_async(reset_caches)()  # Clear trafilatura caches to avoid memory bloat/leaks
 
-    # Parallelize fetch/extract for results that don't include extra_snippets
-    to_process = [
-        (idx, r) for idx, r in enumerate(raw_search_results) if not r.get("extra_snippets")
-    ]
+        # Parallelize fetch/extract for results that don't include extra_snippets
+        to_process = [
+            (idx, r) for idx, r in enumerate(raw_search_results) if not r.get("extra_snippets")
+        ]
 
-    if to_process:
-        max_workers = min(settings.BRAVE_MAX_WORKERS, len(to_process))
-        if max_workers == 1:
-            # Avoid overhead of ThreadPoolExecutor if only one task
-            for idx, r in to_process:
-                raw_search_results[idx]["extra_snippets"] = _extract_and_summarize_snippets(
-                    query, r["url"]
-                )
+        if to_process:
+            # Process all URLs concurrently
+            tasks = [
+                _extract_and_summarize_snippets_async(query, r["url"]) for idx, r in to_process
+            ]
+            results = await asyncio.gather(*tasks, return_exceptions=False)
 
-        else:
-            with ThreadPoolExecutor(max_workers=max_workers) as executor:
-                future_map = {
-                    executor.submit(_extract_and_summarize_snippets, query, r["url"]): idx
-                    for idx, r in to_process
-                }
-                for future in as_completed(future_map):
-                    idx = future_map[future]
-                    raw_search_results[idx]["extra_snippets"] = future.result()
+            # Update raw_search_results with extracted snippets
+            for (idx, _), snippets in zip(to_process, results, strict=True):
+                raw_search_results[idx]["extra_snippets"] = snippets
 
-    return format_tool_return(raw_search_results)
+        formatted_result = format_tool_return(raw_search_results)
+
+        # Check if we got any valid results
+        if not formatted_result.return_value:
+            raise ModelRetry(
+                "No valid search results were extracted from the web pages. "
+                "Retrying the search to find better sources..."
+            )
+
+        return formatted_result
+
+    except (ModelCannotRetry, ModelRetry):
+        # Re-raise these as-is
+        raise
+    except Exception as exc:
+        # Unexpected error in our code - stop and inform user
+        logger.exception("Unexpected error in web_search_brave: %s", exc)
+        raise ModelCannotRetry(
+            f"An unexpected error occurred during web search: {type(exc).__name__}. "
+            "You must explain this to the user and not try to answer based on your knowledge."
+        ) from exc
 
 
-def web_search_brave_with_document_backend(ctx: RunContext, query: str) -> ToolReturn:
+@last_model_retry_soft_fail
+async def web_search_brave_with_document_backend(ctx: RunContext, query: str) -> ToolReturn:
     """
-    Search the web for up-to-date information
+    Search the web for up-to-date information using RAG backend
 
     Args:
         ctx (RunContext): The run context containing the conversation.
         query (str): The query to search for.
     """
-    raw_search_results = _query_brave_api(query)
+    logger.info("Starting web search with RAG backend for query: %s", query)
+    try:
+        raw_search_results = await _query_brave_api_async(query)
 
-    reset_caches()  # Clear trafilatura caches to avoid memory bloat/leaks
+        # Clear trafilatura caches in thread pool to avoid blocking
+        loop = asyncio.get_event_loop()
+        await loop.run_in_executor(None, reset_caches)
 
-    # Store documents in a temporary document store for RAG search
-    document_store_backend = import_string(settings.RAG_DOCUMENT_SEARCH_BACKEND)
-    with document_store_backend.temporary_collection(f"tmp-{uuid.uuid4()}") as document_store:
-        max_workers = min(settings.BRAVE_MAX_WORKERS, len(raw_search_results))
-        if max_workers == 1:
-            for result in raw_search_results:
-                # Fetch and extract document content
-                _fetch_and_store(result["url"], document_store)
-        else:
-            with ThreadPoolExecutor(max_workers=max_workers) as executor:
-                futures = [
-                    executor.submit(_fetch_and_store, result["url"], document_store)
+        # Store documents in a temporary document store for RAG search
+        document_store_backend = import_string(settings.RAG_DOCUMENT_SEARCH_BACKEND)
+
+        # Create temporary collection
+        temp_collection_name = f"tmp-{uuid.uuid4()}"
+        try:
+            async with document_store_backend.temporary_collection_async(
+                temp_collection_name
+            ) as document_store:
+                # Fetch and store all documents concurrently
+                tasks = [
+                    _fetch_and_store_async(result["url"], document_store)
                     for result in raw_search_results
                 ]
-                for future in as_completed(futures):
-                    try:
-                        future.result()
-                    except Exception as e:  # pylint: disable=broad-except
-                        logger.exception("Error fetching/storing document: %s", e)
+                await asyncio.gather(*tasks, return_exceptions=True)
 
-        rag_results = document_store.search(
-            query,
-            results_count=settings.BRAVE_RAG_WEB_SEARCH_CHUNK_NUMBER,
-        )
+                # Perform RAG search
+                rag_results = await document_store.asearch(
+                    query,
+                    results_count=settings.BRAVE_RAG_WEB_SEARCH_CHUNK_NUMBER,
+                )
+                logger.info("RAG search returned:  %s", rag_results)
 
-        ctx.usage += RunUsage(
-            input_tokens=rag_results.usage.prompt_tokens,
-            output_tokens=rag_results.usage.completion_tokens,
-        )
+                ctx.usage += RunUsage(
+                    input_tokens=rag_results.usage.prompt_tokens,
+                    output_tokens=rag_results.usage.completion_tokens,
+                )
 
-        # Map RAG results back to raw search results to include extra_snippets
-        # Suboptimal O(N^2) but N is small...
-        for rag_result in rag_results.data:
-            for result in raw_search_results:
-                if result["url"] == rag_result.url:
-                    result.setdefault("extra_snippets", []).append(rag_result.content)
-                    break
+                # Map RAG results back to raw search results to include extra_snippets
+                for rag_result in rag_results.data:
+                    for result in raw_search_results:
+                        if result["url"] == rag_result.url:
+                            result.setdefault("extra_snippets", []).append(rag_result.content)
+                            break
 
-    return format_tool_return(raw_search_results)
+        except Exception as exc:
+            logger.exception("Error with document store: %s", exc)
+            raise ModelRetry(
+                f"Document storage temporarily failed: {type(exc).__name__}. "
+                "Retrying the operation..."
+            ) from exc
+
+        formatted_result = format_tool_return(raw_search_results)
+
+        # Check if we got any valid results
+        if not formatted_result.return_value:
+            raise ModelRetry("No valid search results were extracted.")
+
+        return formatted_result
+    except (ModelCannotRetry, ModelRetry):
+        # Re-raise these as-is
+        raise
+    except Exception as e:
+        # Unexpected error - stop and inform user
+        logger.exception("Unexpected error in web_search_brave_with_document_backend: %s", e)
+        raise ModelCannotRetry(
+            f"An unexpected error occurred during web search with RAG: {type(e).__name__}. "
+            "You must explain this to the user and not try to answer based on your knowledge."
+        ) from e


### PR DESCRIPTION
## Purpose

When the tool call fails, we don't want the user to be blocked without any clue.

This adds:
 - auto retry when possible
 - nice message preventing the LLM to generate an answer without updated information


## Proposal

- [x] use `ModelRetry` exception to allow Pydantic AI to manage exception properly
- [x] add decorator to manage "no more retry" while preventing the LLM to build an answer without fresh information
- [x] add tests



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Web search and RAG document workflows converted to async for non-blocking fetch, summarization, and store operations.
  * Tools gain soft-retry behavior (limited automatic retries) and clearer non-retryable error types; some tools now accept execution context.

* **Bug Fixes**
  * Improved handling of rate limits, timeouts, HTTP and document-fetch errors with better retry semantics and fallbacks.

* **Tests**
  * Expanded async and retry-focused tests, including document-backend and formatting scenarios.

* **Documentation**
  * Changelog updated about resilient web-search behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->