### PR TITLE
🔥(chat) remove thinking part from frontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to
 - 🐛(back) fix system prompt compatibility with self-hosted models #200
 - ⚰️(back) remove dead code and unused files
 
+### Removed
+
+- 🔥(chat) remove thinking part from frontend #227
+
 ## [0.0.10] - 2025-12-15
 
 ### Added

--- a/src/frontend/apps/conversations/src/features/chat/components/Chat.tsx
+++ b/src/frontend/apps/conversations/src/features/chat/components/Chat.tsx
@@ -1,9 +1,4 @@
-import {
-  Message,
-  ReasoningUIPart,
-  SourceUIPart,
-  ToolInvocationUIPart,
-} from '@ai-sdk/ui-utils';
+import { Message, SourceUIPart, ToolInvocationUIPart } from '@ai-sdk/ui-utils';
 import { Modal, ModalSize } from '@openfun/cunningham-react';
 import 'katex/dist/katex.min.css'; // `rehype-katex` does not import the CSS for you
 import { useRouter } from 'next/router';
@@ -816,30 +811,12 @@ export const Chat = ({
                             </Box>
                           )}
                         {message.parts
-                          ?.filter(
-                            (part) =>
-                              part.type === 'reasoning' ||
-                              part.type === 'tool-invocation',
-                          )
+                          ?.filter((part) => part.type === 'tool-invocation')
                           .map(
-                            (
-                              part: ReasoningUIPart | ToolInvocationUIPart,
-                              partIndex: number,
-                            ) =>
-                              part.type === 'reasoning' ? (
-                                <Box
-                                  key={`reasoning-${partIndex}`}
-                                  $background="var(--c--theme--colors--greyscale-100)"
-                                  $color="var(--c--theme--colors--greyscale-500)"
-                                  $padding={{ all: 'sm' }}
-                                  $radius="md"
-                                  $css="font-size: 0.9em;"
-                                >
-                                  {part.reasoning}
-                                </Box>
-                              ) : part.type === 'tool-invocation' &&
-                                isCurrentlyStreaming &&
-                                isLastAssistantMessageInConversation ? (
+                            (part: ToolInvocationUIPart, partIndex: number) =>
+                              part.type === 'tool-invocation' &&
+                              isCurrentlyStreaming &&
+                              isLastAssistantMessageInConversation ? (
                                 <ToolInvocationItem
                                   key={`tool-invocation-${partIndex}`}
                                   toolInvocation={part.toolInvocation}

--- a/src/frontend/apps/e2e/__tests__/app-conversations/chat.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-conversations/chat.spec.ts
@@ -52,7 +52,7 @@ test.describe('Chat page', () => {
 
     const messageContent = page.getByTestId('assistant-message-content');
     await expect(messageContent).toBeVisible();
-    await expect(messageContent).not.toBeEmpty(); 
+    await expect(messageContent).not.toBeEmpty();
 
     // Check history
     const chatHistoryLink = page


### PR DESCRIPTION
## Purpose

We want to enable the OSS model but seems like it returns thinking values twice and we don't manage it well...

So we disable the frontend while we still don't know how to display the thinking stuff.
We could have also cleaned the backend while unused.

```
2026-01-15 22:04:57,217 chat.clients.pydantic_ai DEBUG Received request_stream event: <class 'pydantic_ai.messages.PartStartEvent'>

2026-01-15 22:04:57,217 chat.clients.pydantic_ai DEBUG PartStartEvent: {'index': 0, 'part': {'content': 'We', 'id': 'reasoning_content', 'signature': None, 'provider_name': 'openai', 'part_kind': 'thinking'}, 'previous_part_kind': None, 'event_kind': 'part_start'}

2026-01-15 22:04:57,217 chat.clients.pydantic_ai DEBUG Received request_stream event: <class 'pydantic_ai.messages.PartEndEvent'>

2026-01-15 22:04:57,217 chat.clients.pydantic_ai DEBUG Received request_stream event: <class 'pydantic_ai.messages.PartStartEvent'>

2026-01-15 22:04:57,218 chat.clients.pydantic_ai DEBUG PartStartEvent: {'index': 1, 'part': {'content': 'We', 'id': 'reasoning', 'signature': None, 'provider_name': 'openai', 'part_kind': 'thinking'}, 'previous_part_kind': 'thinking', 'event_kind': 'part_start'}

2026-01-15 22:04:57,222 chat.clients.pydantic_ai DEBUG Received request_stream event: <class 'pydantic_ai.messages.PartDeltaEvent'>

2026-01-15 22:04:57,222 chat.clients.pydantic_ai DEBUG PartDeltaEvent: <class 'pydantic_ai.messages.PartDeltaEvent'> {'index': 0, 'delta': {'content_delta': ' have', 'signature_delta': None, 'provider_name': 'openai', 'part_delta_kind': 'thinking'}, 'event_kind': 'part_delta'}

2026-01-15 22:04:57,222 chat.clients.pydantic_ai DEBUG Received request_stream event: <class 'pydantic_ai.messages.PartDeltaEvent'>

2026-01-15 22:04:57,222 chat.clients.pydantic_ai DEBUG PartDeltaEvent: <class 'pydantic_ai.messages.PartDeltaEvent'> {'index': 1, 'delta': {'content_delta': ' have', 'signature_delta': None, 'provider_name': 'openai', 'part_delta_kind': 'thinking'}, 'event_kind': 'part_delta'}

2026-01-15 22:04:57,230 chat.clients.pydantic_ai DEBUG Received request_stream event: <class 'pydantic_ai.messages.PartDeltaEvent'>

2026-01-15 22:04:57,230 chat.clients.pydantic_ai DEBUG PartDeltaEvent: <class 'pydantic_ai.messages.PartDeltaEvent'> {'index': 0, 'delta': {'content_delta': ' fetched', 'signature_delta': None, 'provider_name': 'openai', 'part_delta_kind': 'thinking'}, 'event_kind': 'part_delta'}

2026-01-15 22:04:57,230 chat.clients.pydantic_ai DEBUG Received request_stream event: <class 'pydantic_ai.messages.PartDeltaEvent'>

2026-01-15 22:04:57,230 chat.clients.pydantic_ai DEBUG PartDeltaEvent: <class 'pydantic_ai.messages.PartDeltaEvent'> {'index': 1, 'delta': {'content_delta': ' fetched', 'signature_delta': None, 'provider_name': 'openai', 'part_delta_kind': 'thinking'}, 'event_kind': 'part_delta'}
````


## Proposal

- [x] remove thinking item display in frontend.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Removed**
  * Reasoning display has been removed from the chat streaming view, streamlining conversations to show only tool interactions.
* **Tests**
  * Minor whitespace cleanup in an end-to-end chat test (no behavioral change).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->