### PR TITLE
✨(front) i18n and standardize pdf parsing display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to
 ### Fixed
 
 - ⚡️(front) performance improvements on chat input
+- 💄(front) i18n and standardize pdf parsing display
 
 ### Removed
 

--- a/src/frontend/apps/conversations/src/features/chat/components/ToolInvocationItem.tsx
+++ b/src/frontend/apps/conversations/src/features/chat/components/ToolInvocationItem.tsx
@@ -18,7 +18,10 @@ export const ToolInvocationItem: React.FC<ToolInvocationItemProps> = ({
   const { t } = useTranslation();
 
   if (toolInvocation.toolName === 'document_parsing') {
-    if (toolInvocation.state === 'partial-call') {
+    if (
+      toolInvocation.state === 'partial-call' ||
+      toolInvocation.state === 'result'
+    ) {
       return null;
     }
 
@@ -32,24 +35,23 @@ export const ToolInvocationItem: React.FC<ToolInvocationItemProps> = ({
       )
         ? documents.map((doc) => doc.identifier)
         : [];
+
     return (
       <Box
-        as="pre"
+        $direction="row"
+        $align="center"
+        $gap="6px"
         key={toolInvocation.toolCallId}
-        $background="var(--c--theme--colors--greyscale-100)"
-        $color="var(--c--theme--colors--greyscale-500)"
-        $padding={{ all: 'sm' }}
-        $radius="8px"
-        $css="font-size: 0.9em; width: 100%; white-space: pre-wrap; word-wrap: break-word;"
+        $width="100%"
+        $maxWidth="750px"
+        $margin={{ all: 'auto', top: 'base', bottom: 'md' }}
       >
-        {toolInvocation.state === 'result' ? (
-          <Text>{`Parsing done: ${documentIdentifiers.join(', ')}`}</Text>
-        ) : (
-          <Box $direction="row" $gap="1rem" $align="center">
-            <Loader />
-            <Text>{`Parsing documents: ${documentIdentifiers.join(', ')} ...`}</Text>
-          </Box>
-        )}
+        <Loader />
+        <Text $variation="600" $size="md">
+          {t('Extracting documents: {{documents}} ...', {
+            documents: documentIdentifiers.join(', '),
+          })}
+        </Text>
       </Box>
     );
   }

--- a/src/frontend/apps/conversations/src/i18n/translations.json
+++ b/src/frontend/apps/conversations/src/i18n/translations.json
@@ -1,6 +1,12 @@
 {
   "de": { "translation": { "ABC-1234-XY": "ABC-1234-XY" } },
-  "en": { "translation": { "Login": "Login", "Logout": "Logout" } },
+  "en": {
+    "translation": {
+      "Login": "Login",
+      "Logout": "Logout",
+      "Extracting documents {{documents}} ...": "Extracting documents {{documents}} ..."
+    }
+  },
   "fr": {
     "translation": {
       "30 sec to tell us what you think or report a bug": "Prenez 30 secondes pour partager votre avis ou signaler un bug",
@@ -43,6 +49,7 @@
       "Direct exchange with our team": "Échange direct avec notre équipe",
       "Enter your message or a question": "Entrez votre message ou une question",
       "Explore other LaSuite apps": "Explorer les autres applications de LaSuite",
+      "Extracting documents: {{documents}} ...": "Extraction des documents: {{documents}} ...",
       "Failed to activate account. Please try again.": "Échec de l'activation du compte. Veuillez réessayer.",
       "Failed to copy": "Échec de la copie",
       "Failed to register for notifications. Please try again.": "Échec de l'inscription aux notifications. Veuillez réessayer.",
@@ -176,6 +183,7 @@
       "Direct exchange with our team": "Directe uitwisseling met ons team",
       "Enter your message or a question": "Voer uw bericht of een vraag in",
       "Explore other LaSuite apps": "Ontdek andere LaSuite-apps",
+      "Extracting documents: {{documents}} ...": "Documenten extraheren: {{documents}} ...",
       "Failed to activate account. Please try again.": "Account activeren mislukt. Probeer het opnieuw.",
       "Failed to copy": "Kopiëren mislukt",
       "Failed to register for notifications. Please try again.": "Registratie voor meldingen mislukt. Probeer het opnieuw.",
@@ -309,6 +317,7 @@
       "Direct exchange with our team": "Прямое общение с нашей командой",
       "Enter your message or a question": "Введите сообщение или вопрос",
       "Explore other LaSuite apps": "Посмотреть другие приложения LaSuite",
+      "Extracting documents: {{documents}} ...": "Извлечение документов: {{documents}} ...",
       "Failed to activate account. Please try again.": "Не удалось активировать учётную запись. Пожалуйста, попробуйте снова.",
       "Failed to copy": "Не удалось скопировать",
       "Failed to register for notifications. Please try again.": "Не удалось зарегистрироваться для получения уведомлений. Пожалуйста, попробуйте ещё раз.",
@@ -442,6 +451,7 @@
       "Direct exchange with our team": "Пряме спілкування з нашою командою",
       "Enter your message or a question": "Введіть ваше повідомлення або питання",
       "Explore other LaSuite apps": "Ознайомтесь з іншими застосунками LaSuite",
+      "Extracting documents: {{documents}} ...": "Вилучення документів: {{documents}} ...",
       "Failed to activate account. Please try again.": "Не вдалося активувати обліковий запис. Спробуйте ще раз.",
       "Failed to copy": "Не вдалось скопіювати",
       "Failed to register for notifications. Please try again.": "Не вдалося виконати реєстрацію для повідомлень. Будь ласка, спробуйте ще раз.",


### PR DESCRIPTION
## Purpose

Just as my other PR, wanted to setup the app running, but took the opportunity to fix a couple things to test out the setup.
Here I want to fix the display of PDF parsing, which has been like this for a while and should be at least i18n'ed and styled a bit.

<img width="798" height="203" alt="image" src="https://github.com/user-attachments/assets/18e53859-99ae-4b75-b789-d44c44a53603" />


## Proposal

Use the same standard style as for other actions.

<img width="928" height="300" alt="image" src="https://github.com/user-attachments/assets/63144371-061c-4374-9d9f-0fb8fe414c4a" />


cf. https://github.com/orgs/suitenumerique/projects/13/views/3?pane=issue&itemId=152410382&issue=suitenumerique%7Cconversations%7C246

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified document extraction UI: loader with a localized status message displayed during extraction (EN, FR, NL, RU, UK).

* **Bug Fixes**
  * Prevents showing intermediate or completed extraction states incorrectly.

* **Style**
  * Updated extraction container layout to a centered, row-oriented presentation with refined width, alignment, and spacing.

* **Chores**
  * Updated changelog entry to reflect i18n and standardized PDF parsing display.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->