### PR TITLE
🐛(back) fix system prompt compatibility with self-hosted models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ and this project adheres to
 
 ### Fixed
 
-- 🐛(e2e) fix test-e2e-chronium
+- 🐛(e2e) fix test-e2e-chromium
+- 🐛(back) fix system prompt compatibility with self-hosted models #200
 
 ## [0.0.10] - 2025-12-15
 
@@ -34,13 +35,13 @@ and this project adheres to
 ## [0.0.9] - 2025-11-17
 
 ### Added
+
 - ✨(front) add code copy button
 - ✨(RAG) add generic collection RAG tools #159
 
 ### Fixed
 
 - 🔊(langfuse) enable tracing with redacted content #162
-
 
 ## [0.0.8] - 2025-11-10
 
@@ -56,13 +57,11 @@ and this project adheres to
 
 - 🔥(posthog) remove posthog middleware for async mode fix #146
 
-
 ## [0.0.7] - 2025-10-28
 
 ### Fixed
 
 - 🚑️(posthog) fix the posthog middleware for async mode #133
-
 
 ## [0.0.6] - 2025-10-28
 
@@ -70,13 +69,11 @@ and this project adheres to
 
 - 🚑️(stats) fix tracking id in upload event #130
 
-
 ## [0.0.5] - 2025-10-27
 
 ### Fixed
 
 - 🚑️(drag-drop) fix the rejection display on Safari #127
-
 
 ## [0.0.4] - 2025-10-27
 
@@ -94,13 +91,11 @@ and this project adheres to
 - 🐛(front) fix mobile source
 - 🐛(attachments) reject the whole drag&drop if unsupported formats #123
 
-
 ## [0.0.3] - 2025-10-21
 
 ### Fixed
 
 - 🚑️(web-search) fix missing argument in RAG backend #116
-
 
 ## [0.0.2] - 2025-10-21
 
@@ -111,13 +106,13 @@ and this project adheres to
 - 📈(posthog) add `sub` field to tracking #95
 
 ### Changed
+
 - 🔧(front) change links feedback tchap + settings popup
 - 🐛(front) code activation fix session end #93
 - 💬(wording) error page wording #102
 - ⚡️(web-search) allow to override returned chunks #107
 - 🐛(activation-codes) create contact in brevo before add to list #108
 - ⚗️(summarization) add system prompt to handle tool #112
-
 
 ## [0.0.1] - 2025-10-19
 
@@ -141,7 +136,7 @@ and this project adheres to
 - 🎨(front) change list attachment in chat
 - 🎨(front) move emplacement for attachment
 - 🎨(ui) retour ui sources files
-- ✨(ui) fix retour global ui 
+- ✨(ui) fix retour global ui
 - 🐛(fix) broken staging css
 - 🎨(alpha) adjustment for alpha version
 - ✨(ui) delete flex message

--- a/src/backend/chat/agents/base.py
+++ b/src/backend/chat/agents/base.py
@@ -190,6 +190,4 @@ class BaseAgent(Agent):
 
         _tools = [get_pydantic_tools_by_name(tool_name) for tool_name in self.configuration.tools]
 
-        super().__init__(
-            model=_model_instance, system_prompt=_system_prompt, tools=_tools, **kwargs
-        )
+        super().__init__(model=_model_instance, instructions=_system_prompt, tools=_tools, **kwargs)

--- a/src/backend/chat/agents/conversation.py
+++ b/src/backend/chat/agents/conversation.py
@@ -16,7 +16,6 @@ from .base import BaseAgent
 
 logger = logging.getLogger(__name__)
 
-
 MOCKED_RESPONSE = """
 # **Ode to the AI Assistant** 🤖✨
 
@@ -102,10 +101,10 @@ class ConversationAgent(BaseAgent):
         if settings.WARNING_MOCK_CONVERSATION_AGENT:
             self._model = FunctionModel(stream_function=mocked_agent_model)
 
-        @self.system_prompt
+        @self.instructions
         def add_the_date() -> str:
             """
