### PR TITLE
🐛(back) add missing color option for project colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to
 ### Changed
 
 - ⬆️(dependencies) upgrade Next.js 15 to 16, upgrade python dependencies
+ 
+### Fixed
+
+- 🐛(back) add missing color option for project colors
 
 ## [0.0.14] - 2026-03-11
 

--- a/src/backend/chat/migrations/0006_chatproject_chatconversation_project.py
+++ b/src/backend/chat/migrations/0006_chatproject_chatconversation_project.py
@@ -87,6 +87,7 @@ class Migration(migrations.Migration):
                             ("color_7", "Color 7"),
                             ("color_8", "Color 8"),
                             ("color_9", "Color 9"),
+                            ("color_10", "Color 10"),
                         ],
                         help_text="Project icon color",
                         max_length=20,

--- a/src/backend/chat/models.py
+++ b/src/backend/chat/models.py
@@ -52,6 +52,7 @@ class ChatProjectColor(models.TextChoices):
     COLOR_7 = "color_7", "Color 7"
     COLOR_8 = "color_8", "Color 8"
     COLOR_9 = "color_9", "Color 9"
+    COLOR_10 = "color_10", "Color 10"
 
 
 class ChatProject(BaseModel):

--- a/src/backend/chat/tests/views/projects/test_create.py
+++ b/src/backend/chat/tests/views/projects/test_create.py
@@ -78,6 +78,24 @@ def test_create_project_with_llm_instructions(api_client):
     assert project.llm_instructions == "Always answer in French."
 
 
+@pytest.mark.parametrize("color", ChatProjectColor)
+def test_create_project_with_each_color(api_client, color):
+    """Test creating a project with each available color."""
+    user = UserFactory()
+    url = "/api/v1.0/projects/"
+    data = {
+        "title": "Color Project",
+        "icon": ChatProjectIcon.FOLDER,
+        "color": color,
+    }
+    api_client.force_login(user)
+    response = api_client.post(url, data, format="json")
+
+    assert response.status_code == status.HTTP_201_CREATED
+    project = ChatProject.objects.get(id=response.data["id"])
+    assert project.color == color
+
+
 def test_create_project_anonymous(api_client):
     """Test creating a project as an anonymous user returns a 401 error."""
     url = "/api/v1.0/projects/"


### PR DESCRIPTION
## Purpose

Backend only defined 9 project colors but the frontend expects 10

 NB: an existing migration is edited (entry added to choices)


cf. https://github.com/orgs/suitenumerique/projects/13/views/3?pane=issue&itemId=168528782&issue=suitenumerique%7Cconversations%7C355


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restored a previously missing project color option so users can select the new color.

* **Tests**
  * Added end-to-end tests covering all project color options to verify project creation with each color.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->