### PR TITLE
✨(front) copy button preserves formatting when pasting into Word

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to
 ### Changed
 
 - ⬆️(dependencies) upgrade Next.js 15 to 16, upgrade python dependencies
+- ✨(front) rich text copy for Word/Docs paste
  
 ### Fixed
 

--- a/src/frontend/apps/conversations/src/features/chat/components/MessageItem.tsx
+++ b/src/frontend/apps/conversations/src/features/chat/components/MessageItem.tsx
@@ -1,9 +1,9 @@
 import { Message, SourceUIPart, ToolInvocationUIPart } from '@ai-sdk/ui-utils';
+import { Button } from '@gouvfr-lasuite/cunningham-react';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { Button } from '@gouvfr-lasuite/cunningham-react';
-import { Box, Icon, Loader, Text } from '@/components';
+import { Box, Icon, Loader, Text, useToast } from '@/components';
 import { AttachmentList } from '@/features/chat/components/AttachmentList';
 import { FeedbackButtons } from '@/features/chat/components/FeedbackButtons';
 import {
@@ -187,6 +187,8 @@ const MessageItemComponent: React.FC<MessageItemProps> = ({
   getMetadata,
 }) => {
   const { t } = useTranslation();
+  const { showToast } = useToast();
+  const contentRef = React.useRef<HTMLDivElement>(null);
 
   const shouldApplyStreamingHeight =
     isLastAssistantMessage &&
@@ -242,8 +244,26 @@ const MessageItemComponent: React.FC<MessageItemProps> = ({
   }, [isCurrentlyStreaming, message.content]);
 
   const handleCopy = React.useCallback(() => {
-    onCopyToClipboard(message.content);
-  }, [onCopyToClipboard, message.content]);
+    const html = contentRef.current?.innerHTML;
+    if (
+      html &&
+      typeof ClipboardItem !== 'undefined' &&
+      navigator.clipboard.write
+    ) {
+      // Write both formats: Word/Docs use text/html (preserving formatting),
+      // while code editors and plain-text apps use text/plain (raw markdown).
+      const item = new ClipboardItem({
+        'text/html': new Blob([html], { type: 'text/html' }),
+        'text/plain': new Blob([message.content], { type: 'text/plain' }),
+      });
+      navigator.clipboard.write([item]).then(
+        () => showToast('success', t('Copied'), 'content_copy', 3000),
+        () => onCopyToClipboard(message.content),
+      );
+    } else {
+      onCopyToClipboard(message.content);
+    }
+  }, [contentRef, message.content, onCopyToClipboard, showToast, t]);
 
   const handleOpenSources = React.useCallback(() => {
     onOpenSources(message.id);
@@ -292,6 +312,7 @@ const MessageItemComponent: React.FC<MessageItemProps> = ({
           {/* Message content */}
           {message.content && (
             <Box
+              ref={contentRef}
               className="mainContent-chat"
               data-testid={
                 message.role === 'assistant'

--- a/src/frontend/apps/conversations/src/features/chat/components/__tests__/MessageItem.test.tsx
+++ b/src/frontend/apps/conversations/src/features/chat/components/__tests__/MessageItem.test.tsx
@@ -4,6 +4,8 @@ import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Suspense } from 'react';
 
+import { ToastProvider } from '@/components/ToastProvider';
+
 import {
   MessageItem,
   splitIntoBlocks,
@@ -367,7 +369,9 @@ describe('MessageItem', () => {
   const renderWithProviders = (ui: React.ReactNode) => {
     return render(
       <CunninghamProvider>
-        <Suspense fallback={null}>{ui}</Suspense>
+        <ToastProvider>
+          <Suspense fallback={null}>{ui}</Suspense>
+        </ToastProvider>
       </CunninghamProvider>,
     );
   };


### PR DESCRIPTION
## Purpose

Users complain of md formatting when pasting Assistant answers to Word


## Proposal

Copy button now write both formats to pastebin 
 

https://github.com/user-attachments/assets/e9970a88-bfe8-40bf-ba88-e51d6eda46d2

cf. https://github.com/orgs/suitenumerique/projects/13/views/3?pane=issue&itemId=168636462&issue=suitenumerique%7Cconversations%7C356

 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented rich text copying to clipboard with HTML formatting support, enabling better compatibility when pasting chat messages into Word and Google Docs while preserving formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->