### PR TITLE
⚗️(summarize) move the system prompt to instruction

### DIFF
--- a/src/backend/chat/clients/pydantic_ai.py
+++ b/src/backend/chat/clients/pydantic_ai.py
@@ -481,7 +481,7 @@ class AIAgentService:  # pylint: disable=too-many-instance-attributes
         elif has_not_pdf_docs:
             add_document_rag_search_tool(self.conversation_agent)
 
-            @self.conversation_agent.system_prompt
+            @self.conversation_agent.instructions
             def summarization_system_prompt() -> str:
                 return (
                     "When you receive a result from the summarization tool, you MUST return it "

--- a/src/backend/chat/tests/views/chat/conversations/test_conversation_with_document_upload.py
+++ b/src/backend/chat/tests/views/chat/conversations/test_conversation_with_document_upload.py
@@ -352,7 +352,14 @@ def test_post_conversation_with_document_upload(  # pylint: disable=too-many-arg
 
     assert len(chat_conversation.pydantic_messages) == 4
     assert chat_conversation.pydantic_messages[0] == {
-        "instructions": None,
+        "instructions": "When you receive a result from the summarization tool, you "
+        "MUST return it directly to the user without any "
+        "modification, paraphrasing, or additional summarization.The "
+        "tool already produces optimized summaries that should be "
+        "presented verbatim.You may translate the summary if "
+        "required, but you MUST preserve all the information from the "
+        "original summary.You may add a follow-up question after the "
+        "summary if needed.",
         "kind": "request",
         "parts": [
             {
@@ -378,20 +385,6 @@ def test_post_conversation_with_document_upload(  # pylint: disable=too-many-arg
                 "passages from attached documents. Do NOT use it to "
                 "summarize; for summaries, call the summarize tool "
                 "instead.",
-                "dynamic_ref": None,
-                "part_kind": "system-prompt",
-                "timestamp": timezone_now,
-            },
-            {
-                "content": "When you receive a result from the summarization tool, "
-                "you MUST return it directly to the user without any "
-                "modification, paraphrasing, or additional "
-                "summarization.The tool already produces optimized "
-                "summaries that should be presented verbatim.You may "
-                "translate the summary if required, but you MUST "
-                "preserve all the information from the original "
-                "summary.You may add a follow-up question after the "
-                "summary if needed.",
                 "dynamic_ref": None,
                 "part_kind": "system-prompt",
                 "timestamp": timezone_now,
@@ -441,7 +434,16 @@ def test_post_conversation_with_document_upload(  # pylint: disable=too-many-arg
         },
     }
     assert chat_conversation.pydantic_messages[2] == {
-        "instructions": None,
+        "instructions": (
+            "When you receive a result from the summarization tool, you MUST "
+            "return it directly to the user without any modification, "
+            "paraphrasing, or additional summarization."
+            "The tool already produces optimized summaries that should "
+            "be presented verbatim."
+            "You may translate the summary if required, but you MUST preserve "
+            "all the information from the original summary."
+            "You may add a follow-up question after the summary if needed."
+        ),
         "kind": "request",
         "parts": [
             {
@@ -695,7 +697,14 @@ def test_post_conversation_with_document_upload_summarize(  # pylint: disable=to
 
     assert len(chat_conversation.pydantic_messages) == 4
     assert chat_conversation.pydantic_messages[0] == {
-        "instructions": None,
+        "instructions": "When you receive a result from the summarization tool, you "
+        "MUST return it directly to the user without any "
+        "modification, paraphrasing, or additional summarization.The "
+        "tool already produces optimized summaries that should be "
+        "presented verbatim.You may translate the summary if "
+        "required, but you MUST preserve all the information from the "
+        "original summary.You may add a follow-up question after the "
+        "summary if needed.",
         "kind": "request",
         "parts": [
             {
@@ -721,20 +730,6 @@ def test_post_conversation_with_document_upload_summarize(  # pylint: disable=to
                 "passages from attached documents. Do NOT use it to "
                 "summarize; for summaries, call the summarize tool "
                 "instead.",
-                "dynamic_ref": None,
-                "part_kind": "system-prompt",
-                "timestamp": timezone_now,
-            },
-            {
-                "content": "When you receive a result from the summarization tool, "
-                "you MUST return it directly to the user without any "
-                "modification, paraphrasing, or additional "
-                "summarization.The tool already produces optimized "
-                "summaries that should be presented verbatim.You may "
-                "translate the summary if required, but you MUST "
-                "preserve all the information from the original "
-                "summary.You may add a follow-up question after the "
-                "summary if needed.",
                 "dynamic_ref": None,
                 "part_kind": "system-prompt",
                 "timestamp": timezone_now,
@@ -784,7 +779,16 @@ def test_post_conversation_with_document_upload_summarize(  # pylint: disable=to
         },
     }
     assert chat_conversation.pydantic_messages[2] == {
-        "instructions": None,
+        "instructions": (
+            "When you receive a result from the summarization tool, you MUST "
+            "return it directly to the user without any modification, "
+            "paraphrasing, or additional summarization."
+            "The tool already produces optimized summaries that should "
+            "be presented verbatim."
+            "You may translate the summary if required, but you MUST preserve "
+            "all the information from the original summary."
+            "You may add a follow-up question after the summary if needed."
+        ),
         "kind": "request",
         "parts": [
             {

--- a/src/backend/chat/tests/views/chat/conversations/test_conversation_with_document_url.py
+++ b/src/backend/chat/tests/views/chat/conversations/test_conversation_with_document_url.py
@@ -889,19 +889,6 @@ def test_post_conversation_with_local_not_pdf_document_url(  # pylint: disable=t
                     ),
                     SystemPromptPart(
                         content=(
-                            "When you receive a result from the summarization tool, you MUST "
-                            "return it directly to the user without any modification, "
-                            "paraphrasing, or additional summarization."
-                            "The tool already produces optimized summaries that should "
-                            "be presented verbatim."
-                            "You may translate the summary if required, but you MUST preserve "
-                            "all the information from the original summary."
-                            "You may add a follow-up question after the summary if needed."
-                        ),
-                        timestamp=timezone.now(),
-                    ),
-                    SystemPromptPart(
-                        content=(
                             "[Internal context] User documents are attached to this conversation. "
                             "Do not request re-upload of documents; consider them already "
                             "available via the internal store."
@@ -915,7 +902,17 @@ def test_post_conversation_with_local_not_pdf_document_url(  # pylint: disable=t
                         ],
                         timestamp=timezone.now(),
                     ),
-                ]
+                ],
+                instructions=(
+                    "When you receive a result from the summarization tool, you MUST "
+                    "return it directly to the user without any modification, "
+                    "paraphrasing, or additional summarization."
+                    "The tool already produces optimized summaries that should "
+                    "be presented verbatim."
+                    "You may translate the summary if required, but you MUST preserve "
+                    "all the information from the original summary."
+                    "You may add a follow-up question after the summary if needed."
+                ),
             )
         ]
         yield "This is a document about you."
@@ -987,7 +984,16 @@ def test_post_conversation_with_local_not_pdf_document_url(  # pylint: disable=t
 
     assert chat_conversation.pydantic_messages == [
         {
-            "instructions": None,
+            "instructions": (
+                "When you receive a result from the summarization tool, you MUST "
+                "return it directly to the user without any modification, "
+                "paraphrasing, or additional summarization."
+                "The tool already produces optimized summaries that should "
+                "be presented verbatim."
+                "You may translate the summary if required, but you MUST preserve "
+                "all the information from the original summary."
+                "You may add a follow-up question after the summary if needed."
+            ),
             "kind": "request",
             "parts": [
                 {
@@ -1013,20 +1019,6 @@ def test_post_conversation_with_local_not_pdf_document_url(  # pylint: disable=t
                     "passages from attached documents. Do NOT use it to "
                     "summarize; for summaries, call the summarize tool "
                     "instead.",
-                    "dynamic_ref": None,
-                    "part_kind": "system-prompt",
-                    "timestamp": timestamp,
-                },
-                {
-                    "content": "When you receive a result from the summarization "
-                    "tool, you MUST return it directly to the user without "
-                    "any modification, paraphrasing, or additional "
-                    "summarization.The tool already produces optimized "
-                    "summaries that should be presented verbatim.You may "
-                    "translate the summary if required, but you MUST "
-                    "preserve all the information from the original "
-                    "summary.You may add a follow-up question after the "
-                    "summary if needed.",
                     "dynamic_ref": None,
                     "part_kind": "system-prompt",
                     "timestamp": timestamp,


### PR DESCRIPTION
## Purpose

When the tool is called, the agent graph call the LLM again with the tool response, and the instructions. I hope using instruction here will provide better results.

The former way to add the summarize tool as output does not work properly with Mistral:
- if the user ask for a summary, the tool is called and the result is returned directly
- then if there is another user request which does not trigger a tool: boom, there is a JSON encode error...

I was not able to understand why this happens, so for now, the summarize tool is not an "output".


## Proposal

- [x] use instruction instead of system prompt because:

```python
    async def _handle_tool_calls(
        self,
        ctx: GraphRunContext[GraphAgentState, GraphAgentDeps[DepsT, NodeRunEndT]],
        tool_calls: list[_messages.ToolCallPart],
    ) -> AsyncIterator[_messages.HandleResponseEvent]:
        run_context = build_run_context(ctx)

        # This will raise errors for any tool name conflicts
        ctx.deps.tool_manager = await ctx.deps.tool_manager.for_run_step(run_context)

        output_parts: list[_messages.ModelRequestPart] = []
        output_final_result: deque[result.FinalResult[NodeRunEndT]] = deque(maxlen=1)

        async for event in process_tool_calls(
            tool_manager=ctx.deps.tool_manager,
            tool_calls=tool_calls,
            tool_call_results=self.tool_call_results,
            final_result=None,
            ctx=ctx,
            output_parts=output_parts,
            output_final_result=output_final_result,
        ):
            yield event

        if output_final_result:
            final_result = output_final_result[0]
            self._next_node = self._handle_final_result(ctx, final_result, output_parts)
        else:
            instructions = await ctx.deps.get_instructions(run_context)
            self._next_node = ModelRequestNode[DepsT, NodeRunEndT](
                _messages.ModelRequest(parts=output_parts, instructions=instructions)
            )
```




## The former way to do

```python
async with self.conversation_agent.iter(
                [user_prompt] + input_images + document_urls,
                message_history=history,  # history will pass through agent's history_processors
                deps=self._context_deps,
                toolsets=mcp_servers,
                output_type=(
                        [str, ToolOutput(document_summarize, name="summarize")]
                        if conversation_has_documents
                        else str
                ),
            ) as run:
```

use this fails...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Summarization directives are now delivered via a top-level instructions field in model requests for more consistent document summarization behavior.

* **Tests**
  * Updated test expectations to reflect the new instructions placement and removed duplicated system-prompt entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->