### PR TITLE
🐛(front) fix target blank links in chat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ### Fixed
 
+- 🐛(front) fix target blank links in chat #103
 - 🚑️(posthog) pass str instead of UUID for user PK #134
 
 

--- a/src/frontend/apps/conversations/src/features/chat/components/Chat.tsx
+++ b/src/frontend/apps/conversations/src/features/chat/components/Chat.tsx
@@ -665,6 +665,11 @@ export const Chat = ({
                                   {...props}
                                 />
                               ),
+                              a: ({ children, ...props }) => (
+                                <a target="_blank" {...props}>
+                                  {children}
+                                </a>
+                              ),
                             }}
                           >
                             {message.content}


### PR DESCRIPTION
Add target blank to link in chat

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Links in chat now open in a new browser tab by default, preventing the conversation view from being replaced when following external links.
  * Markdown-rendered links in messages will consistently use the new-tab behavior across chat content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->