### PR TITLE
🐛(front) fix dark mode styling on chat messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to
 - 💚(docker) vendor mime.types file instead of fetching from Apache SVN
 - 🐛(front) fix math formulas and carousel translations
 - 🐛(helm) reverse liveness and readiness for backend deployment
+- 🐛(front) fix dark mode styling on chat messages
 
 ## [0.0.13] - 2026-02-09
 

--- a/src/frontend/apps/conversations/src/features/chat/components/MessageItem.tsx
+++ b/src/frontend/apps/conversations/src/features/chat/components/MessageItem.tsx
@@ -15,14 +15,14 @@ import { ToolInvocationItem } from '@/features/chat/components/ToolInvocationIte
 // Memoized blocks list to prevent parent re-renders from causing block remounts
 const BlocksList = React.memo(
   ({ blocks, pending }: { blocks: string[]; pending: string }) => (
-    <div>
+    <>
       {/* key={index} is safe here: blocks are append-only during streaming
          and a completed block's content never changes once finalized. */}
       {blocks.map((block, index) => (
         <CompletedMarkdownBlock key={index} content={block} />
       ))}
       {pending && <RawTextBlock content={pending} />}
-    </div>
+    </>
   ),
   (prev, next) => {
     const lengthChanged = prev.blocks.length !== next.blocks.length;
@@ -299,16 +299,12 @@ const MessageItemComponent: React.FC<MessageItemProps> = ({
             </Box>
           )}
         <Box
-          $radius="8px"
-          $width={`${message.role === 'user' ? 'auto' : '100%'}`}
-          $maxWidth="100%"
-          $padding={`${message.role === 'user' ? '12px' : '0'}`}
-          $margin={{ vertical: 'base' }}
-          $background={`${message.role === 'user' ? '#EEF1F4' : 'white'}`}
-          $css={`
-            display: inline-block;
-            float: right;
-            ${shouldApplyStreamingHeight ? `min-height: ${streamingMessageHeight}px;` : ''}`}
+          className={`chatMessage ${message.role === 'user' ? 'chatMessage--user' : 'chatMessage--assistant'}`}
+          style={
+            shouldApplyStreamingHeight
+              ? { minHeight: `${streamingMessageHeight}px` }
+              : undefined
+          }
         >
           {/* Message content */}
           {message.content && (


### PR DESCRIPTION
## Purpose

Fix dark mode on chat elements and hide hr tags

cf. https://github.com/orgs/suitenumerique/projects/13/views/3?pane=issue&itemId=158843940&issue=suitenumerique%7Cconversations%7C303

## Proposal

 - Replace inline styled-component props  with CSS class names on message bubbles, enabling dark mode
  theming via CSS (overwrittent by mistake)
 - Simplify `BlocksList` wrapper from `<div>` to a React fragment to  avoid extra DOM nesting
 
<img width="1232" height="756" alt="Capture d’écran 2026-02-23 à 13 36 13" src="https://github.com/user-attachments/assets/3261d55a-f1b8-4da0-952a-13431a9c2068" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed dark mode styling for chat messages to ensure proper display and readability.

* **Refactor**
  * Consolidated chat message rendering to use class-based styles and simplified handling of streaming message height for more consistent presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->