### PR TITLE
🐛(back) fix keepalives not sent during document parsing

### DIFF
--- a/src/backend/chat/clients/pydantic_ai.py
+++ b/src/backend/chat/clients/pydantic_ai.py
@@ -6,6 +6,7 @@ implementation while keeping the *exact* same public API so that no
 changes are needed in views.py or tests.
 """
 
+import asyncio
 import dataclasses
 import functools
 import json
@@ -273,7 +274,9 @@ class AIAgentService:  # pylint: disable=too-many-instance-attributes
                     # Retrieve the document data
                     with default_storage.open(key, "rb") as file:
                         document_data = file.read()
-                    parsed_content = document_store.parse_and_store_document(
+                    # Run in thread to avoid blocking the event loop during parsing
+                    parsed_content = await asyncio.to_thread(
+                        document_store.parse_and_store_document,
                         name=document.identifier,
                         content_type=document.media_type,
                         content=document_data,
@@ -282,7 +285,9 @@ class AIAgentService:  # pylint: disable=too-many-instance-attributes
                     # Remote URL
                     raise ValueError("External document URL are not accepted yet.")
             else:
-                parsed_content = document_store.parse_and_store_document(
+                # Run in thread to avoid blocking the event loop during parsing
+                parsed_content = await asyncio.to_thread(
+                    document_store.parse_and_store_document,
                     name=document.identifier,
                     content_type=document.media_type,
                     content=document.data,


### PR DESCRIPTION
## Purpose

Fix keepalives not being sent during long document parsing operations by wrapping   blocking calls with asyncio.to_thread()

In production, nginx was timing out during document uploads because keepalive  messages were not sent while parsing documents (PDF, etc.).

  The root caus is  parse_and_store_document() is a synchronous.   Calling it directly inside an async def function blocks the entire event loop,   preventing asyncio.wait_for() timeouts from triggering and keepalives from being
  triggered.

## Proposal

  Wrap document_store.parse_and_store_document() calls with
  asyncio.to_thread() to prevent blocking the event loop.
 
Works in sync and async mode.
 
<img width="1185" height="809" alt="Capture d’écran 2026-01-26 à 15 31 35" src="https://github.com/user-attachments/assets/a829c64f-1103-4c46-b25b-4b8c973a7819" />

Please ensure the following items are checked before submitting your pull request:
- [x] I have read and followed the [contributing guidelines](https://github.com/suitenumerique/conversations/blob/main/CONTRIBUTING.md)
- [x] I have read and agreed to the [Code of Conduct](https://github.com/suitenumerique/conversations/blob/main/CODE_OF_CONDUCT.md)
- [x] I have signed off my commits with `git commit --signoff` (DCO compliance)
- [x] I have signed my commits with my SSH or GPG key (`git commit -S`)
- [x] My commit messages follow the required format: `<gitmoji>(type) title description`
- [x] I have added a changelog entry under `## [Unreleased]` section (if noticeable change)
- [x] I have added corresponding tests for new features or bug fixes (if applicable)