### PR TITLE
🚑️(back) fix mime type for pptx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to
 ### Fixed
 
 - 💚(docker) vendor mime.types file instead of fetching from Apache SVN
+- 🚑️(back) fix mime type for pptx
 - 🐛(front) fix math formulas and carousel translations
 - 🐛(helm) reverse liveness and readiness for backend deployment
 - 🐛(front) fix dark mode styling on chat messages

--- a/src/backend/conversations/settings.py
+++ b/src/backend/conversations/settings.py
@@ -702,7 +702,7 @@ class Base(BraveSettings, Configuration):
             # docx files
             "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
             # pptx files
-            "application/vnd.openxmlformats-officedocument.presentationml",
+            "application/vnd.openxmlformats-officedocument.presentationml.presentation",
             # xlsx and xls files
             "application/vnd.ms-excel",
             "application/excel",

--- a/src/frontend/apps/e2e/__tests__/app-conversations/common.ts
+++ b/src/frontend/apps/e2e/__tests__/app-conversations/common.ts
@@ -26,7 +26,7 @@ export const CONFIG = {
   theme_customization: {},
   chat_upload_accept:
     'application/vnd.openxmlformats-officedocument.wordprocessingml.document,' +
-    'application/vnd.openxmlformats-officedocument.presentationml,' +
+    'application/vnd.openxmlformats-officedocument.presentationml.presentation,' +
     'application/vnd.ms-excel,' +
     'application/excel,' +
     'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,' +


### PR DESCRIPTION
## Purpose

The mime type for pptx was wrong, causing pptx to be not attacheable.

## Proposal

Use the correct mime type. **⚠️ May require an update in env!**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed PowerPoint (.pptx) upload validation so presentation files are correctly recognized and accepted across the app, reducing false rejections.

* **Documentation**
  * Added an "Unreleased → Fixed" changelog entry noting the PPTX upload validation fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->