### PR TITLE
🐛(back) add keepalive wrappers to prevent tool call timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to
 - 🐛(e2e) fix test-e2e-chromium
 - 🐛(back) fix system prompt compatibility with self-hosted models #200
 - ⚰️(back) remove dead code and unused files
+- 🐛(back) prevent tool call timeouts
 
 ### Removed
 

--- a/src/backend/chat/clients/pydantic_ai.py
+++ b/src/backend/chat/clients/pydantic_ai.py
@@ -76,7 +76,7 @@ from chat.tools.document_generic_search_rag import add_document_rag_search_tool_
 from chat.tools.document_search_rag import add_document_rag_search_tool
 from chat.tools.document_summarize import document_summarize
 from chat.vercel_ai_sdk.core import events_v4, events_v5
-from chat.vercel_ai_sdk.encoder import EventEncoder
+from chat.vercel_ai_sdk.encoder import CURRENT_EVENT_ENCODER_VERSION, EventEncoder
 
 # Keep at the top of the file to avoid mocking issues
 document_store_backend = import_string(settings.RAG_DOCUMENT_SEARCH_BACKEND)
@@ -122,7 +122,7 @@ class AIAgentService:  # pylint: disable=too-many-instance-attributes
 
         self._langfuse_available = settings.LANGFUSE_ENABLED
         self._store_analytics = self._langfuse_available and user.allow_conversation_analytics
-        self.event_encoder = EventEncoder("v4")  # Always use v4 for now
+        self.event_encoder = EventEncoder(CURRENT_EVENT_ENCODER_VERSION)  # We use v4 for now
 
         self._support_streaming = True
         if (streaming := get_model_configuration(self.model_hrid).supports_streaming) is not None:

