### PR TITLE
✨(front) enable pasting an attachment from clipboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- ✨(front) allow pasting an attachment from clipboard
+
 ### Fixed
 
 - 💚(docker) vendor mime.types file instead of fetching from Apache SVN

--- a/src/frontend/apps/conversations/src/features/chat/components/ToolInvocationItem.tsx
+++ b/src/frontend/apps/conversations/src/features/chat/components/ToolInvocationItem.tsx
@@ -45,11 +45,6 @@ export const ToolInvocationItem: React.FC<ToolInvocationItemProps> = ({
         $width="100%"
         $maxWidth="750px"
         $margin={{ all: 'auto', top: 'base', bottom: 'md' }}
-        $background="var(--c--contextuals--background--surface--tertiary)"
-        $color="var(--c--contextuals--content--semantic--neutral--secondary)"
-        $padding={{ all: 'sm' }}
-        $radius="8px"
-        $css="font-size: 0.9em; width: 100%; white-space: pre-wrap; word-wrap: break-word;"
       >
         <Loader />
         <Text $variation="600" $size="md">

--- a/src/frontend/apps/e2e/__tests__/app-conversations/chat.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-conversations/chat.spec.ts
@@ -1,5 +1,7 @@
 import { expect, test } from '@playwright/test';
 
+import { overrideConfig } from './common';
+
 test.beforeEach(async ({ page }) => {
   await page.goto('/home/');
 });
@@ -68,5 +70,72 @@ test.describe('Chat page', () => {
 
     await chatHistoryLink.click();
     await expect(messageContent).toBeVisible();
+  });
+
+  test('the user can paste a document into the chat input', async ({ page }) => {
+    await overrideConfig(page, {
+      FEATURE_FLAGS: {
+        'document-upload': 'enabled',
+        'web-search': 'enabled',
+      },
+    });
+
+    await page.goto('/');
+
+    const chatInput = page.getByRole('textbox', {
+      name: 'Enter your message or a',
+    });
+    await expect(chatInput).toBeVisible();
+    await chatInput.click();
+
+    // Create a test file content
+    const fileContent = 'Test document content for paste';
+    const fileName = 'test-document.txt';
+    const fileType = 'text/plain';
+
+    // Simulate paste event with file
+    await page.evaluate(
+      ({ content, name, type }) => {
+        const textarea = document.querySelector(
+          'textarea[name="inputchat-textarea"]',
+        ) as HTMLTextAreaElement;
+        if (!textarea) return;
+
+        // Create a File object
+        const file = new File([content], name, { type });
+
+        // Create a DataTransfer object to simulate clipboard
+        const dataTransfer = new DataTransfer();
+        dataTransfer.items.add(file);
+
+        // Create a paste event - ClipboardEvent constructor doesn't accept clipboardData
+        // so we create a regular Event and add clipboardData property
+        const pasteEvent = new Event('paste', {
+          bubbles: true,
+          cancelable: true,
+        }) as unknown as ClipboardEvent;
+
+        // Define clipboardData property to make it accessible
+        Object.defineProperty(pasteEvent, 'clipboardData', {
+          value: {
+            files: dataTransfer.files,
+            items: dataTransfer.items,
+            types: Array.from(dataTransfer.types),
+            getData: () => '',
+            setData: () => {},
+          },
+          writable: false,
+          configurable: true,
+        });
+
+        textarea.dispatchEvent(pasteEvent);
+      },
+      { content: fileContent, name: fileName, type: fileType },
+    );
+
+    // Wait for the file to be processed and appear in the attachment list
+    // The attachment should be visible with the file name
+    const attachment = page.getByText(fileName, { exact: false }).first();
+    await expect(attachment).toBeVisible({ timeout: 5000 });
   });
 });


### PR DESCRIPTION
## Purpose

I wanted to set-up conversations locally.. But figured let's actually do something with it.

Fixes https://github.com/suitenumerique/conversations/issues/184

Also, restore a small fix on the parsing document message

## Proposal

Quite simple implem, could be improved but should work most of the times

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Paste attachments from clipboard directly into chat.

* **Improvements**
  * Centralized file validation with clearer rejection handling.
  * Toast notifications when files are rejected.
  * Improved duplicate detection while preserving existing attachments.

* **Style**
  * Slight visual simplification of a tool invocation item.

* **Tests**
  * Added end-to-end test covering pasting a document into chat.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->