### PR TITLE
🥚(front) add April Fools day prank

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to
 
 - ✨(back) add projects with custom LLM instructions
 - ✨(front) projects management UI
+- 🥚(front) add April Fools day prank
 
 ### Changed
 

--- a/src/frontend/apps/conversations/src/features/chat/components/Chat.tsx
+++ b/src/frontend/apps/conversations/src/features/chat/components/Chat.tsx
@@ -3,7 +3,13 @@ import { Modal, ModalSize } from '@gouvfr-lasuite/cunningham-react';
 import { InfiniteData, useQueryClient } from '@tanstack/react-query';
 import 'katex/dist/katex.min.css'; // `rehype-katex` does not import the CSS for you
 import { useRouter } from 'next/router';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import type { ChangeEvent, FormEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -28,6 +34,7 @@ import { useClipboard } from '@/hook';
 import { useResponsiveStore } from '@/stores';
 
 import { useSourceMetadataCache } from '../hooks';
+import { useAprilFools } from '../hooks/useAprilFools';
 import { useChatPreferencesStore } from '../stores/useChatPreferencesStore';
 import { usePendingChatStore } from '../stores/usePendingChatStore';
 import { useScrollStore } from '../stores/useScrollStore';
@@ -167,6 +174,7 @@ export const Chat = ({
   const queryClient = useQueryClient();
   const [isReadingInstructions, setIsReadingInstructions] = useState(false);
   const readingInstructionsStartRef = useRef<number>(0);
+  const aprilFools = useAprilFools();
 
   // Zustand store for pending chat state
   const {
@@ -550,6 +558,12 @@ export const Chat = ({
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
 
+    // April Fools' prank on the very first message of a new conversation.
+    // Use triggerDeferred so the prank survives the router.push() remount.
+    if (messages.length === 0) {
+      aprilFools.triggerDeferred();
+    }
+
     // Upload files to server and get URLs
     let attachments: Attachment[] = [];
     if (files && files.length > 0 && conversationId) {
@@ -684,30 +698,63 @@ export const Chat = ({
       >
         {messages.length > 0 && (
           <Box>
-            {messages.map((message, index) => (
-              <MessageItem
-                key={message.id}
-                message={message}
-                isLastMessage={index === messages.length - 1}
-                isLastAssistantMessage={
-                  message.role === 'assistant' &&
-                  index === lastAssistantMessageIndex
-                }
-                isFirstConversationMessage={isFirstConversationMessage}
-                streamingMessageHeight={streamingMessageHeight}
-                status={status}
-                conversationId={conversationId}
-                isSourceOpen={isSourceOpen}
-                isMobile={isMobile}
-                onCopyToClipboard={copyToClipboard}
-                onOpenSources={openSources}
-                getMetadata={getMetadata}
-              />
-            ))}
+            {messages.map((message, index) => {
+              // Hide the real assistant response while the prank is still streaming
+              const hideAssistant =
+                aprilFools.isActive &&
+                message.role === 'assistant' &&
+                index === messages.length - 1;
+
+              return (
+                <React.Fragment key={message.id}>
+                  {hideAssistant ? null : (
+                    <MessageItem
+                      message={message}
+                      isLastMessage={index === messages.length - 1}
+                      isLastAssistantMessage={
+                        message.role === 'assistant' &&
+                        index === lastAssistantMessageIndex
+                      }
+                      isFirstConversationMessage={isFirstConversationMessage}
+                      streamingMessageHeight={streamingMessageHeight}
+                      status={status}
+                      conversationId={conversationId}
+                      isSourceOpen={isSourceOpen}
+                      isMobile={isMobile}
+                      onCopyToClipboard={copyToClipboard}
+                      onOpenSources={openSources}
+                      getMetadata={getMetadata}
+                    />
+                  )}
+                  {/* Inject the prank right after the last user message */}
+                  {aprilFools.isActive &&
+                    message.role === 'user' &&
+                    (index === messages.length - 1 ||
+                      index === messages.length - 2) && (
+                      <Box
+                        $direction="column"
+                        $width="100%"
+                        $maxWidth="750px"
+                        $margin={{ all: 'auto', top: 'base', bottom: '0' }}
+                        $padding={{ left: '13px', bottom: 'md' }}
+                      >
+                        <Text
+                          $variation="600"
+                          $size="md"
+                          $css="white-space: pre-wrap;"
+                        >
+                          {aprilFools.displayedText}
+                        </Text>
+                      </Box>
+                    )}
+                </React.Fragment>
+              );
+            })}
           </Box>
         )}
-        {(status !== 'ready' && status !== 'streaming' && status !== 'error') ||
-        isUploadingFiles ? (
+        {!aprilFools.isActive &&
+        ((status !== 'ready' && status !== 'streaming' && status !== 'error') ||
+          isUploadingFiles) ? (
           <Box
             $direction="row"
             $align="start"

--- a/src/frontend/apps/conversations/src/features/chat/hooks/useAprilFools.ts
+++ b/src/frontend/apps/conversations/src/features/chat/hooks/useAprilFools.ts
@@ -1,0 +1,131 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+const APRIL_FOOLS_MESSAGES = [
+  'Destroying all documents in 3...2...1...',
+  'Due to budget cuts, I will now only provide 10% of answers',
+  "Sorry, I'm a little tired today. Maybe ask another AI?",
+];
+
+const REVEAL_MESSAGE = '😄 April Fools! Alright, let me answer for real...';
+
+const CHAR_INTERVAL_MS = 30;
+const PAUSE_AFTER_PRANK_MS = 1500;
+const PAUSE_AFTER_REVEAL_MS = 1500;
+const STORAGE_KEY = 'april-fools-year';
+const PENDING_KEY = 'april-fools-pending';
+
+type Phase = 'idle' | 'streaming' | 'pause' | 'reveal' | 'done';
+
+function canRunPrank(): boolean {
+  const now = new Date();
+  if (now.getMonth() !== 3 || now.getDate() !== 1) return false;
+
+  const year = String(now.getFullYear());
+  return localStorage.getItem(STORAGE_KEY) !== year;
+}
+
+function markPrankDone(): void {
+  localStorage.setItem(STORAGE_KEY, String(new Date().getFullYear()));
+}
+
+export function useAprilFools() {
+  const { t } = useTranslation();
+  const [phase, setPhase] = useState<Phase>('idle');
+  const [displayedText, setDisplayedText] = useState('');
+  const fullMessageRef = useRef('');
+  const charIndexRef = useRef(0);
+  const usedRef = useRef(false);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const cleanup = useCallback(() => {
+    if (intervalRef.current) clearInterval(intervalRef.current);
+    if (timeoutRef.current) clearTimeout(timeoutRef.current);
+  }, []);
+
+  const trigger = useCallback(() => {
+    if (usedRef.current || !canRunPrank()) return false;
+    usedRef.current = true;
+    markPrankDone();
+
+    const translatedMessages = APRIL_FOOLS_MESSAGES.map((msg) => t(msg));
+    // not security-sensitive, just picking a random joke
+    const msg =
+      translatedMessages[Math.floor(Math.random() * translatedMessages.length)]; // NOSONAR
+    fullMessageRef.current = msg;
+    charIndexRef.current = 0;
+    setDisplayedText('');
+    setPhase('streaming');
+
+    return true;
+  }, [t]);
+
+  // Queue the prank so it survives a navigation remount
+  const triggerDeferred = useCallback(() => {
+    if (usedRef.current || !canRunPrank()) return;
+    sessionStorage.setItem(PENDING_KEY, '1');
+  }, []);
+
+  // On mount, check for a deferred trigger
+  useEffect(() => {
+    if (sessionStorage.getItem(PENDING_KEY)) {
+      sessionStorage.removeItem(PENDING_KEY);
+      trigger();
+    }
+  }, [trigger]);
+
+  // Fake-stream the prank message character by character like a legit answer would do
+  useEffect(() => {
+    if (phase !== 'streaming') return;
+
+    intervalRef.current = setInterval(() => {
+      charIndexRef.current += 1;
+      const next = fullMessageRef.current.slice(0, charIndexRef.current);
+      setDisplayedText(next);
+
+      if (charIndexRef.current >= fullMessageRef.current.length) {
+        if (intervalRef.current) clearInterval(intervalRef.current);
+        setPhase('pause');
+      }
+    }, CHAR_INTERVAL_MS);
+
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    };
+  }, [phase]);
+
+  // After prank finishes streaming, pause then show reveal
+  useEffect(() => {
+    if (phase !== 'pause') return;
+
+    timeoutRef.current = setTimeout(() => {
+      setDisplayedText((prev) => prev + '\n\n' + t(REVEAL_MESSAGE));
+      setPhase('reveal');
+    }, PAUSE_AFTER_PRANK_MS);
+
+    return () => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    };
+  }, [phase, t]);
+
+  // After reveal, transition to done
+  useEffect(() => {
+    if (phase !== 'reveal') return;
+
+    timeoutRef.current = setTimeout(() => {
+      setPhase('done');
+    }, PAUSE_AFTER_REVEAL_MS);
+
+    return () => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    };
+  }, [phase]);
+
+  // Cleanup on unmount
+  useEffect(() => cleanup, [cleanup]);
+
+  const isActive = phase !== 'idle' && phase !== 'done';
+
+  return { phase, displayedText, isActive, trigger, triggerDeferred };
+}

--- a/src/frontend/apps/conversations/src/i18n/translations.json
+++ b/src/frontend/apps/conversations/src/i18n/translations.json
@@ -41,7 +41,9 @@
       "Delete": "Supprimer",
       "Delete a conversation": "Supprimer une conversation",
       "Delete chat": "Supprimer la conversation",
+      "Destroying all documents in 3...2...1...": "Destruction de l'ensemble des documents dans 3...2...1...",
       "Direct exchange with our team": "Échange direct avec notre équipe",
+      "Due to budget cuts, I will now only provide 10% of answers": "A la suite de restrictions budgétaires, je ne fournirai plus que 10% des réponses",
       "Enter your message or a question": "Entrez votre message ou une question",
       "Explore other LaSuite apps": "Explorer les autres applications de LaSuite",
       "Extracting documents: {{documents}} ...": "Extraction des documents : {{documents}}...",
@@ -65,6 +67,7 @@
       "If enabled, this allows us to analyse your exchanges to improve the Assistant. If disabled, all conversations remain confidential and are not used in any way. ": "Si cette option est activée, cela nous permet d'analyser vos conversations afin d'améliorer l'Assistant. Si elle est désactivée, toutes les conversations restent confidentielles et ne sont utilisées d'aucune manière. ",
       "Image 401": "Image 401",
       "Image 403": "Image 403",
+      "Sorry, I'm a little tired today. Maybe ask another AI?": "Désolé, je suis un peu fatigué aujourd'hui. Demandez peut-être à une autre IA ?",
       "Invalid activation code. Please check and try again.": "Code d'activation invalide. Veuillez le vérifier et réessayer.",
       "It seems that the page you are looking for does not exist or cannot be displayed correctly.": "Il semble que la page que vous cherchez n'existe pas ou ne puisse pas être affichée correctement.",
       "Know more": "En savoir plus",
@@ -137,7 +140,8 @@
       "Your sovereign AI assistant": "Votre assistant IA souverain",
       "source": "source",
       "sources": "sources",
-      "{{productName}} Logo": "Logo {{productName}}"
+      "{{productName}} Logo": "Logo {{productName}}",
+      "😄 April Fools! Alright, let me answer for real...": "😄 Poisson d'avril ! Allez, je réponds pour de vrai..."
     }
   },
   "nl": {
@@ -180,7 +184,9 @@
       "Delete": "Verwijderen",
       "Delete a conversation": "Een gesprek verwijderen",
       "Delete chat": "Chat verwijderen",
+      "Destroying all documents in 3...2...1...": "",
       "Direct exchange with our team": "Directe uitwisseling met ons team",
+      "Due to budget cuts, I will now only provide 10% of answers": "",
       "Enter your message or a question": "Voer uw bericht of een vraag in",
       "Explore other LaSuite apps": "Ontdek andere LaSuite-apps",
       "Extracting documents: {{documents}} ...": "Documenten uitpakken: {{documents}}...",
@@ -204,6 +210,7 @@
       "If enabled, this allows us to analyse your exchanges to improve the Assistant. If disabled, all conversations remain confidential and are not used in any way. ": "Indien ingeschakeld, kunnen we uw gesprekken analyseren om de Assistent te verbeteren. Indien uitgeschakeld, blijven alle gesprekken vertrouwelijk en worden ze op geen enkele manier gebruikt. ",
       "Image 401": "Afbeelding 401",
       "Image 403": "Afbeelding 403",
+      "Sorry, I'm a little tired today. Maybe ask another AI?": "",
       "Invalid activation code. Please check and try again.": "Ongeldige activeringscode. Controleer en probeer het opnieuw.",
       "It seems that the page you are looking for does not exist or cannot be displayed correctly.": "Het lijkt erop dat de pagina die u zoekt niet bestaat of niet correct kan worden weergegeven.",
       "Know more": "Meer weten",
@@ -276,7 +283,8 @@
       "Your sovereign AI assistant": "Uw soevereine AI-assistent",
       "source": "bron",
       "sources": "bronnen",
-      "{{productName}} Logo": "{{productName}} Logo"
+      "{{productName}} Logo": "{{productName}} Logo",
+      "😄 April Fools! Alright, let me answer for real...": ""
     }
   },
   "ru": {
@@ -319,7 +327,9 @@
       "Delete": "Удалить",
       "Delete a conversation": "Удалить беседу",
       "Delete chat": "Удалить беседу",
+      "Destroying all documents in 3...2...1...": "",
       "Direct exchange with our team": "Прямое общение с нашей командой",
+      "Due to budget cuts, I will now only provide 10% of answers": "",
       "Enter your message or a question": "Введите сообщение или вопрос",
       "Explore other LaSuite apps": "Посмотреть другие приложения LaSuite",
       "Extracting documents: {{documents}} ...": "Извлечение документов: {{documents}}...",
@@ -343,6 +353,7 @@
       "If enabled, this allows us to analyse your exchanges to improve the Assistant. If disabled, all conversations remain confidential and are not used in any way. ": "Если этот параметр включён, мы можем анализировать ваши беседы для улучшения интеллекта помощника. Если отключён, то все разговоры остаются конфиденциальными и никак не используются. ",
       "Image 401": "Изображение 401",
       "Image 403": "Изображение 403",
+      "Sorry, I'm a little tired today. Maybe ask another AI?": "",
       "Invalid activation code. Please check and try again.": "Неверный код активации. Пожалуйста, проверьте его и повторите попытку.",
       "It seems that the page you are looking for does not exist or cannot be displayed correctly.": "Похоже, страница, которую вы ищете, не существует или не может быть правильно отображена.",
       "Know more": "Подробнее",
@@ -415,7 +426,8 @@
       "Your sovereign AI assistant": "Ваш надёжный ИИ-помощник",
       "source": "источник",
       "sources": "источники",
-      "{{productName}} Logo": "Логотип {{productName}}"
+      "{{productName}} Logo": "Логотип {{productName}}",
+      "😄 April Fools! Alright, let me answer for real...": ""
     }
   },
   "uk": {
@@ -458,7 +470,9 @@
       "Delete": "Видалити",
       "Delete a conversation": "Видалити розмову",
       "Delete chat": "Видалити розмову",
+      "Destroying all documents in 3...2...1...": "",
       "Direct exchange with our team": "Пряме спілкування з нашою командою",
+      "Due to budget cuts, I will now only provide 10% of answers": "",
       "Enter your message or a question": "Введіть ваше повідомлення або питання",
       "Explore other LaSuite apps": "Ознайомтесь з іншими застосунками LaSuite",
       "Extracting documents: {{documents}} ...": "Видобування документів: {{documents}}...",
@@ -482,6 +496,7 @@
       "If enabled, this allows us to analyse your exchanges to improve the Assistant. If disabled, all conversations remain confidential and are not used in any way. ": "Якщо увімкнуто, це дозволить нам аналізувати ваші розмови для покращення помічника. Якщо вимкнено, всі розмови залишаються конфіденційними та не використовуються жодним чином. ",
       "Image 401": "Зображення 401",
       "Image 403": "Зображення 403",
+      "Sorry, I'm a little tired today. Maybe ask another AI?": "",
       "Invalid activation code. Please check and try again.": "Невірний код активації. Будь ласка, перевірте та повторіть спробу.",
       "It seems that the page you are looking for does not exist or cannot be displayed correctly.": "Схоже, що сторінка, яку ви шукаєте, не існує або не може бути показаною правильно.",
       "Know more": "Докладніше",
@@ -554,7 +569,8 @@
       "Your sovereign AI assistant": "Ваш надійний помічник з ШІ",
       "source": "джерело",
       "sources": "джерела",
-      "{{productName}} Logo": "Логотип {{productName}}"
+      "{{productName}} Logo": "Логотип {{productName}}",
+      "😄 April Fools! Alright, let me answer for real...": ""
     }
   }
 }


### PR DESCRIPTION
## Purpose

Dsiplay a hopefully funny april fools joke. 

This is a full-front implementation, no backend impact at all.

https://github.com/orgs/suitenumerique/projects/13/views/3?pane=issue&itemId=170881186&issue=suitenumerique%7Cconversations%7C368

## Proposal

  - On April 1st, the first user message triggers a fake streaming prank  response before the real answer
  - Prank only runs once per year per browser (localStorage guard)
  -  Messages are i18n-ready with French translations; other languages have  blank entries (fallback to English)
  
  Available jokes:   "Destruction de l'ensemble des documents dans 3…2…1…",
  'A la suite de restrictions budgétaires, je ne fournirai plus que 10% des réponses',
  ~~"J'ai grave la flemme là, tu veux pas demander à une autre IA ?"~~,
"Désolé, je suis un peu fatigué aujourd'hui. Demandez peut-être à une autre IA ?"
  
  ## How to test
  - use https://addons.mozilla.org/fr/firefox/addon/timetravel/  (or similar) to fake the date
  - edit localstorage april-fools-year key if needed
 

https://github.com/user-attachments/assets/24a33e3a-1214-4430-8589-700e26ba2651

https://github.com/orgs/suitenumerique/projects/13/views/3?pane=issue&itemId=170881186&issue=suitenumerique%7Cconversations%7C368

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an April Fools prank in chat that streams a humorous message sequence on April 1st (runs once per year), alters message rendering and suppresses the normal thinking/loader UI during the prank, and then reveals the joke.

* **Localization**
  * Added April Fools-related translations (French populated; Dutch, Russian, Ukrainian placeholders).

* **Documentation**
  * Updated changelog with the April Fools entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->