### PR TITLE
🐛(front) fix link color in LeftPanelConversationItem component

### DIFF
--- a/src/frontend/apps/conversations/src/features/left-panel/components/LeftPanelConversationItem.tsx
+++ b/src/frontend/apps/conversations/src/features/left-panel/components/LeftPanelConversationItem.tsx
@@ -58,7 +58,7 @@ export const LeftPanelConversationItem = ({
     >
       <StyledLink
         href={`/chat/${conversation.id}/`}
-        $css="overflow: auto; flex-grow: 1;"
+        $css="overflow: auto; flex-grow: 1; color: var(--c--theme--colors--greyscale-900);"
         onClick={handleLinkClick}
       >
         <SimpleConversationItem showAccesses conversation={conversation} />


### PR DESCRIPTION
fix link color component for default theme


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated text color styling for conversation links in the left panel to enhance visual consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->