-            Dynamic system prompt function to add the current date.
+            Dynamic instruction function to add the current date.
 
             Warning: this will always use the date in the server timezone,
             not the user's timezone...
@@ -113,9 +112,9 @@ class ConversationAgent(BaseAgent):
             _formatted_date = formats.date_format(timezone.now(), "l d/m/Y", use_l10n=False)
             return f"Today is {_formatted_date}."
 
-        @self.system_prompt
+        @self.instructions
         def enforce_response_language() -> str:
-            """Dynamic system prompt function to set the expected language to use."""
+            """Dynamic instruction function to set the expected language to use."""
             return f"Answer in {get_language_name(language).lower()}." if language else ""
 
     def get_web_search_tool_name(self) -> str | None:

--- a/src/backend/chat/tests/views/chat/conversations/test_conversation.py
+++ b/src/backend/chat/tests/views/chat/conversations/test_conversation.py
@@ -130,6 +130,16 @@ def test_post_conversation_data_protocol(api_client, mock_openai_stream):
 
     assert mock_openai_stream.called
 
+    # ensure instructions are merged as a system prompt
+    last_request_payload = json.loads(respx.calls.last.request.content)
+    assert last_request_payload["messages"][0] == {
+        "content": (
+            "You are a helpful test assistant :)\n\nToday is Friday 25/07/2025.\n\n"
+            "Answer in english."
+        ),
+        "role": "system",
+    }
+
     chat_conversation.refresh_from_db()
     assert chat_conversation.ui_messages == [
         {
@@ -170,29 +180,15 @@ def test_post_conversation_data_protocol(api_client, mock_openai_stream):
     )
 
     _run_id = chat_conversation.pydantic_messages[0]["run_id"]
+
     assert chat_conversation.pydantic_messages == [
         {
-            "instructions": None,
+            "instructions": (
+                "You are a helpful test assistant :)\n\n"
+                "Today is Friday 25/07/2025.\n\nAnswer in english."
+            ),
             "kind": "request",
             "parts": [
-                {
-                    "content": "You are a helpful test assistant :)",
-                    "dynamic_ref": None,
-                    "part_kind": "system-prompt",
-                    "timestamp": "2025-07-25T10:36:35.297675Z",
-                },
-                {
-                    "content": "Today is Friday 25/07/2025.",
-                    "dynamic_ref": None,
-                    "part_kind": "system-prompt",
-                    "timestamp": "2025-07-25T10:36:35.297675Z",
-                },
-                {
-                    "content": "Answer in english.",
-                    "dynamic_ref": None,
-                    "part_kind": "system-prompt",
-                    "timestamp": "2025-07-25T10:36:35.297675Z",
-                },
                 {
                     "content": ["Hello"],
                     "part_kind": "user-prompt",
@@ -255,6 +251,15 @@ def test_post_conversation_text_protocol(api_client, mock_openai_stream):
     assert response_content == "Hello there"
 
     assert mock_openai_stream.called
+    # ensure instructions are merged as a system prompt
+    last_request_payload = json.loads(respx.calls.last.request.content)
+    assert last_request_payload["messages"][0] == {
+        "content": (
+            "You are a helpful test assistant :)\n\nToday is Friday 25/07/2025.\n\n"
+            "Answer in english."
+        ),
+        "role": "system",
+    }
 
     chat_conversation.refresh_from_db()
     assert chat_conversation.ui_messages == [
@@ -296,29 +301,15 @@ def test_post_conversation_text_protocol(api_client, mock_openai_stream):
     )
 
     _run_id = chat_conversation.pydantic_messages[0]["run_id"]
+
     assert chat_conversation.pydantic_messages == [
         {
-            "instructions": None,
+            "instructions": (
+                "You are a helpful test assistant :)\n\n"
+                "Today is Friday 25/07/2025.\n\nAnswer in english."
+            ),
             "kind": "request",
             "parts": [
-                {
-                    "content": "You are a helpful test assistant :)",
-                    "dynamic_ref": None,
-                    "part_kind": "system-prompt",
-                    "timestamp": "2025-07-25T10:36:35.297675Z",
-                },
-                {
-                    "content": "Today is Friday 25/07/2025.",
-                    "dynamic_ref": None,
-                    "part_kind": "system-prompt",
-                    "timestamp": "2025-07-25T10:36:35.297675Z",
-                },
-                {
-                    "content": "Answer in english.",
-                    "dynamic_ref": None,
-                    "part_kind": "system-prompt",
-                    "timestamp": "2025-07-25T10:36:35.297675Z",
-                },
                 {
                     "content": ["Hello"],
                     "part_kind": "user-prompt",
@@ -409,11 +400,12 @@ def test_post_conversation_with_image(api_client, mock_openai_stream_image):
     # Check the exact structure expected by the AI service
     assert body["messages"] == [
         {
-            "content": "You are a helpful test assistant :)",
+            "content": (
+                "You are a helpful test assistant :)\n\nToday is Friday 25/07/2025."
+                "\n\nAnswer in english."
+            ),
             "role": "system",
         },
-        {"content": "Today is Friday 25/07/2025.", "role": "system"},
-        {"content": "Answer in english.", "role": "system"},
         {
             "content": [
                 {"text": "Hello, what do you see on this picture?", "type": "text"},
@@ -498,27 +490,12 @@ def test_post_conversation_with_image(api_client, mock_openai_stream_image):
     _run_id = chat_conversation.pydantic_messages[0]["run_id"]
     assert chat_conversation.pydantic_messages == [
         {
-            "instructions": None,
+            "instructions": (
+                "You are a helpful test assistant :)\n\n"
+                "Today is Friday 25/07/2025.\n\nAnswer in english."
+            ),
             "kind": "request",
             "parts": [
-                {
-                    "content": "You are a helpful test assistant :)",
-                    "dynamic_ref": None,
-                    "part_kind": "system-prompt",
-                    "timestamp": "2025-07-25T10:36:35.297675Z",
-                },
-                {
-                    "content": "Today is Friday 25/07/2025.",
-                    "dynamic_ref": None,
-                    "part_kind": "system-prompt",
-                    "timestamp": "2025-07-25T10:36:35.297675Z",
-                },
-                {
-                    "content": "Answer in english.",
-                    "dynamic_ref": None,
-                    "part_kind": "system-prompt",
-                    "timestamp": "2025-07-25T10:36:35.297675Z",
-                },
                 {
                     "content": [
                         "Hello, what do you see on this picture?",
@@ -616,11 +593,12 @@ def test_post_conversation_tool_call(api_client, mock_openai_stream_tool, settin
 
     assert body["messages"] == [
         {
-            "content": "You are a helpful test assistant :)",
+            "content": (
+                "You are a helpful test assistant :)\n\n"
+                "Today is Friday 25/07/2025.\n\nAnswer in english."
+            ),
             "role": "system",
         },
-        {"content": "Today is Friday 25/07/2025.", "role": "system"},
-        {"content": "Answer in english.", "role": "system"},
         {"content": [{"text": "Weather in Paris?", "type": "text"}], "role": "user"},
     ]
 
@@ -678,27 +656,12 @@ def test_post_conversation_tool_call(api_client, mock_openai_stream_tool, settin
     _run_id = chat_conversation.pydantic_messages[0]["run_id"]
     assert chat_conversation.pydantic_messages == [
         {
-            "instructions": None,
+            "instructions": (
+                "You are a helpful test assistant :)\n\n"
+                "Today is Friday 25/07/2025.\n\nAnswer in english."
+            ),
             "kind": "request",
             "parts": [
-                {
-                    "content": "You are a helpful test assistant :)",
-                    "dynamic_ref": None,
-                    "part_kind": "system-prompt",
-                    "timestamp": "2025-07-25T10:36:35.297675Z",
-                },
-                {
-                    "content": "Today is Friday 25/07/2025.",
-                    "dynamic_ref": None,
-                    "part_kind": "system-prompt",
-                    "timestamp": "2025-07-25T10:36:35.297675Z",
-                },
-                {
-                    "content": "Answer in english.",
-                    "dynamic_ref": None,
-                    "part_kind": "system-prompt",
-                    "timestamp": "2025-07-25T10:36:35.297675Z",
-                },
                 {
                     "content": ["Weather in Paris?"],
                     "part_kind": "user-prompt",
@@ -737,7 +700,10 @@ def test_post_conversation_tool_call(api_client, mock_openai_stream_tool, settin
             "run_id": _run_id,
         },
         {
-            "instructions": None,
+            "instructions": (
+                "You are a helpful test assistant :)\n\n"
+                "Today is Friday 25/07/2025.\n\nAnswer in english."
+            ),
             "kind": "request",
             "parts": [
                 {
@@ -829,11 +795,12 @@ def test_post_conversation_tool_call_fails(api_client, mock_openai_stream_tool, 
 
     assert body["messages"] == [
         {
-            "content": "You are a helpful test assistant :)",
+            "content": (
+                "You are a helpful test assistant :)\n\n"
+                "Today is Friday 25/07/2025.\n\nAnswer in french."
+            ),
             "role": "system",
         },
-        {"content": "Today is Friday 25/07/2025.", "role": "system"},
-        {"content": "Answer in french.", "role": "system"},
         {"content": [{"text": "Weather in Paris?", "type": "text"}], "role": "user"},
     ]
 
@@ -891,27 +858,12 @@ def test_post_conversation_tool_call_fails(api_client, mock_openai_stream_tool, 
     _run_id = chat_conversation.pydantic_messages[0]["run_id"]
     assert chat_conversation.pydantic_messages == [
         {
-            "instructions": None,
+            "instructions": (
+                "You are a helpful test assistant :)\n\n"
+                "Today is Friday 25/07/2025.\n\nAnswer in french."
+            ),
             "kind": "request",
             "parts": [
-                {
-                    "content": "You are a helpful test assistant :)",
-                    "dynamic_ref": None,
-                    "part_kind": "system-prompt",
-                    "timestamp": "2025-07-25T10:36:35.297675Z",
-                },
-                {
-                    "content": "Today is Friday 25/07/2025.",
-                    "dynamic_ref": None,
-                    "part_kind": "system-prompt",
-                    "timestamp": "2025-07-25T10:36:35.297675Z",
-                },
-                {
-                    "content": "Answer in french.",
-                    "dynamic_ref": None,
-                    "part_kind": "system-prompt",
-                    "timestamp": "2025-07-25T10:36:35.297675Z",
-                },
                 {
                     "content": ["Weather in Paris?"],
                     "part_kind": "user-prompt",
@@ -950,7 +902,10 @@ def test_post_conversation_tool_call_fails(api_client, mock_openai_stream_tool, 
             "run_id": _run_id,
         },
         {
-            "instructions": None,
+            "instructions": (
+                "You are a helpful test assistant :)\n\n"
+                "Today is Friday 25/07/2025.\n\nAnswer in french."
+            ),
             "kind": "request",
             "parts": [
                 {
@@ -1214,27 +1169,11 @@ def test_post_conversation_data_protocol_no_stream(
     _run_id = chat_conversation.pydantic_messages[0]["run_id"]
     assert chat_conversation.pydantic_messages == [
         {
-            "instructions": None,
+            "instructions": (
+                "You are an amazing assistant.\n\nToday is Friday 25/07/2025.\n\nAnswer in english."
+            ),
             "kind": "request",
             "parts": [
-                {
-                    "content": "You are an amazing assistant.",
-                    "dynamic_ref": None,
-                    "part_kind": "system-prompt",
-                    "timestamp": "2025-07-25T10:36:35.297675Z",
-                },
-                {
-                    "content": "Today is Friday 25/07/2025.",
-                    "dynamic_ref": None,
-                    "part_kind": "system-prompt",
-                    "timestamp": "2025-07-25T10:36:35.297675Z",
-                },
-                {
-                    "content": "Answer in english.",
-                    "dynamic_ref": None,
-                    "part_kind": "system-prompt",
-                    "timestamp": "2025-07-25T10:36:35.297675Z",
-                },
                 {
                     "content": ["Why the sky is blue?"],
                     "part_kind": "user-prompt",
@@ -1369,27 +1308,12 @@ async def test_post_conversation_async(api_client, mock_openai_stream, monkeypat
     _run_id = chat_conversation.pydantic_messages[0]["run_id"]
     assert chat_conversation.pydantic_messages == [
         {
-            "instructions": None,
+            "instructions": (
+                "You are a helpful test assistant :)\n\n"
+                "Today is Friday 25/07/2025.\n\nAnswer in english."
+            ),
             "kind": "request",
             "parts": [
-                {
-                    "content": "You are a helpful test assistant :)",
-                    "dynamic_ref": None,
-                    "part_kind": "system-prompt",
-                    "timestamp": "2025-07-25T10:36:35.297675Z",
-                },
-                {
-                    "content": "Today is Friday 25/07/2025.",
-                    "dynamic_ref": None,
-                    "part_kind": "system-prompt",
-                    "timestamp": "2025-07-25T10:36:35.297675Z",
-                },
-                {
-                    "content": "Answer in english.",
-                    "dynamic_ref": None,
-                    "part_kind": "system-prompt",
-                    "timestamp": "2025-07-25T10:36:35.297675Z",
-                },
                 {
                     "content": ["Hello"],
                     "part_kind": "user-prompt",

--- a/src/backend/chat/tests/views/chat/conversations/test_conversation_with_document_upload.py
+++ b/src/backend/chat/tests/views/chat/conversations/test_conversation_with_document_upload.py
@@ -216,7 +216,8 @@ def fixture_mock_openai_stream():
 @responses.activate
 @respx.mock
 @freeze_time()
-def test_post_conversation_with_document_upload(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+def test_post_conversation_with_document_upload(
+    # pylint: disable=too-many-arguments,too-many-positional-arguments
     api_client,
     mock_albert_api,  # pylint: disable=unused-argument
     sample_pdf_content,
@@ -353,53 +354,25 @@ def test_post_conversation_with_document_upload(  # pylint: disable=too-many-arg
     assert len(chat_conversation.pydantic_messages) == 4
 
     _run_id = chat_conversation.pydantic_messages[0]["run_id"]
+
     assert chat_conversation.pydantic_messages[0] == {
-        "instructions": "When you receive a result from the summarization tool, you "
-        "MUST return it directly to the user without any "
-        "modification, paraphrasing, or additional summarization.The "
-        "tool already produces optimized summaries that should be "
-        "presented verbatim.You may translate the summary if "
-        "required, but you MUST preserve all the information from the "
-        "original summary.You may add a follow-up question after the "
-        "summary if needed.",
+        "instructions": "You are a helpful test assistant :)\n\n"
+        f"{today_promt_date}\n\n"
+        "Answer in english.\n\n"
+        "Use document_search_rag ONLY to retrieve specific passages from "
+        "attached documents. Do NOT use it to summarize; for summaries, "
+        "call the summarize tool instead.\n\nWhen you receive a result from the "
+        "summarization tool, you MUST return it directly to the user without "
+        "any modification, paraphrasing, or additional summarization."
+        "The tool already produces optimized summaries that should be "
+        "presented verbatim.You may translate the summary if required, "
+        "but you MUST preserve all the information from the original summary."
+        "You may add a follow-up question after the summary if needed.\n\n"
+        "[Internal context] User documents are attached to this conversation. "
+        "Do not request re-upload of documents; consider them already "
+        "available via the internal store.",
         "kind": "request",
         "parts": [
-            {
-                "content": "You are a helpful test assistant :)",
-                "dynamic_ref": None,
-                "part_kind": "system-prompt",
-                "timestamp": timezone_now,
-            },
-            {
-                "content": today_promt_date,
-                "dynamic_ref": None,
-                "part_kind": "system-prompt",
-                "timestamp": timezone_now,
-            },
-            {
-                "content": "Answer in english.",
-                "dynamic_ref": None,
-                "part_kind": "system-prompt",
-                "timestamp": timezone_now,
-            },
-            {
-                "content": "Use document_search_rag ONLY to retrieve specific "
-                "passages from attached documents. Do NOT use it to "
-                "summarize; for summaries, call the summarize tool "
-                "instead.",
-                "dynamic_ref": None,
-                "part_kind": "system-prompt",
-                "timestamp": timezone_now,
-            },
-            {
-                "content": "[Internal context] User documents are attached to this "
-                "conversation. Do not request re-upload of documents; "
-                "consider them already available via the internal "
-                "store.",
-                "dynamic_ref": None,
-                "part_kind": "system-prompt",
-                "timestamp": timezone_now,
-            },
             {
                 "content": ["What does the document say?"],
                 "part_kind": "user-prompt",
@@ -439,14 +412,21 @@ def test_post_conversation_with_document_upload(  # pylint: disable=too-many-arg
     }
     assert chat_conversation.pydantic_messages[2] == {
         "instructions": (
-            "When you receive a result from the summarization tool, you MUST "
-            "return it directly to the user without any modification, "
-            "paraphrasing, or additional summarization."
-            "The tool already produces optimized summaries that should "
-            "be presented verbatim."
-            "You may translate the summary if required, but you MUST preserve "
-            "all the information from the original summary."
-            "You may add a follow-up question after the summary if needed."
+            "You are a helpful test assistant :)\n\n"
+            f"{today_promt_date}\n\n"
+            "Answer in english.\n\n"
+            "Use document_search_rag ONLY to retrieve specific passages from "
+            "attached documents. Do NOT use it to summarize; for summaries, "
+            "call the summarize tool instead.\n\nWhen you receive a result from the "
+            "summarization tool, you MUST return it directly to the user without "
+            "any modification, paraphrasing, or additional summarization."
+            "The tool already produces optimized summaries that should be "
+            "presented verbatim.You may translate the summary if required, "
+            "but you MUST preserve all the information from the original summary."
+            "You may add a follow-up question after the summary if needed.\n\n"
+            "[Internal context] User documents are attached to this conversation. "
+            "Do not request re-upload of documents; consider them already "
+            "available via the internal store."
         ),
         "kind": "request",
         "parts": [
@@ -499,7 +479,8 @@ def test_post_conversation_with_document_upload(  # pylint: disable=too-many-arg
 @responses.activate
 @respx.mock
 @freeze_time("2025-07-25T10:36:35.297675Z")
-def test_post_conversation_with_document_upload_feature_disabled(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+def test_post_conversation_with_document_upload_feature_disabled(
+    # pylint: disable=too-many-arguments,too-many-positional-arguments
     api_client,
     caplog,
     mock_openai_stream,  # pylint: disable=unused-argument
@@ -552,14 +533,12 @@ def test_post_conversation_with_document_upload_feature_disabled(  # pylint: dis
 
     # Replace UUIDs with placeholders for assertion
     response_content = replace_uuids_with_placeholder(response_content)
-
     assert response_content == (
         '0:"From the document, I can see that "\n'
         "0:\"it says 'Hello PDF'.\"\n"
         'f:{"messageId":"<mocked_uuid>"}\n'
         'd:{"finishReason":"stop","usage":{"promptTokens":150,"completionTokens":25}}\n'
     )
-
     # This behavior must be improved in the future to inform the user properly
     assert "Document upload feature is disabled, ignoring input documents." in caplog.text
 
@@ -582,6 +561,7 @@ def test_post_conversation_with_document_upload_summarize(  # pylint: disable=to
     api_client.force_authenticate(user=chat_conversation.owner)
 
     pdf_base64 = base64.b64encode(sample_pdf_content.read()).decode("utf-8")
+
     message = UIMessage(
         id="1",
         role="user",
@@ -643,7 +623,7 @@ def test_post_conversation_with_document_upload_summarize(  # pylint: disable=to
         'document discusses various topics."}\n'
         '0:"The document discusses various topics."\n'
         'f:{"messageId":"<mocked_uuid>"}\n'
-        'd:{"finishReason":"stop","usage":{"promptTokens":317,"completionTokens":19}}\n'
+        'd:{"finishReason":"stop","usage":{"promptTokens":287,"completionTokens":19}}\n'
     )
 
     # Check that the conversation was updated
@@ -705,52 +685,25 @@ def test_post_conversation_with_document_upload_summarize(  # pylint: disable=to
 
     _run_id = chat_conversation.pydantic_messages[0]["run_id"]
     assert chat_conversation.pydantic_messages[0] == {
-        "instructions": "When you receive a result from the summarization tool, you "
-        "MUST return it directly to the user without any "
-        "modification, paraphrasing, or additional summarization.The "
-        "tool already produces optimized summaries that should be "
-        "presented verbatim.You may translate the summary if "
-        "required, but you MUST preserve all the information from the "
-        "original summary.You may add a follow-up question after the "
-        "summary if needed.",
+        "instructions": (
+            "You are a helpful test assistant :)\n\n"
+            f"{today_promt_date}\n\n"
+            "Answer in english.\n\n"
+            "Use document_search_rag ONLY to retrieve specific passages from "
+            "attached documents. Do NOT use it to summarize; for summaries, "
+            "call the summarize tool instead.\n\nWhen you receive a result from the "
+            "summarization tool, you MUST return it directly to the user without "
+            "any modification, paraphrasing, or additional summarization."
+            "The tool already produces optimized summaries that should be "
+            "presented verbatim.You may translate the summary if required, "
+            "but you MUST preserve all the information from the original summary."
+            "You may add a follow-up question after the summary if needed.\n\n"
+            "[Internal context] User documents are attached to this conversation. "
+            "Do not request re-upload of documents; consider them already "
+            "available via the internal store."
+        ),
         "kind": "request",
         "parts": [
-            {
-                "content": "You are a helpful test assistant :)",
-                "dynamic_ref": None,
-                "part_kind": "system-prompt",
-                "timestamp": timezone_now,
-            },
-            {
-                "content": today_promt_date,
-                "dynamic_ref": None,
-                "part_kind": "system-prompt",
-                "timestamp": timezone_now,
-            },
-            {
-                "content": "Answer in english.",
-                "dynamic_ref": None,
-                "part_kind": "system-prompt",
-                "timestamp": timezone_now,
-            },
-            {
-                "content": "Use document_search_rag ONLY to retrieve specific "
-                "passages from attached documents. Do NOT use it to "
-                "summarize; for summaries, call the summarize tool "
-                "instead.",
-                "dynamic_ref": None,
-                "part_kind": "system-prompt",
-                "timestamp": timezone_now,
-            },
-            {
-                "content": "[Internal context] User documents are attached to this "
-                "conversation. Do not request re-upload of documents; "
-                "consider them already available via the internal "
-                "store.",
-                "dynamic_ref": None,
-                "part_kind": "system-prompt",
-                "timestamp": timezone_now,
-            },
             {
                 "content": ["Make a summary of this document."],
                 "part_kind": "user-prompt",
@@ -790,14 +743,21 @@ def test_post_conversation_with_document_upload_summarize(  # pylint: disable=to
     }
     assert chat_conversation.pydantic_messages[2] == {
         "instructions": (
-            "When you receive a result from the summarization tool, you MUST "
-            "return it directly to the user without any modification, "
-            "paraphrasing, or additional summarization."
-            "The tool already produces optimized summaries that should "
-            "be presented verbatim."
-            "You may translate the summary if required, but you MUST preserve "
-            "all the information from the original summary."
-            "You may add a follow-up question after the summary if needed."
+            "You are a helpful test assistant :)\n\n"
+            f"{today_promt_date}\n\n"
+            "Answer in english.\n\n"
+            "Use document_search_rag ONLY to retrieve specific passages from "
+            "attached documents. Do NOT use it to summarize; for summaries, "
+            "call the summarize tool instead.\n\nWhen you receive a result from the "
+            "summarization tool, you MUST return it directly to the user without "
+            "any modification, paraphrasing, or additional summarization."
+            "The tool already produces optimized summaries that should be "
+            "presented verbatim.You may translate the summary if required, "
+            "but you MUST preserve all the information from the original summary."
+            "You may add a follow-up question after the summary if needed.\n\n"
+            "[Internal context] User documents are attached to this conversation. "
+            "Do not request re-upload of documents; consider them already "
+            "available via the internal store."
         ),
         "kind": "request",
         "parts": [

--- a/src/backend/chat/tests/views/chat/conversations/test_conversation_with_history.py
+++ b/src/backend/chat/tests/views/chat/conversations/test_conversation_with_history.py
@@ -919,7 +919,7 @@ def history_conversation_with_tool_fixture():
     history_timestamp = timezone.now().replace(year=2025, month=6, day=15, hour=10, minute=30)
 
     # Create a conversation with pre-existing messages including a tool invocation
-    conversation = ChatConversationFactory()
+    conversation = ChatConversationFactory(owner__language="nl-nl")
 
     # Add previous user and assistant messages with tool invocation
     conversation.messages = [
@@ -1377,7 +1377,9 @@ def test_post_conversation_with_existing_tool_history(
 
     # Verify the new tool call request is included
     assert history_conversation_with_tool.pydantic_messages[8] == {
-        "instructions": None,
+        "instructions": "You are a helpful test assistant :)\n\n"
+        "Today is Friday 25/07/2025.\n\n"
+        "Answer in dutch.",
         "kind": "request",
         "parts": [
             {
@@ -1420,7 +1422,9 @@ def test_post_conversation_with_existing_tool_history(
     }
 
     assert history_conversation_with_tool.pydantic_messages[10] == {
-        "instructions": None,
+        "instructions": "You are a helpful test assistant :)\n\n"
+        "Today is Friday 25/07/2025.\n\n"
+        "Answer in dutch.",
         "kind": "request",
         "parts": [
             {

--- a/src/backend/chat/tools/document_search_rag.py
+++ b/src/backend/chat/tools/document_search_rag.py
@@ -39,7 +39,7 @@ def add_document_rag_search_tool(agent: Agent) -> None:
             metadata={"sources": {result.url for result in rag_results.data}},
         )
 
-    @agent.system_prompt
+    @agent.instructions
     def document_rag_instructions() -> str:
         """Dynamic system prompt function to add RAG instructions if any."""
         return (


### PR DESCRIPTION
 When using Gemma 3 via vLLM, an error occurs, because the vLLM template expect only one system message at the beginning.

## Purpose

Pydantic AI allows setting multiple static and dynamic system prompts to define conversation context and rules. Previously, these were sent to the model API as separate messages, which caused compatibility issues with some self-hosted models (e.g., Gemma3/vLLM).
## Proposal
This PR switches from using `system_prompt` to `instruction` as recommended in the Pydantic AI documentation, thus merging several instructions into a single message.

Reference: https://ai.pydantic.dev/agents/#system-prompts

Fixed several tests that failed when run individually due to pytest being unable to properly mock modules imported dynamically via Django's import_string(). The issue occurred because dynamic imports bypassed pytest's standard mocking mechanisms. Tests now pass consistently both in isolation and as part of the full suite.


- [x] I have read and followed the [contributing guidelines](https://github.com/suitenumerique/conversations/blob/main/CONTRIBUTING.md)
- [x] I have read and agreed to the [Code of Conduct](https://github.com/suitenumerique/conversations/blob/main/CODE_OF_CONDUCT.md)
- [x] I have signed off my commits with `git commit --signoff` (DCO compliance)
- [x] I have signed my commits with my SSH or GPG key (`git commit -S`)
- [x] My commit messages follow the required format: `<gitmoji>(type) title description`
- [x] I have added a changelog entry under `## [Unreleased]` section (if noticeable change)
- [x] I have added corresponding tests for new features or bug fixes (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected e2e test label (chronium → chromium) and improved handling/error reporting for invalid or external document URLs.
  * Better error propagation when document parsing fails.

* **Refactor**
  * Consolidated system prompts into a single "instructions" message and standardized dynamic prompt usage.
  * Centralized document-store selection for reuse.

* **Tests**
  * Updated tests to reflect merged instructions flow and revised document validation.

* **Documentation**
  * Edited unreleased changelog entries and minor editorial updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->