### PR TITLE
🐛(front) Fix send prohibited file types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ### Fixed
 
+- 🦺(front) Fix send prohibited file types
 - 🐛(front) fix target blank links in chat #103
 - 🚑️(posthog) pass str instead of UUID for user PK #134
 - ⚡️(web-search) keep running when tool call fails #137

--- a/src/frontend/apps/conversations/src/components/CustomToast.tsx
+++ b/src/frontend/apps/conversations/src/components/CustomToast.tsx
@@ -3,6 +3,7 @@ import { css } from 'styled-components';
 
 import { Box, Text } from '@/components';
 import { Icon } from '@/components/Icon';
+import { useResponsiveStore } from '@/stores';
 
 export type ToastType = 'success' | 'error' | 'info' | 'warning';
 
@@ -13,6 +14,8 @@ export interface ToastProps {
   icon?: string;
   duration?: number;
   onClose: (id: string) => void;
+  actionLabel?: string;
+  actionHref?: string;
 }
 
 const getToastConfig = (type: ToastType) => {
@@ -62,11 +65,14 @@ export const Toast = ({
   icon,
   duration = 4000,
   onClose,
+  actionLabel,
+  actionHref,
 }: ToastProps) => {
   const [isVisible, setIsVisible] = useState(false);
   const [isLeaving, setIsLeaving] = useState(false);
   const config = getToastConfig(type);
   const iconToUse = icon || config.icon;
+  const { isMobile } = useResponsiveStore();
 
   useEffect(() => {
     setIsVisible(true);
@@ -102,7 +108,12 @@ export const Toast = ({
         overflow: hidden;
       `}
     >
-      <Box $direction="row" $align="center" $gap="12px">
+      <Box
+        $direction="row"
+        $align="center"
+        $gap="12px"
+        $justify="space-between"
+      >
         <Icon
           iconName={iconToUse}
           $variation="600"
@@ -111,16 +122,41 @@ export const Toast = ({
             color: ${config.color} !important;
           `}
         />
-        <Text
-          $weight="500"
-          $size="14px"
-          $css={css`
-            color: ${config.color} !important;
-            padding: 4px;
-          `}
+        <Box
+          $direction="row"
+          $align="center"
+          $gap="12px"
+          $flex={1}
+          $justify="space-between"
         >
-          {message}
-        </Text>
+          <Text
+            $weight="500"
+            $size="14px"
+            $css={css`
+              color: ${config.color} !important;
+              padding: 4px;
+            `}
+          >
+            {message}
+          </Text>
+
+          {actionLabel && actionHref && !isMobile && (
+            <a
+              href={actionHref}
+              target="_blank"
+              rel="noopener noreferrer"
+              style={{
+                color: config.color,
+                fontWeight: '500',
+                fontSize: '14px',
+                textDecoration: 'underline',
+                whiteSpace: 'nowrap',
+              }}
+            >
+              {actionLabel}
+            </a>
+          )}
+        </Box>
       </Box>
     </Box>
   );

--- a/src/frontend/apps/conversations/src/components/ToastProvider.tsx
+++ b/src/frontend/apps/conversations/src/components/ToastProvider.tsx
@@ -17,6 +17,8 @@ interface ToastItem {
   type: ToastType;
   icon?: string;
   duration?: number;
+  actionLabel?: string;
+  actionHref?: string;
 }
 
 interface ToastContextType {
@@ -25,6 +27,7 @@ interface ToastContextType {
     message: string,
     icon?: string,
     duration?: number,
+    options?: { actionLabel?: string; actionHref?: string },
   ) => void;
 }
 
@@ -46,9 +49,23 @@ export const ToastProvider = ({ children }: ToastProviderProps) => {
   const [toasts, setToasts] = useState<ToastItem[]>([]);
 
   const showToast = useCallback(
-    (type: ToastType, message: string, icon?: string, duration = 4000) => {
+    (
+      type: ToastType,
+      message: string,
+      icon?: string,
+      duration = 4000,
+      options?: { actionLabel?: string; actionHref?: string },
+    ) => {
       const id = Math.random().toString(36).substr(2, 9);
-      const newToast: ToastItem = { id, message, type, icon, duration };
+      const newToast: ToastItem = {
+        id,
+        message,
+        type,
+        icon,
+        duration,
+        actionLabel: options?.actionLabel,
+        actionHref: options?.actionHref,
+      };
 
       setToasts((prev) => [newToast, ...prev]);
     },
@@ -95,6 +112,8 @@ export const ToastProvider = ({ children }: ToastProviderProps) => {
                 type={toast.type}
                 icon={toast.icon}
                 duration={toast.duration}
+                actionLabel={toast.actionLabel}
+                actionHref={toast.actionHref}
                 onClose={removeToast}
               />
             ))}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed issue preventing uploads of certain prohibited file types; rejected files now show a single standardized error toast.

* **New Features**
  * Toasts can include an optional action link on desktop for quick follow-up actions.
  * Drag-and-drop and file picker flows simplified: only accepted files are added, rejected files trigger a clear toast, and the uploader UI displays a consistent "Add file" prompt.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->