### PR TITLE
🩺(back) add context to setting sanity check

### DIFF
--- a/src/backend/conversations/settings.py
+++ b/src/backend/conversations/settings.py
@@ -1169,10 +1169,13 @@ USER QUESTION:
         # @property returning a lazy object, which cannot be accessed via cls in a classmethod.
         if cls.RAG_DOCUMENT_PARSER == "chat.agent_rag.document_converter.parser.AdaptivePdfParser":
             llm_configs = load_llm_configuration(cls._llm_configuration_file_path)
+
             if cls.OCR_HRID not in llm_configs:
+                available_hrids = ", ".join([f"'{hrid}'" for hrid in llm_configs])
                 raise ValueError(
                     f"OCR_HRID '{cls.OCR_HRID}' not found in LLM_CONFIGURATIONS. "
                     "Please add a matching provider entry or set OCR_HRID to an existing key."
+                    f"Available models id: {available_hrids}"
                 )
 
         # Langfuse initialization


### PR DESCRIPTION
## Purpose

Add context to an erro message iot understand the issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced OCR configuration error messaging to display available models when the specified model is not found, enabling users to quickly identify valid configuration options and resolve issues independently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->