### PR TITLE
🐛(back) cast collection Ids to API expected types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ and this project adheres to
 - 🏗️(back) migrate to uv
 - ♻️(front) optimize syntax highlighting bundle size
 
+### Fixed
+
+-  🐛(back) Cast collection Ids to API expected types
+
 ## [0.0.12] - 2026-01-27
 
 ### Fixed

--- a/src/backend/chat/agent_rag/document_rag_backends/albert_rag_backend.py
+++ b/src/backend/chat/agent_rag/document_rag_backends/albert_rag_backend.py
@@ -48,6 +48,11 @@ class AlbertRagBackend(BaseRagBackend):  # pylint: disable=too-many-instance-att
         parser_class = import_string(settings.RAG_DOCUMENT_PARSER)
         self.parser = parser_class()
 
+    @staticmethod
+    def cast_collection_id(collection_id):
+        """Albert API expects int Ids."""
+        return int(collection_id)
+
     def create_collection(self, name: str, description: Optional[str] = None) -> str:
         """
         Create a temporary collection for the search operation.

--- a/src/backend/chat/agent_rag/document_rag_backends/base_rag_backend.py
+++ b/src/backend/chat/agent_rag/document_rag_backends/base_rag_backend.py
@@ -41,6 +41,11 @@ class BaseRagBackend(ABC):
         self._default_collection_description = "Temporary collection for RAG document search"
         self.parser: BaseParser = BaseParser()
 
+    @staticmethod
+    def cast_collection_id(collection_id):
+        """Dummy method to be overridden when needed."""
+        return collection_id
+
     def get_all_collection_ids(self) -> List[str]:
         """
         Get all collection IDs, including the main collection ID and read-only collection IDs.
@@ -55,10 +60,13 @@ class BaseRagBackend(ABC):
 
         collection_ids = []
         if self.collection_id:
-            collection_ids.append(self.collection_id)
+            collection_ids.append(self.cast_collection_id(self.collection_id))
         if self.read_only_collection_id:
             collection_ids.extend(
-                [int(collection_id) for collection_id in self.read_only_collection_id]
+                [
+                    self.cast_collection_id(collection_id)
+                    for collection_id in self.read_only_collection_id
+                ]
             )
         return collection_ids
 


### PR DESCRIPTION
## Purpose

Albert API expects interger values for collection ids 


## Proposal

Cast values when needed

 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected collection ID type conversion to ensure proper API compatibility and data validation across document retrieval operations.

* **Documentation**
  * Updated changelog documenting the collection ID handling fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->