### PR TITLE
🐛(helm) reverse liveness and readiness for backend deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to
 
 - 💚(docker) vendor mime.types file instead of fetching from Apache SVN
 - 🐛(front) fix math formulas and carousel translations
+- 🐛(helm) reverse liveness and readiness for backend deployment
 
 ## [0.0.13] - 2026-02-09
 

--- a/src/helm/conversations/values.yaml
+++ b/src/helm/conversations/values.yaml
@@ -234,10 +234,10 @@ backend:
   ## @param backend.probes.readiness.initialDelaySeconds [nullable] Configure timeout for backend readiness probe
   probes:
     liveness:
-      path: /__heartbeat__
+      path: /__lbheartbeat__
       initialDelaySeconds: 10
     readiness:
-      path: /__lbheartbeat__
+      path: /__heartbeat__
       initialDelaySeconds: 10
 
   ## @param backend.resources Resource requirements for the backend container


### PR DESCRIPTION
## Purpose

The liveness and readiness are reversed. The liveness was using the heartbeat process that is cheking all django checks and the database connection.


## Proposal

- [x] 🐛(helm) reverse liveness and readiness for backend deployment


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Corrected reversed health check endpoints for backend deployment. Liveness and readiness probes now use the correct paths to ensure accurate health monitoring and proper service availability detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->