### PR TITLE
🐛(frontend) fix inverted toast message for settings toggles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to
 - 🐛(front) fix math formulas and carousel translations
 - 🐛(helm) reverse liveness and readiness for backend deployment
 - 🐛(front) fix dark mode styling on chat messages
+- 🐛(front) fixed inverted toast for setting changes
 
 ## [0.0.13] - 2026-02-09
 

--- a/src/frontend/apps/conversations/src/features/settings/components/SettingsModal.tsx
+++ b/src/frontend/apps/conversations/src/features/settings/components/SettingsModal.tsx
@@ -47,8 +47,8 @@ export const SettingsModal = ({ onClose, isOpen }: SettingsModalProps) => {
       });
 
       const toastMessage = updatedValue
-        ? t(STATUS_I18N_KEYS[field].disabled)
-        : t(STATUS_I18N_KEYS[field].enabled);
+        ? t(STATUS_I18N_KEYS[field].enabled)
+        : t(STATUS_I18N_KEYS[field].disabled);
       showToast('success', toastMessage, 'check_circle', 3000);
     } catch (error) {
       console.error(`Error updating user settings for ${field}:`, error);


### PR DESCRIPTION
fixes inverted toast introduced in smart search PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed toast notification messages in Settings that previously showed the opposite status; notifications now correctly display "enabled" when a feature is turned on and "disabled" when it is turned off, providing accurate immediate feedback when changing settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->