### PR TITLE
🩹(e2e) force English language before left-panel tests

### DIFF
--- a/src/frontend/apps/e2e/__tests__/app-conversations/language.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-conversations/language.spec.ts
@@ -40,8 +40,8 @@ test.describe.serial('Language', () => {
 
     await expect(page.getByLabel('Se déconnecter')).toBeVisible();
 
-    await header.getByRole('button').getByText('Français').click();
-    await page.getByLabel('English').click();
+    // Switch back to English (including backend PATCH)
+    await waitForLanguageSwitch(page, TestLanguage.English);
   });
 
   test.fixme(

--- a/src/frontend/apps/e2e/__tests__/app-conversations/left-panel.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-conversations/left-panel.spec.ts
@@ -1,18 +1,8 @@
-import { Page, expect, test } from '@playwright/test';
+import { expect, test } from '@playwright/test';
+
+import { createProject } from '../helpers';
 
 import { randomName } from './common';
-
-const createProject = async (page: Page, projectName: string) => {
-  await page.getByRole('button', { name: 'New project' }).click();
-  const createModal = page.getByRole('dialog', {
-    name: 'Content modal to create a project',
-  });
-  await createModal
-    .getByRole('textbox', { name: 'Project name' })
-    .fill(projectName);
-  await createModal.getByRole('button', { name: 'Create project' }).click();
-  await expect(page.getByText('The project has been created.')).toBeVisible();
-};
 
 test.describe('Left panel desktop', () => {
   test.beforeEach(async ({ page }) => {

--- a/src/frontend/apps/e2e/__tests__/app-conversations/projects.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-conversations/projects.spec.ts
@@ -1,18 +1,8 @@
-import { Page, expect, test } from '@playwright/test';
+import { expect, test } from '@playwright/test';
+
+import { createProject } from '../helpers';
 
 import { randomName } from './common';
-
-const createProject = async (page: Page, projectName: string) => {
-  await page.getByRole('button', { name: 'New project' }).click();
-  const createModal = page.getByRole('dialog', {
-    name: 'Content modal to create a project',
-  });
-  await createModal
-    .getByRole('textbox', { name: 'Project name' })
-    .fill(projectName);
-  await createModal.getByRole('button', { name: 'Create project' }).click();
-  await expect(page.getByText('The project has been created.')).toBeVisible();
-};
 
 test.describe('Projects', () => {
   test.beforeEach(async ({ page }) => {

--- a/src/frontend/apps/e2e/__tests__/helpers.ts
+++ b/src/frontend/apps/e2e/__tests__/helpers.ts
@@ -1,21 +1,13 @@
-import { Locator } from '@playwright/test';
+import { Page, expect } from '@playwright/test';
 
-export async function waitForElementCount(
-  locator: Locator,
-  count: number,
-  timeout: number,
-) {
-  let elapsedTime = 0;
-  const interval = 200; // Check every 200 ms
-  while (elapsedTime < timeout) {
-    const currentCount = await locator.count();
-    if (currentCount >= count) {
-      return true;
-    }
-    await locator.page().waitForTimeout(interval); // Wait for the interval before checking again
-    elapsedTime += interval;
-  }
-  throw new Error(
-    `Timeout after ${timeout}ms waiting for element count to be at least ${count}`,
-  );
-}
+export const createProject = async (page: Page, projectName: string) => {
+  await page.getByRole('button', { name: 'New project' }).click();
+  const createModal = page.getByRole('dialog', {
+    name: 'Content modal to create a project',
+  });
+  await createModal
+    .getByRole('textbox', { name: 'Project name' })
+    .fill(projectName);
+  await createModal.getByRole('button', { name: 'Create project' }).click();
+  await expect(page.getByText('The project has been created.')).toBeVisible();
+};

--- a/src/frontend/apps/e2e/package.json
+++ b/src/frontend/apps/e2e/package.json
@@ -4,6 +4,8 @@
   "private": true,
   "scripts": {
     "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "prettier": "prettier --write .",
     "install-playwright": "playwright install --with-deps",
     "test": "playwright test",
     "test:ui": "yarn test --ui",

--- a/src/frontend/apps/e2e/tsconfig.json
+++ b/src/frontend/apps/e2e/tsconfig.json
@@ -12,7 +12,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
-    "incremental": true,
+    "incremental": true
   },
   "include": ["**/*.ts", "**/*.d.ts"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
## Purpose

Some e2e tests fail  

## Solution

- fix language.spec.ts not resetting backend user to English after  French switch
- add prettier and lint:fix scripts on e2e app 


 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved reliability for language switching and consolidated project-creation flows in end-to-end tests to reduce flakiness.
* **Chores**
  * Added project-level scripts for automatic lint fixing and code formatting (lint:fix, prettier).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->