### PR TITLE
👷(crowdin) use `uv` instead of pip

### DIFF
--- a/.github/workflows/crowdin_upload.yml
+++ b/.github/workflows/crowdin_upload.yml
@@ -22,15 +22,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       # Backend i18n
-      - name: Install Python
-        uses: actions/setup-python@v5
+      - name: Set up Python
+        uses: actions/setup-python@v6
         with:
-          python-version: "3.13.3"
-          cache: "pip"
-      - name: Upgrade pip and setuptools
-        run: pip install --upgrade pip setuptools
-      - name: Install development dependencies
-        run: pip install --user .
+          python-version-file: "src/backend/pyproject.toml"
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+      - name: Install the project
+        run: uv sync --locked --all-extras
         working-directory: src/backend
       - name: Restore the mail templates
         uses: actions/cache@v4
@@ -46,7 +45,7 @@ jobs:
       - name: generate pot files
         working-directory: src/backend
         run: |
-          DJANGO_CONFIGURATION=Build python manage.py makemessages -a --keep-pot
+          DJANGO_CONFIGURATION=Build uv run python manage.py makemessages -a --keep-pot
       # frontend i18n
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Purpose

This garanties consistency across actions (eg. we don't want to have to update the python version in the workflow while our `uv` configuration already defines it).


## Proposal

- [x] replace `pip` use with `uv` in Crowdin related Github Action


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow and build tooling for a more consistent environment setup.
  * Streamlined dependency installation and project setup steps to reduce redundancy.
  * Switched translation extraction to run via the consolidated build runner for improved consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->