--- a/src/backend/chat/keepalive.py
+++ b/src/backend/chat/keepalive.py
@@ -1,0 +1,171 @@
+"""Helpers to prevent proxy timeouts during long-running stream operations.
+
+This module provides utilities to wrap synchronous and asynchronous iterators
+with keepalive messages. When a stream pauses for longer than the specified
+interval, keepalive messages are injected to prevent proxy/gateway
+timeouts while waiting for the stream data.
+"""
+
+import asyncio
+import logging
+import queue
+import threading
+import time
+from typing import AsyncIterator, Iterator
+
+from django.conf import settings
+
+from .vercel_ai_sdk.core.events_v4 import DataPart as V4DataPart
+from .vercel_ai_sdk.core.events_v5 import DataPart as V5DataPart
+from .vercel_ai_sdk.encoder import (
+    CURRENT_EVENT_ENCODER_VERSION,
+    EventEncoder,
+    EventEncoderVersion,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def get_keepalive_message() -> str:
+    """Generate a keepalive message based on encoder/SDK version."""
+    if CURRENT_EVENT_ENCODER_VERSION == EventEncoderVersion.V4:
+        event = V4DataPart(data=[{"status": "WAITING"}])
+    else:
+        event = V5DataPart(data={"status": "WAITING"})
+    encoder = EventEncoder(CURRENT_EVENT_ENCODER_VERSION)
+    return encoder.encode(event)
+
+
+async def stream_with_keepalive_async(
+    stream: AsyncIterator[str],
+) -> AsyncIterator[str]:
+    """Wrap an async iterator to emit keepalive during long pauses.
+
+    Args:
+        stream: The async iterator to wrap
+    Yields:
+        Items from the original stream, plus keepalive messages during pauses
+    Raises:
+        Any exception raised by the original stream
+    """
+    q: asyncio.Queue = asyncio.Queue()
+    finished = asyncio.Event()
+    keepalive_message = get_keepalive_message()
+
+    async def producer():
+        """Background task that consumes the original stream into a queue."""
+
+        try:
+            async for stream_item in stream:
+                await q.put(stream_item)
+        except Exception as exc:  # pylint: disable=broad-except #noqa: BLE001
+            # Pass exceptions through the queue so the consumer can re-raise them.
+            # This ensures errors aren't silently swallowed.
+            await q.put(exc)
+        finally:
+            finished.set()
+            await q.put(None)  # Sentinel to signal completion
+
+    producer_task = asyncio.create_task(producer())
+
+    try:
+        while True:
+            try:
+                item = await asyncio.wait_for(q.get(), timeout=settings.KEEPALIVE_INTERVAL)
+                if item is None:
+                    break
+                if isinstance(item, Exception):
+                    raise item
+                yield item
+            except asyncio.TimeoutError:
+                # No data received within interval
+                if finished.is_set():
+                    # Producer is done, queue is empty (else we would not have timed out)
+                    break
+
+                logger.debug("Send keepalive")
+                yield keepalive_message
+    finally:
+        # Cleanup
+        producer_task.cancel()
+        try:
+            await producer_task
+        except asyncio.CancelledError:
+            pass
+
+
+def get_current_time() -> float:
+    """Get current monotonic time, avoiding freezegun interferences.
+
+    Returns time.monotonic() which:
+    - Is NOT affected by freezegun's @freeze_time decorator (unlike time.time())
+    - Prevents issues where frozen time in main thread differs from real time in
+      spawned threads, causing incorrect keepalive interval computation
+    - Is the best clock for measuring time intervals
+
+    Wrapped in a function to ease mocking in tests.
+
+    Returns:
+        float: Monotonic time in seconds since an arbitrary reference point
+    """
+    return time.monotonic()
+
+
+def stream_with_keepalive_sync(stream: Iterator[str]) -> Iterator[str]:
+    """Wraps a synchronous stream with keepalive messages."""
+
+    q: queue.Queue = queue.Queue()
+    stream_done = threading.Event()
+    keepalive_message = get_keepalive_message()
+    # Mutable container so threads can read/write shared timestamp
+    last_yield_time = [get_current_time()]
+
+    def consume_stream():
+        """Read from source stream and forward chunks to queue."""
+        try:
+            for chunk in stream:
+                if stream_done.is_set():
+                    return  # early exit
+                q.put(chunk, timeout=1)  # Arbitrary timeout prevents blocking forever
+        # pylint: disable=broad-exception-caught
+        except Exception as e:
+            logger.exception("Error in stream consumption")
+            q.put(e)
+        finally:
+            stream_done.set()
+
+    def send_keepalives():
+        """Inject keepalive messages when idle too long.
+
+        Uses get_current_time() (time.monotonic) instead of time.time()
+        to avoid issues with freezegun in tests.
+        """
+        while not stream_done.is_set():
+            # Sleep before checking to give main loop time to process and update timestamp
+            time.sleep(0.5)  # let main loop process first, empiric value
+            if get_current_time() - last_yield_time[0] >= settings.KEEPALIVE_INTERVAL:
+                try:
+                    q.put(keepalive_message, timeout=0.1)
+                except queue.Full:
+                    pass
+
+    for target in (consume_stream, send_keepalives):
+        threading.Thread(target=target, daemon=True).start()
+
+    try:
+        # Continue while stream is active or queue has still items
+        while not stream_done.is_set() or not q.empty():
+            try:
+                item = q.get(timeout=1)  # short timeout, avoid blocking and stay responsive
+            except queue.Empty:
+                continue
+
+            # Re-raise from consume_stream
+            if isinstance(item, Exception):
+                raise item
+
+            yield item
+            last_yield_time[0] = get_current_time()
+    finally:
+        # Signal threads to stop
+        stream_done.set()

--- a/src/backend/chat/vercel_ai_sdk/encoder/__init__.py
+++ b/src/backend/chat/vercel_ai_sdk/encoder/__init__.py
@@ -2,6 +2,6 @@
 This module contains the EventEncoder class.
 """
 
-from .encoder import EventEncoder
+from .encoder import CURRENT_EVENT_ENCODER_VERSION, EventEncoder, EventEncoderVersion
 
-__all__ = ["EventEncoder"]
+__all__ = ["EventEncoder", "CURRENT_EVENT_ENCODER_VERSION", "EventEncoderVersion"]

--- a/src/backend/chat/vercel_ai_sdk/encoder/encoder.py
+++ b/src/backend/chat/vercel_ai_sdk/encoder/encoder.py
@@ -1,6 +1,7 @@
 """Event Encoder for Vercel AI SDK"""
 
-from typing import Literal, Union
+from enum import Enum
+from typing import Union
 
 from ..core.events_v4 import BaseEvent as V4BaseEvent
 from ..core.events_v4 import TextPart
@@ -8,16 +9,26 @@ from ..core.events_v5 import BaseEvent as V5BaseEvent
 from ..core.events_v5 import TextDeltaEvent
 
 
+class EventEncoderVersion(str, Enum):
+    """Enumeration of supported event encoder versions."""
+
+    V4 = "v4"
+    V5 = "v5"
+
+
+CURRENT_EVENT_ENCODER_VERSION = EventEncoderVersion.V4  # used encoder version
+
+
 class EventEncoder:
     """
     Encodes events for the Vercel AI SDK based on the specified version.
     """
 
-    def __init__(self, version: Literal["v4", "v5"] = None):
+    def __init__(self, version: EventEncoderVersion):
         """
         Initializes the EventEncoder with the specified version.
         """
-        if version not in ["v4", "v5"]:
+        if version not in [EventEncoderVersion.V4, EventEncoderVersion.V5]:
             raise ValueError("Unsupported version. Supported versions are 'v4' and 'v5'.")
 
         self.version = version
@@ -28,7 +39,7 @@ class EventEncoder:
         """
         return "text/event-stream"
 
-    def encode(self, event: Union[V5BaseEvent, V5BaseEvent]) -> str | None:
+    def encode(self, event: Union[V4BaseEvent, V5BaseEvent]) -> str | None:
         """
         Encodes an event based on the version.
 
@@ -38,15 +49,15 @@ class EventEncoder:
             str | None: The encoded event as a string,
             or None if the event type is not adapted to the SDK version.
         """
-        if self.version == "v4" and isinstance(event, V4BaseEvent):
+        if self.version == EventEncoderVersion.V4 and isinstance(event, V4BaseEvent):
             return self._encode_v4_streaming(event)
 
-        if self.version == "v5" and isinstance(event, V5BaseEvent):
+        if self.version == EventEncoderVersion.V5 and isinstance(event, V5BaseEvent):
             return self._encode_sse(event)
 
         return None
 
-    def encode_text(self, event: Union[V5BaseEvent, V5BaseEvent]) -> str | None:
+    def encode_text(self, event: Union[V4BaseEvent, V5BaseEvent]) -> str | None:
         """
         Encodes an event based on the version.
 
@@ -56,10 +67,10 @@ class EventEncoder:
             str | None: The encoded event as a string,
             or None if the event type is not adapted to the SDK version.
         """
-        if self.version == "v4" and isinstance(event, TextPart):
+        if self.version == EventEncoderVersion.V4 and isinstance(event, TextPart):
             return event.text
 
-        if self.version == "v5" and isinstance(event, TextDeltaEvent):
+        if self.version == EventEncoderVersion.V5 and isinstance(event, TextDeltaEvent):
             return event.delta
 
         return None
@@ -70,7 +81,7 @@ class EventEncoder:
         """
         return f"{event.type}:{event.model_dump_json(by_alias=True, exclude={'type'})}\n"
 
-    def _encode_sse(self, event: Union[V5BaseEvent, V5BaseEvent]) -> str:
+    def _encode_sse(self, event: Union[V4BaseEvent, V5BaseEvent]) -> str:
         """
         Encodes an event into an SSE string.
         """

--- a/src/backend/conversations/settings.py
+++ b/src/backend/conversations/settings.py
@@ -919,6 +919,12 @@ USER QUESTION:
         environ_prefix=None,
     )
 
+    # Default keepalive interval: 55s (safely below typical 60s proxy timeouts)
+    # Prevents connection drops during long stream pauses while providing 5s safety margin.
+    KEEPALIVE_INTERVAL = values.PositiveIntegerValue(
+        default=55, environ_name="KEEPALIVE_INTERVAL", environ_prefix=None
+    )
+
     # pylint: disable=invalid-name
     @property
     def ENVIRONMENT(self):


### PR DESCRIPTION
## Purpose

Fixes issue where tool calls exceeding proxy timeout thresholds would 
cause connection drops, forcing users to start new conversations. This 
particularly affected document summarization over multiple or large files.

cf. https://github.com/orgs/suitenumerique/projects/13/views/3?pane=issue&itemId=141618405&issue=suitenumerique%7Cconversations%7C179

## Proposal

 
- Add stream_with_keepalive_async/sync wrapper utilities to inject
  keepalive messages during stream pauses
- Send keepalive at configurable intervals (default below proxy timeout
  with safety margin)
- Keepalive message format: '2:[{"status":"WAITING"}]\n'
- Support both async and sync iterators with background producer pattern
- Handle graceful cleanup and error propagation

The wrappers monitor stream activity and automatically emit keepalive
messages when no data is produced within the configured interval,
maintaining the connection alive during extended tool execution times.

 

Please ensure the following items are checked before submitting your pull request:
- [x] I have read and followed the [contributing guidelines](https://github.com/suitenumerique/conversations/blob/main/CONTRIBUTING.md)
- [x] I have read and agreed to the [Code of Conduct](https://github.com/suitenumerique/conversations/blob/main/CODE_OF_CONDUCT.md)
- [x] I have signed off my commits with `git commit --signoff` (DCO compliance)
- [x] I have signed my commits with my SSH or GPG key (`git commit -S`)
- [x] My commit messages follow the required format: `<gitmoji>(type) title description`
- [x] I have added a changelog entry under `## [Unreleased]` section (if noticeable change)
- [x] I have added corresponding tests for new features or bug fixes (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Streaming responses now emit periodic keepalives to prevent tool/stream timeouts and disable upstream buffering for more reliable delivery.

* **New Features**
  * Keepalive support for sync/async streams, a stop-streaming action, configurable keepalive interval (default 55s), and explicit encoder versioning/content-type exposure.

* **Tests**
  * Added tests covering keepalive behavior across sync and async streaming.

* **Documentation**
  * CHANGELOG updated to note the prevent-tool-call-timeouts fix.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->