### PR TITLE
✨(back) strip legacy search tools from model config

### DIFF
--- a/src/backend/chat/llm_configuration.py
+++ b/src/backend/chat/llm_configuration.py
@@ -1,5 +1,6 @@
 """Module for managing LLM configurations from a JSON configuration file."""
 
+import logging
 import os
 from functools import lru_cache
 from typing import Annotated, Any, Literal, Optional, Self, Sequence
@@ -14,6 +15,21 @@ from pydantic import (
     model_validator,
 )
 from pydantic_ai.profiles import JsonSchemaTransformer
+
+logger = logging.getLogger(__name__)
+
+# Legacy tool names that were moved to the `web_search` setting.
+# Kept here for backward compatibility: old configs that still list them
+# under `tools` won't break - the values are stripped and a warning is logged
+# so admins know to update their configuration.
+LEGACY_TOOL_NAMES = frozenset(
+    {
+        "web_search_brave",
+        "web_search_brave_with_document_backend",
+        "web_search_tavily",
+        "web_search_albert_rag",
+    }
+)
 
 
 def _get_setting_or_env_or_value(value: str) -> Any:
@@ -132,7 +148,18 @@ class LLModel(BaseModel):
     def validate_tools(cls, value: list[str] | str) -> list[str]:
         """Convert the tools if it's a setting or environment variable."""
         if isinstance(value, str):
-            return _get_setting_or_env_or_value(value)
+            value = _get_setting_or_env_or_value(value)
+
+        # Strip legacy tool names that are now handled by `web_search`
+        legacy_found = LEGACY_TOOL_NAMES.intersection(value)
+        if legacy_found:
+            logger.warning(
+                "Ignoring legacy tool(s) %s in model configuration. "
+                "Use the 'web_search' setting instead.",
+                ", ".join(sorted(legacy_found)),
+            )
+            value = [t for t in value if t not in LEGACY_TOOL_NAMES]
+
         return value
 
     @field_validator("web_search", mode="before")

--- a/src/backend/chat/tests/agents/test_build_conversation_agent.py
+++ b/src/backend/chat/tests/agents/test_build_conversation_agent.py
@@ -2,6 +2,8 @@
 
 # pylint:disable=protected-access
 
+import logging
+
 import pytest
 from freezegun import freeze_time
 from pydantic_ai import Agent
@@ -112,3 +114,36 @@ def test_agent_is_web_search_configured_when_defined_in_model_config(settings):
     }
     agent = ConversationAgent(model_hrid="default-model")
     assert agent.is_web_search_configured() is True
+
+
+@freeze_time("2025-07-25T10:36:35.297675Z")
+@pytest.mark.parametrize(
+    "legacy_tool",
+    [
+        "web_search_brave",
+        "web_search_brave_with_document_backend",
+        "web_search_tavily",
+        "web_search_albert_rag",
+    ],
+)
+def test_build_pydantic_agent_with_legacy_tools(settings, caplog, legacy_tool):
+    """Test successful agent creation when obsolete tools are used."""
+    settings.AI_AGENT_TOOLS = [legacy_tool]
+    with caplog.at_level(logging.WARNING, logger="chat.llm_configuration"):
+        agent = ConversationAgent(model_hrid="default-model")
+    assert "Ignoring legacy tool(s)" in caplog.text
+    assert isinstance(agent, Agent)
+
+    instructions = agent._instructions
+    assert len(instructions) == 3
+    assert instructions[0] == "You are a helpful assistant"
+    assert instructions[1].__name__ == "add_the_date"
+    assert instructions[1]() == "Today is Friday 25/07/2025."
+    assert instructions[2].__name__ == "enforce_response_language"
+    assert instructions[2]() == ""
+
+    assert isinstance(agent.model, OpenAIChatModel)
+    assert agent.model.model_name == "model-123"
+    assert str(agent.model.client.base_url) == "https://api.llm.com/v1/"
+    assert agent.model.client.api_key == "test-key"
+    assert not list(agent._function_toolset.tools.keys())

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -61,7 +61,7 @@ dependencies = [
     "PyJWT==2.12.0",
     "python-magic==0.4.27",
     "redis<6.0.0",
-    "requests==2.32.5",
+    "requests==2.33.0",
     "semchunk==3.2.5",
     "sentry-sdk==2.44.0",
     "trafilatura==2.0.0",

--- a/src/backend/uv.lock
+++ b/src/backend/uv.lock
@@ -530,7 +530,7 @@ requires-dist = [
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = "==3.8.0" },
     { name = "python-magic", specifier = "==0.4.27" },
     { name = "redis", specifier = "<6.0.0" },
-    { name = "requests", specifier = "==2.32.5" },
+    { name = "requests", specifier = "==2.33.0" },
     { name = "responses", marker = "extra == 'dev'", specifier = "==0.25.8" },
     { name = "respx", marker = "extra == 'dev'", specifier = "==0.22.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = "==0.14.5" },
@@ -1047,6 +1047,7 @@ wheels = [
 name = "griffelib"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ad/06/eccbd311c9e2b3ca45dbc063b93134c57a1ccc7607c5e545264ad092c4a9/griffelib-2.0.0.tar.gz", hash = "sha256:e504d637a089f5cab9b5daf18f7645970509bf4f53eda8d79ed71cce8bd97934", size = 166312, upload-time = "2026-03-23T21:06:55.954Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4d/51/c936033e16d12b627ea334aaaaf42229c37620d0f15593456ab69ab48161/griffelib-2.0.0-py3-none-any.whl", hash = "sha256:01284878c966508b6d6f1dbff9b6fa607bc062d8261c5c7253cb285b06422a7f", size = 142004, upload-time = "2026-02-09T19:09:40.561Z" },
 ]
@@ -2618,7 +2619,7 @@ wheels = [
 
 [[package]]
 name = "requests"
-version = "2.32.5"
+version = "2.33.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -2626,9 +2627,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/64/8860370b167a9721e8956ae116825caff829224fbca0ca6e7bf8ddef8430/requests-2.33.0.tar.gz", hash = "sha256:c7ebc5e8b0f21837386ad0e1c8fe8b829fa5f544d8df3b2253bff14ef29d7652", size = 134232, upload-time = "2026-03-25T15:10:41.586Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+    { url = "https://files.pythonhosted.org/packages/56/5d/c814546c2333ceea4ba42262d8c4d55763003e767fa169adc693bd524478/requests-2.33.0-py3-none-any.whl", hash = "sha256:3324635456fa185245e24865e810cecec7b4caf933d7eb133dcde67d48cee69b", size = 65017, upload-time = "2026-03-25T15:10:40.382Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Purpose

Snippet search features intriduces a setting breaking chhange, which we 'd rather avoid.

https://github.com/orgs/suitenumerique/projects/13/views/3?pane=issue&itemId=170591641&issue=suitenumerique%7Cconversations%7C365

## Proposal

- Handle legacy search tools without breaking the app (and force us to bump to a major version)
- Raise a warning
- (unrelated) bump requests package

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Legacy tool identifiers are now detected and ignored; users see a warning and those tools are excluded from active agent configurations.

* **Tests**
  * Added tests covering agent construction, default instructions, and behavior when legacy tools are present.

* **Chores**
  * Updated a pinned HTTP client dependency to a newer patch release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->