### PR TITLE
🧱(helm) mount the LLM json config file in jobs

### DIFF
--- a/src/helm/conversations/Chart.yaml
+++ b/src/helm/conversations/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 type: application
 name: conversations
-version:  0.0.4
+version:  0.0.5
 appVersion: latest

--- a/src/helm/conversations/templates/backend_job.yml
+++ b/src/helm/conversations/templates/backend_job.yml
@@ -72,6 +72,11 @@ spec:
               subPath: {{ .subPath | default "" }}
               readOnly: {{ .readOnly }}
             {{- end }}
+            {{- if .Values.backend.llmConfiguration.enabled }}
+            - name: llm-configuration
+              mountPath: {{ .Values.backend.llmConfiguration.mount_path }}
+              readOnly: true
+            {{- end }}
       {{- with .Values.backend.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -120,5 +125,10 @@ spec:
           {{- else }}
           emptyDir: {}
           {{- end }}
+        {{- end }}
+        {{- if .Values.backend.llmConfiguration.enabled }}
+        - name: llm-configuration
+          configMap:
+            name: conversations-llm-configuration
         {{- end }}
 {{- end }}

--- a/src/helm/conversations/templates/backend_job_createsuperuser.yaml
+++ b/src/helm/conversations/templates/backend_job_createsuperuser.yaml
@@ -73,6 +73,11 @@ spec:
               subPath: {{ .subPath | default "" }}
               readOnly: {{ .readOnly }}
             {{- end }}
+            {{- if .Values.backend.llmConfiguration.enabled }}
+            - name: llm-configuration
+              mountPath: {{ .Values.backend.llmConfiguration.mount_path }}
+              readOnly: true
+            {{- end }}
       {{- with .Values.backend.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -121,4 +126,9 @@ spec:
           {{- else }}
           emptyDir: {}
           {{- end }}
+        {{- end }}
+        {{- if .Values.backend.llmConfiguration.enabled }}
+        - name: llm-configuration
+          configMap:
+            name: conversations-llm-configuration
         {{- end }}

--- a/src/helm/conversations/templates/backend_job_migrate.yaml
+++ b/src/helm/conversations/templates/backend_job_migrate.yaml
@@ -73,6 +73,11 @@ spec:
               subPath: {{ .subPath | default "" }}
               readOnly: {{ .readOnly }}
             {{- end }}
+            {{- if .Values.backend.llmConfiguration.enabled }}
+            - name: llm-configuration
+              mountPath: {{ .Values.backend.llmConfiguration.mount_path }}
+              readOnly: true
+            {{- end }}
       {{- with .Values.backend.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -121,4 +126,9 @@ spec:
           {{- else }}
           emptyDir: {}
           {{- end }}
+        {{- end }}
+        {{- if .Values.backend.llmConfiguration.enabled }}
+        - name: llm-configuration
+          configMap:
+            name: conversations-llm-configuration
         {{- end }}


### PR DESCRIPTION
## Purpose

The backend might do some consistency checks for settings, some of them are the proper LLM configuration...


## Proposal

- [x] mount the LLM configuration file volume also for jobs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added optional LLM configuration support across backend deployment and job templates: when enabled in deployment settings, a read-only configuration mount is injected into containers along with a corresponding config-map-backed volume, allowing the backend to consume external LLM configuration without code changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->