### PR TITLE
🐛(front) fix april fools i18n

### DIFF
--- a/src/frontend/apps/conversations/src/features/chat/hooks/useAprilFools.ts
+++ b/src/frontend/apps/conversations/src/features/chat/hooks/useAprilFools.ts
@@ -1,13 +1,5 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-
-const APRIL_FOOLS_MESSAGES = [
-  'Destroying all documents in 3...2...1...',
-  'Due to budget cuts, I will now only provide 10% of answers',
-  "Sorry, I'm a little tired today. Maybe ask another AI?",
-];
-
-const REVEAL_MESSAGE = '😄 April Fools! Alright, let me answer for real...';
 
 const CHAR_INTERVAL_MS = 30;
 const PAUSE_AFTER_PRANK_MS = 1500;
@@ -39,6 +31,20 @@ export function useAprilFools() {
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  const aprilFoolsMessages = useMemo(
+    () => [
+      t('Destroying all documents in 3...2...1...'),
+      t('Due to budget cuts, I will now only provide 10% of answers'),
+      t("Sorry, I'm a little tired today. Maybe ask another AI?"),
+    ],
+    [t],
+  );
+
+  const revealMessage = useMemo(
+    () => t('😄 April Fools! Alright, let me answer for real...'),
+    [t],
+  );
+
   const cleanup = useCallback(() => {
     if (intervalRef.current) clearInterval(intervalRef.current);
     if (timeoutRef.current) clearTimeout(timeoutRef.current);
@@ -49,17 +55,16 @@ export function useAprilFools() {
     usedRef.current = true;
     markPrankDone();
 
-    const translatedMessages = APRIL_FOOLS_MESSAGES.map((msg) => t(msg));
     // not security-sensitive, just picking a random joke
     const msg =
-      translatedMessages[Math.floor(Math.random() * translatedMessages.length)]; // NOSONAR
+      aprilFoolsMessages[Math.floor(Math.random() * aprilFoolsMessages.length)]; // NOSONAR
     fullMessageRef.current = msg;
     charIndexRef.current = 0;
     setDisplayedText('');
     setPhase('streaming');
 
     return true;
-  }, [t]);
+  }, [aprilFoolsMessages]);
 
   // Queue the prank so it survives a navigation remount
   const triggerDeferred = useCallback(() => {
@@ -100,14 +105,14 @@ export function useAprilFools() {
     if (phase !== 'pause') return;
 
     timeoutRef.current = setTimeout(() => {
-      setDisplayedText((prev) => prev + '\n\n' + t(REVEAL_MESSAGE));
+      setDisplayedText((prev) => prev + '\n\n' + revealMessage);
       setPhase('reveal');
     }, PAUSE_AFTER_PRANK_MS);
 
     return () => {
       if (timeoutRef.current) clearTimeout(timeoutRef.current);
     };
-  }, [phase, t]);
+  }, [phase, revealMessage]);
 
   // After reveal, transition to done
   useEffect(() => {

--- a/src/frontend/packages/i18n/i18next-parser.config.mjs
+++ b/src/frontend/packages/i18n/i18next-parser.config.mjs
@@ -3,6 +3,7 @@ const config = {
     message: '${key}',
     description: '${description}',
   },
+  input: ['../../apps/conversations/**/*.{ts,tsx}'],
   keepRemoved: false,
   keySeparator: false,
   nsSeparator: false,

--- a/src/frontend/packages/i18n/package.json
+++ b/src/frontend/packages/i18n/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "extract-translation": "yarn extract-translation:conversations",
-    "extract-translation:conversations": "yarn i18next ../../apps/conversations/**/*.{ts,tsx} -c ./i18next-parser.config.mjs -o ./locales/conversations/translations-crowdin.json",
+    "extract-translation:conversations": "yarn i18next -c ./i18next-parser.config.mjs -o ./locales/conversations/translations-crowdin.json",
     "format-deploy": "yarn format-deploy:conversations",
     "format-deploy:conversations": "node ./format-deploy.mjs --app=conversations --output=../../apps/conversations/src/i18n/translations.json",
     "format-rebuild-fr:conversations": "node ./rebuild-translations.mjs --language=fr --app=conversations --output=../../apps/conversations/src/i18n/translations.json",


### PR DESCRIPTION
## Purpose

Some frontend translations are not picked up.
2 issues: 
- dynamically translated strings where not picked up 
- For some reason **/*.ts got resolved by the shell to only one file (custom-next.d.ts while **/*.tsx was passed as a glob and prpoerly working.Nested .ts files (like useAprilFools.ts) were never scanned.


## Proposal

Fix how translations are gathered in non tsx files.

 
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized translation handling in the April Fools feature to reduce unnecessary recomputation.
  * Updated translation parser configuration to improve scanning of application files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->