### PR TITLE
🚸(oidc) ignore case when fallback on email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to
 - ⚡️(front) optimize streaming markdown rendering performance
 - ⬆️(back) update pydantic-ai
 - ♻️(chat) refactor AIAgentService for readability and maintainability
+- 🚸(oidc) ignore case when fallback on email #281
 
 ### Fixed
 

--- a/src/backend/core/models.py
+++ b/src/backend/core/models.py
@@ -77,10 +77,13 @@ class UserManager(auth_models.UserManager):
 
             if settings.OIDC_FALLBACK_TO_EMAIL_FOR_IDENTIFICATION:
                 try:
-                    return self.get(email=email)
+                    return self.get(email__iexact=email)
                 except self.model.DoesNotExist:
                     pass
-            elif self.filter(email=email).exists() and not settings.OIDC_ALLOW_DUPLICATE_EMAILS:
+            elif (
+                self.filter(email__iexact=email).exists()
+                and not settings.OIDC_ALLOW_DUPLICATE_EMAILS
+            ):
                 raise DuplicateEmailError(
                     _(
                         "We couldn't find a user with this sub but the email is already "

--- a/src/backend/core/tests/authentication/test_backends.py
+++ b/src/backend/core/tests/authentication/test_backends.py
@@ -64,6 +64,28 @@ def test_authentication_getter_existing_user_via_email(django_assert_num_queries
     assert user == db_user
 
 
+def test_authentication_getter_existing_user_via_email_case_insensitive(
+    django_assert_num_queries, monkeypatch
+):
+    """
+    If an existing user doesn't match the sub but matches the email with different case,
+    the user should be returned (case-insensitive email matching).
+    """
+
+    klass = OIDCAuthenticationBackend()
+    db_user = UserFactory(email="john.doe@example.com")
+
+    def get_userinfo_mocked(*args):
+        return {"sub": "123", "email": "JOHN.DOE@EXAMPLE.COM"}
+
+    monkeypatch.setattr(OIDCAuthenticationBackend, "get_userinfo", get_userinfo_mocked)
+
+    with django_assert_num_queries(4):  # user by sub, user by mail, update sub
+        user = klass.get_or_create_user(access_token="test-token", id_token=None, payload=None)
+
+    assert user == db_user
+
+
 def test_authentication_getter_email_none(monkeypatch):
     """
     If no user is found with the sub and no email is provided, a new user should be created.
@@ -141,6 +163,39 @@ def test_authentication_getter_existing_user_no_fallback_to_email_no_duplicate(
         match=(
             "We couldn't find a user with this sub but the email is "
             "already associated with a registered user."
+        ),
+    ):
+        klass.get_or_create_user(access_token="test-token", id_token=None, payload=None)
+
+    # Since the sub doesn't match, it should not create a new user
+    assert models.User.objects.count() == 1
+
+
+def test_authentication_getter_existing_user_no_fallback_to_email_no_duplicate_case_insensitive(
+    settings, monkeypatch
+):
+    """
+    When the "OIDC_FALLBACK_TO_EMAIL_FOR_IDENTIFICATION" setting is set to False,
+    the system should detect duplicate emails even with different case.
+    """
+
+    klass = OIDCAuthenticationBackend()
+    _db_user = UserFactory(email="john.doe@example.com")
+
+    # Set the setting to False
+    settings.OIDC_FALLBACK_TO_EMAIL_FOR_IDENTIFICATION = False
+    settings.OIDC_ALLOW_DUPLICATE_EMAILS = False
+
+    def get_userinfo_mocked(*args):
+        return {"sub": "123", "email": "JOHN.DOE@EXAMPLE.COM"}
+
+    monkeypatch.setattr(OIDCAuthenticationBackend, "get_userinfo", get_userinfo_mocked)
+
+    with pytest.raises(
+        SuspiciousOperation,
+        match=(
+            "We couldn't find a user with this sub but the email is already associated "
+            "with a registered user."
         ),
     ):
         klass.get_or_create_user(access_token="test-token", id_token=None, payload=None)


### PR DESCRIPTION
## Purpose

Some identity providers might change the case, but in our products we don't consider case variation to be consider as different email addresses.

Next step would be to normalize the DB value of email to be lower-case.

## Proposal

- [x] ignore email case in OIDC login fallback

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * OIDC authentication now performs case-insensitive email matching when falling back to email-based user identification, improving reliability while preserving duplicate-email protections when fallback is disabled.

* **Tests**
  * Added tests covering case-insensitive email matching and duplicate-email validation under OIDC fallback configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->