### PR TITLE
 ⚙️(back) get carbon data from albert api provider 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to
 - 💄(ui) new header
 - ✨(back) add debug mode setup for local development
 - ⬆️(dependencies) update pydanticai and related dependencies
+- ⚙️(back) get carbon data from albert api provider
 
 ### Fixed
 

--- a/docs/llm-configuration.md
+++ b/docs/llm-configuration.md
@@ -109,7 +109,8 @@ Providers define the API endpoints and authentication for LLM services.
       "hrid": "unique-provider-id",
       "base_url": "https://api.example.com/v1",
       "api_key": "environ.API_KEY_VAR",
-      "kind": "openai"
+      "kind": "openai",
+      "co2_handling": "albert"
     }
   ]
 }
@@ -117,12 +118,15 @@ Providers define the API endpoints and authentication for LLM services.
 
 **Provider Fields:**
 
-| Field      | Type   | Required | Description                                             |
-|------------|--------|----------|---------------------------------------------------------|
-| `hrid`     | string | Yes      | Unique identifier for the provider                      |
-| `base_url` | string | Yes      | API base URL (can use `settings.` or `environ.` prefix) |
-| `api_key`  | string | Yes      | API authentication key (use `environ.` here)            |
-| `kind`     | string | Yes      | Provider type: `openai` or `mistral`                    |
+| Field              | Type   | Required | Description                                             |
+|--------------------|--------|----------|---------------------------------------------------------|
+| `hrid`             | string | Yes      | Unique identifier for the provider                      |
+| `base_url`         | string | Yes      | API base URL (can use `settings.` or `environ.` prefix) |
+| `api_key`          | string | Yes      | API authentication key (use `environ.` here)            |
+| `kind`             | string | Yes      | Provider type: `openai` or `mistral`                    |
+| `co2_handling`     | string | No       | co2_handling method. Only `albert` is enabled*          |
+
+*Leave `co2_handling` empty if the provider does not provide co2 usage.
 
 ### 2. Models
 

--- a/src/backend/chat/agents/base.py
+++ b/src/backend/chat/agents/base.py
@@ -117,6 +117,11 @@ def prepare_custom_model(configuration: "chat.llm_configuration.LLModel"):
             from pydantic_ai.profiles.openai import OpenAIModelProfile  # noqa: PLC0415
             from pydantic_ai.providers.openai import OpenAIProvider  # noqa: PLC0415
 
+            from chat.providers.albert_models import (  # noqa: PLC0415
+                AlbertOpenAIChatModel,
+                AlbertOpenAIProvider,
+            )
+
             if configuration.profile and (
                 _config_profile := configuration.profile.dict(exclude_unset=True)
             ):
@@ -130,6 +135,16 @@ def prepare_custom_model(configuration: "chat.llm_configuration.LLModel"):
                 profile = OpenAIModelProfile(**_model_profile_params)
             else:
                 profile = None
+
+            if configuration.provider.co2_handling == "albert":
+                return AlbertOpenAIChatModel(
+                    model_name=configuration.model_name,
+                    profile=profile,
+                    provider=AlbertOpenAIProvider(
+                        base_url=configuration.provider.base_url,
+                        api_key=configuration.provider.api_key,
+                    ),
+                )
 
             return OpenAIChatModel(
                 model_name=configuration.model_name,

--- a/src/backend/chat/clients/pydantic_ai.py
+++ b/src/backend/chat/clients/pydantic_ai.py
@@ -84,7 +84,7 @@ import time
 import uuid
 from contextlib import AsyncExitStack, ExitStack
 from io import BytesIO
-from typing import AsyncGenerator, Callable, Dict, List, Optional, Tuple
+from typing import AsyncGenerator, Callable, Dict, List, Optional, Tuple, Union
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -96,7 +96,7 @@ from django.utils.module_loading import import_string
 
 from asgiref.sync import sync_to_async
 from langfuse import get_client
-from pydantic_ai import Agent, InstrumentationSettings, RunContext
+from pydantic_ai import Agent, InstrumentationSettings, RunContext, RunUsage
 from pydantic_ai.messages import (
     BinaryContent,
     DocumentUrl,
@@ -205,6 +205,19 @@ def get_model_configuration(model_hrid: str):
         return settings.LLM_CONFIGURATIONS[model_hrid]
     except KeyError as exc:
         raise ImproperlyConfigured(f"LLM model configuration '{model_hrid}' not found.") from exc
+
+
+def _extract_co2_from_usage(usage: RunUsage) -> float:
+    """Extract the CO2 impact from a RunUsage object.
+
+    Reads `co2_impact_factor_20` from usage.details (set by AlbertOpenAIStreamedResponse),
+    reverting the 10^20 integer scaling back to a float in kgCO2eq.
+    Non-Albert providers always return 0 (details key absent).
+    """
+    co2_impact_scale = 10**20
+    if usage_details := usage.details:
+        return usage_details.get("co2_impact_factor_20", 0) / co2_impact_scale
+    return 0
 
 
 class AIAgentService:  # pylint: disable=too-many-instance-attributes
@@ -369,7 +382,7 @@ class AIAgentService:  # pylint: disable=too-many-instance-attributes
 
     async def _prepare_agent_run(
         self, messages: List[UIMessage]
-    ) -> Tuple[str, List, List, Dict[str, str], Dict[str, int], List, bool]:
+    ) -> Tuple[str, List, List, Dict[str, str], Dict[str, Union[int, float]], List, bool]:
         """
         Prepare all inputs needed before running the agent.
 
@@ -411,7 +424,7 @@ class AIAgentService:  # pylint: disable=too-many-instance-attributes
                 input=user_prompt if self._store_analytics else "REDACTED"
             )
 
-        usage = {"promptTokens": 0, "completionTokens": 0}
+        usage = {"promptTokens": 0, "completionTokens": 0, "co2_impact": 0}
 
         conversation_has_documents = self._is_document_upload_enabled and (
             bool(self.conversation.collection_id)
@@ -728,7 +741,7 @@ class AIAgentService:  # pylint: disable=too-many-instance-attributes
         self,
         input_documents: List[BinaryContent | DocumentUrl],
         conversation_has_documents: bool,
-        usage: Dict[str, int],
+        usage: Dict[str, Union[int, float]],
     ) -> AsyncGenerator[events_v4.Event | DocumentParsingResult, None]:
         """
         Handle document parsing with streaming progress events.
@@ -781,6 +794,7 @@ class AIAgentService:  # pylint: disable=too-many-instance-attributes
                     usage=events_v4.Usage(
                         prompt_tokens=usage["promptTokens"],
                         completion_tokens=usage["completionTokens"],
+                        co2_impact=usage["co2_impact"],
                     ),
                 )
             )
@@ -914,11 +928,30 @@ class AIAgentService:  # pylint: disable=too-many-instance-attributes
         )
         return events_v4.StartStepPart(message_id=state.model_response_message_id)
 
+    async def _generate_title_if_needed(self) -> str | None:
+        """Generate and set title if auto-title conditions are met."""
+        user_messages_count = sum(1 for msg in self.conversation.messages if msg.role == "user")
+        if user_messages_count != settings.AUTO_TITLE_AFTER_USER_MESSAGES:
+            return None
+        if self.conversation.title_set_by_user_at:
+            return None
+        title = await self._generate_title()
+        if title:
+            self.conversation.title = title
+        return title
+
+    def _update_langfuse_trace(self, run_output) -> None:
+        """Update the Langfuse trace with the final output, if analytics are enabled."""
+        if not self._langfuse_available:
+            return
+        output = run_output if self._store_analytics else "REDACTED"
+        get_client().update_current_trace(output=output)
+
     async def _finalize_conversation(  # pylint: disable=too-many-arguments,too-many-positional-arguments
         self,
         new_messages: list,
         run_output,
-        usage: Dict[str, int],
+        usage: Dict[str, Union[int, float]],
         state: StreamingState,
         image_key_mapping: Dict[str, str],
     ) -> AsyncGenerator[events_v4.Event, None]:
@@ -944,7 +977,6 @@ class AIAgentService:  # pylint: disable=too-many-instance-attributes
         """
         await self._agent_stop_streaming(force_cache_check=True)
 
-        # Prepare conversation update (save deferred until after potential title generation)
         await sync_to_async(self._prepare_update_conversation)(
             final_output=new_messages,
             usage=usage,
@@ -952,24 +984,11 @@ class AIAgentService:  # pylint: disable=too-many-instance-attributes
             model_response_message_id=state.model_response_message_id,
             image_key_mapping=image_key_mapping or None,
         )
-        generated_title = None
 
-        # Auto-generate title after N user messages if not manually set
-        user_messages_count = sum(1 for msg in self.conversation.messages if msg.role == "user")
+        generated_title = await self._generate_title_if_needed()
 
-        should_generate_title = (
-            user_messages_count == settings.AUTO_TITLE_AFTER_USER_MESSAGES
-            and not self.conversation.title_set_by_user_at
-        )
-
-        if should_generate_title:
-            if generated_title := await self._generate_title():
-                self.conversation.title = generated_title
-
-        # Persist conversation (including any generated title)
         await sync_to_async(self.conversation.save)()
 
-        # Notify frontend about the title update
         if generated_title:
             yield events_v4.DataPart(
                 data=[
@@ -980,17 +999,14 @@ class AIAgentService:  # pylint: disable=too-many-instance-attributes
                     }
                 ]
             )
-        if self._langfuse_available:
-            langfuse = get_client()
-            langfuse.update_current_trace(
-                output=run_output if self._store_analytics else "REDACTED"
-            )
-            # Vercel finish message
+        self._update_langfuse_trace(run_output)
+        # Vercel finish message
         yield events_v4.FinishMessagePart(
             finish_reason=events_v4.FinishReason.STOP,
             usage=events_v4.Usage(
                 prompt_tokens=usage["promptTokens"],
                 completion_tokens=usage["completionTokens"],
+                co2_impact=usage["co2_impact"],
             ),
         )
 
@@ -1072,6 +1088,7 @@ class AIAgentService:  # pylint: disable=too-many-instance-attributes
                 final_usage = run.usage()
                 usage["promptTokens"] = final_usage.input_tokens
                 usage["completionTokens"] = final_usage.output_tokens
+                usage["co2_impact"] = _extract_co2_from_usage(final_usage)
 
         async for event in self._finalize_conversation(
             new_messages, run_output, usage, state, image_key_mapping
@@ -1082,7 +1099,7 @@ class AIAgentService:  # pylint: disable=too-many-instance-attributes
         self,
         *,
         final_output: List[ModelRequest | ModelMessage],
-        usage: Dict[str, int],
+        usage: Dict[str, Union[int, float]],
         ui_sources: Optional[List[SourceUIPart]] = None,
         model_response_message_id: str | None = None,
         image_key_mapping: Optional[Dict[str, str]] = None,
@@ -1095,7 +1112,8 @@ class AIAgentService:  # pylint: disable=too-many-instance-attributes
 
         Args:
             final_output (List[ModelRequest | ModelMessage]): The final output from the agent.
-            usage (Dict[str, int]): The token usage statistics.
+            usage (Dict[str, Union[int, float]]): Token and CO2 usage statistics
+            (mutated in-place to accumulate across turns).
             model_response_message_id (str | None): Message ID
             image_key_mapping (Dict[str, str] | None): Mapping of image id and S3 urls
             ui_sources (List[SourceUIPart]): Optional UI sources to include in the conversation.
@@ -1130,11 +1148,22 @@ class AIAgentService:  # pylint: disable=too-many-instance-attributes
         else:
             logger.warning("model_response_message_id is None")
 
+        co2_impact = usage["co2_impact"]
+        if co2_impact:
+            if _output_ui_message.annotations is None:
+                _output_ui_message.annotations = []
+            _output_ui_message.annotations.append({"co2_impact": co2_impact})
+
+        usage["co2_impact"] += self.conversation.agent_usage.get("co2_impact", 0)
+        usage["promptTokens"] += self.conversation.agent_usage.get("promptTokens", 0)
+        usage["completionTokens"] += self.conversation.agent_usage.get("completionTokens", 0)
+
+        self.conversation.agent_usage = usage
+
         self.conversation.messages += [
             model_message_to_ui_message(_merged_final_output_request),
             _output_ui_message,
         ]
-        self.conversation.agent_usage = usage
 
         final_output_json = json.loads(
             ModelMessagesTypeAdapter.dump_json(final_output).decode("utf-8")

--- a/src/backend/chat/llm_configuration.py
+++ b/src/backend/chat/llm_configuration.py
@@ -71,6 +71,8 @@ class LLMProvider(BaseModel):
     base_url: SettingEnvValue
     api_key: SettingEnvValue
     kind: Literal["openai", "mistral"] = "openai"
+    co2_handling: Optional[Literal["albert"]] = None  # for now, only Albert has CO2 handling,
+    # but this leaves room for other providers to implement it in the future
 
 
 class LLMProfile(BaseModel):

--- a/src/backend/chat/providers/albert_models.py
+++ b/src/backend/chat/providers/albert_models.py
@@ -1,0 +1,70 @@
+"""Custom pydantic-ai model subclasses for Albert API providers."""
+
+from typing import Any
+
+from pydantic_ai.models.openai import ChatCompletionChunk, OpenAIChatModel, OpenAIStreamedResponse
+from pydantic_ai.providers.openai import OpenAIProvider
+
+
+def _extract_co2_impact(raw_usage) -> float | None:
+    """Extract impact fields from an Albert API usage object.
+
+    Albert returns `impacts` as an extra field (openai SDK uses extra='allow'),
+    so it lives in model_extra, not as a direct attribute.
+    """
+    model_extra = getattr(raw_usage, "model_extra", None) or {}
+    raw_impacts = model_extra.get("impacts")
+    if not raw_impacts:
+        return None
+
+    return raw_impacts.get("kgCO2eq")
+
+
+def _convert_impact_to_factor_20(impact_kg_co2_eq: float) -> int:
+    """Convert a CO2 impact in kg to an integer factor with 20 decimals (for precision).
+    This allows us to store the impact as an integer in ModelResponse.details
+    while preserving precision.
+    Values below 1e-20 would return 0
+    """
+    return int(impact_kg_co2_eq * 10**20)
+
+
+class AlbertOpenAIProvider(OpenAIProvider):
+    """OpenAIProvider subclass with a distinct name for Albert's OpenAI-compatible API."""
+
+    @property
+    def name(self) -> str:
+        return "albert_openai"
+
+
+class AlbertOpenAIStreamedResponse(OpenAIStreamedResponse):
+    """Streamed response that preserves Albert's carbon/impacts usage fields."""
+
+    def _map_usage(self, response: ChatCompletionChunk) -> Any:
+        """Override to extract Albert's carbon impact data from usage."""
+        result = super()._map_usage(response)
+
+        if response.usage:
+            co2_impact = _extract_co2_impact(response.usage)
+            if co2_impact:
+                result.details["co2_impact_factor_20"] = _convert_impact_to_factor_20(co2_impact)
+        return result
+
+
+class AlbertOpenAIChatModel(OpenAIChatModel):
+    """
+    OpenAIChatModel subclass that preserves Albert's carbon impact data.
+
+    Albert's API returns `impacts` inside `usage` that pydantic-ai normally discards.
+    This subclass captures the CO2 value and stores it as an integer (scaled by 10^20
+    for precision) in RequestUsage.details["co2_impact_factor_20"], which pydantic-ai
+    then accumulates into RunUsage.details across the run.
+
+    Note: Albert sends CO2 data only in the final usage chunk. If this changes and
+    partial CO2 values appear in intermediate chunks, RunUsage will sum them, which
+    would produce incorrect totals.
+    """
+
+    @property
+    def _streamed_response_cls(self) -> type[OpenAIStreamedResponse]:
+        return AlbertOpenAIStreamedResponse

--- a/src/backend/chat/tests/agents/test_albert_models.py
+++ b/src/backend/chat/tests/agents/test_albert_models.py
@@ -1,0 +1,132 @@
+"""Tests for AlbertOpenAI model subclasses and carbon extraction helpers."""
+# pylint: disable=protected-access
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pydantic_ai.models.openai import OpenAIStreamedResponse
+from pydantic_ai.usage import RequestUsage
+
+from chat.providers.albert_models import (
+    AlbertOpenAIChatModel,
+    AlbertOpenAIProvider,
+    AlbertOpenAIStreamedResponse,
+    _extract_co2_impact,
+)
+
+# ---------------------------------------------------------------------------
+# _extract_co2_impact
+# ---------------------------------------------------------------------------
+
+
+def test_extract_carbon_details_returns_empty_extra_when_no_model_extra():
+    """Returns None when usage has no model_extra."""
+    raw_usage = MagicMock(spec=[])  # no model_extra attribute
+    result = _extract_co2_impact(raw_usage)
+    assert result is None
+
+
+def test_extract_co2_impact():
+    """Extracts co2 impact field when present in model_extra."""
+    kg_co2_eq = 1.5e-9
+    kwh = 3.0e-6
+
+    impacts = {"kgCO2eq": kg_co2_eq, "kWh": kwh}
+    raw_usage = MagicMock()
+    raw_usage.model_extra = {"impacts": impacts}
+    result = _extract_co2_impact(raw_usage)
+    assert result == pytest.approx(kg_co2_eq)
+
+
+def test_extract_co2_impact_handles_model_extra_none():
+    """Treats model_extra=None the same as missing (returns None)."""
+    raw_usage = MagicMock()
+    raw_usage.model_extra = None
+    result = _extract_co2_impact(raw_usage)
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# AlbertOpenAIStreamedResponse._map_usage
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(name="streamed_response")
+def streamed_response_fixture() -> AlbertOpenAIStreamedResponse:
+    """Build a minimal AlbertOpenAIStreamedResponse without hitting the network."""
+    return AlbertOpenAIStreamedResponse.__new__(AlbertOpenAIStreamedResponse)
+
+
+def test_map_usage_without_chunk_usage_delegates_to_super(streamed_response):
+    """When chunk.usage is None, result is identical to parent's _map_usage output."""
+    expected = RequestUsage(input_tokens=10, output_tokens=5)
+    chunk = MagicMock()
+    chunk.usage = None
+
+    with patch.object(OpenAIStreamedResponse, "_map_usage", return_value=expected) as mock_super:
+        result = streamed_response._map_usage(chunk)
+
+    mock_super.assert_called_once_with(chunk)
+    assert result is expected
+    assert "co2_impact_factor_20" not in result.details
+
+
+def test_map_usage_without_impacts_does_not_add_co2_detail(streamed_response):
+    """When usage has no impacts in model_extra, co2_impact_factor_20 is not added."""
+    base_result = RequestUsage(input_tokens=10, output_tokens=5)
+    chunk = MagicMock()
+    chunk.usage = MagicMock()
+    chunk.usage.model_extra = {}  # no impacts
+
+    with patch.object(OpenAIStreamedResponse, "_map_usage", return_value=base_result):
+        result = streamed_response._map_usage(chunk)
+
+    assert "co2_impact_factor_20" not in result.details
+
+
+def test_map_usage_with_impacts_adds_co2_detail(streamed_response):
+    """When usage has impacts.kgCO2eq, co2_impact_factor_20 is stored in details."""
+    co2_value = 1.23e-9  # kgCO2eq
+    impacts = {"kgCO2eq": co2_value, "kWh": 4.5e-6}
+    base_result = RequestUsage(input_tokens=10, output_tokens=5)
+    chunk = MagicMock()
+    chunk.usage = MagicMock()
+    chunk.usage.model_extra = {"impacts": impacts}
+
+    with patch.object(OpenAIStreamedResponse, "_map_usage", return_value=base_result):
+        result = streamed_response._map_usage(chunk)
+
+    expected_factor = int(co2_value * 10**20)
+    assert result.details["co2_impact_factor_20"] == expected_factor
+
+
+def test_map_usage_with_zero_co2_does_not_add_detail(streamed_response):
+    """When impacts.kgCO2eq is 0.0 (falsy), co2_impact_factor_20 is not added."""
+    impacts = {"kgCO2eq": 0.0, "kWh": 0.0}
+    base_result = RequestUsage(input_tokens=10, output_tokens=5)
+    chunk = MagicMock()
+    chunk.usage = MagicMock()
+    chunk.usage.model_extra = {"impacts": impacts}
+
+    with patch.object(OpenAIStreamedResponse, "_map_usage", return_value=base_result):
+        result = streamed_response._map_usage(chunk)
+
+    assert "co2_impact_factor_20" not in result.details
+
+
+# ---------------------------------------------------------------------------
+# AlbertOpenAIChatModel._streamed_response_cls
+# ---------------------------------------------------------------------------
+
+
+def test_albert_chat_model_uses_albert_streamed_response_cls():
+    """AlbertOpenAIChatModel._streamed_response_cls returns AlbertOpenAIStreamedResponse."""
+    model = AlbertOpenAIChatModel(
+        model_name="test-model",
+        profile="test-profile",
+        provider=AlbertOpenAIProvider(
+            base_url="https://test-albert-api.com",
+            api_key="test-api-key",
+        ),
+    )
+    assert model._streamed_response_cls is AlbertOpenAIStreamedResponse

--- a/src/backend/chat/tests/agents/test_base_agent.py
+++ b/src/backend/chat/tests/agents/test_base_agent.py
@@ -8,6 +8,7 @@ from pydantic_ai.models.openai import OpenAIChatModel
 
 from chat.agents.base import BaseAgent
 from chat.llm_configuration import LLModel, LLMProfile, LLMProvider
+from chat.providers.albert_models import AlbertOpenAIChatModel, AlbertOpenAIProvider
 
 # ---------------------------------------------------------------------------
 # _concatenate_instructions hook — registration tests
@@ -134,6 +135,7 @@ def test_custom_model_openai_profile(settings):
                 kind="openai",
                 base_url="https://test.vllm/v1",
                 api_key="testkey",
+                co2_handling=None,
             ),
             is_active=True,
             system_prompt="direct",
@@ -147,3 +149,30 @@ def test_custom_model_openai_profile(settings):
     assert agent._model.profile.supports_tools is True
     assert agent._model.profile.supports_json_schema_output is False
     assert agent._model.profile.supports_json_object_output is True
+
+
+def test_custom_model_albert(settings):
+    """Test that a provider with hrid='albert' returns an AlbertOpenAIChatModel."""
+    settings.LLM_CONFIGURATIONS = {
+        "albert-model": LLModel(
+            hrid="albert-model",
+            model_name="albert-large",
+            human_readable_name="Albert Large",
+            profile=None,
+            provider=LLMProvider(
+                hrid="albert",
+                kind="openai",
+                base_url="https://albert.api.etalab.gouv.fr/v1",
+                api_key="testkey",
+                co2_handling="albert",
+            ),
+            is_active=True,
+            system_prompt="direct",
+            tools=[],
+        ),
+    }
+
+    agent = BaseAgent(model_hrid="albert-model")
+
+    assert isinstance(agent._model, AlbertOpenAIChatModel)
+    assert isinstance(agent._model._provider, AlbertOpenAIProvider)

--- a/src/backend/chat/tests/clients/pydantic_ai/test_extract_co2_from_usage.py
+++ b/src/backend/chat/tests/clients/pydantic_ai/test_extract_co2_from_usage.py
@@ -1,0 +1,23 @@
+"""Tests for _extract_co2_from_usage in chat.clients.pydantic_ai."""
+# pylint: disable=protected-access
+
+import pytest
+from pydantic_ai import RunUsage
+
+from chat.clients.pydantic_ai import _extract_co2_from_usage
+
+CO2_SCALE = 10**20
+
+
+@pytest.mark.parametrize(
+    ("usage", "expected_kg_co2"),
+    (
+        [RunUsage(details={"co2_impact_factor_20": int(1.23e-9 * CO2_SCALE)}), 1.23e-9],
+        [RunUsage(details={"other_metric": 36}), 0.0],
+        [RunUsage(details={"co2_impact_factor_20": 0.0}), 0.0],
+    ),
+)
+def test_extract_co2_from_usage(usage, expected_kg_co2):
+    """Typical Albert value: integer-scaled CO2 is divided back to kgCO2eq."""
+    result = _extract_co2_from_usage(usage)
+    assert result == pytest.approx(expected_kg_co2, rel=1e-9)

--- a/src/backend/chat/tests/clients/pydantic_ai/test_stream_methods.py
+++ b/src/backend/chat/tests/clients/pydantic_ai/test_stream_methods.py
@@ -95,6 +95,7 @@ async def test_stream_data_async_formats_as_sdk_events(ui_messages):
             usage=events_v4.Usage(
                 prompt_tokens=120,
                 completion_tokens=456,
+                co2_impact=0.0,
             ),
         )
 
@@ -105,5 +106,6 @@ async def test_stream_data_async_formats_as_sdk_events(ui_messages):
 
         assert results == [
             '0:"Hello"\n',
-            'd:{"finishReason":"stop","usage":{"promptTokens":120,"completionTokens":456}}\n',
+            'd:{"finishReason":"stop","usage":{"promptTokens":120,"completionTokens":456,'
+            '"co2Impact":0.0}}\n',
         ]

--- a/src/backend/chat/tests/test_ai_agent_service_co2.py
+++ b/src/backend/chat/tests/test_ai_agent_service_co2.py
@@ -1,0 +1,149 @@
+"""Tests for co2_impact accumulation in AIAgentService."""
+
+# pylint: disable=protected-access
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic_ai.messages import ModelResponse, TextPart
+
+from chat.clients.pydantic_ai import AIAgentService, StreamingState
+from chat.vercel_ai_sdk.core import events_v4
+
+
+def _fake_sync_to_async(fn):
+    """Replacement for sync_to_async: runs the callable directly (no thread pool)."""
+
+    async def wrapper(*args, **kwargs):
+        return fn(*args, **kwargs)
+
+    return wrapper
+
+
+@pytest.fixture(name="conversation")
+def conversation_fixture():
+    """Return a minimal mock conversation (no DB required)."""
+    conv = MagicMock()
+    conv.messages = []
+    conv.pydantic_messages = []
+    conv.agent_usage = {}
+    conv.title_set_by_user_at = None
+    return conv
+
+
+@pytest.fixture(name="service")
+def service_fixture(conversation):
+    """Instantiate AIAgentService without __init__, injecting only the conversation."""
+    s = object.__new__(AIAgentService)
+    s.conversation = conversation
+    return s
+
+
+@pytest.fixture(name="final_output")
+def final_output_fixture():
+    """Minimal model response for _prepare_update_conversation calls."""
+    return [ModelResponse(parts=[TextPart(content="Hello")], kind="response")]
+
+
+# --- _prepare_update_conversation: per-message annotation ---
+
+
+@pytest.mark.parametrize("co2_impact", [500, 123])
+def test_co2_annotation_added_when_nonzero(conversation, service, final_output, co2_impact):
+    """An annotation with the co2_impact value is added to the assistant message."""
+    service._prepare_update_conversation(
+        final_output=final_output,
+        usage={"promptTokens": 10, "completionTokens": 5, "co2_impact": co2_impact},
+        model_response_message_id="msg-1",
+    )
+
+    assistant_msg = conversation.messages[-1]
+    assert {"co2_impact": pytest.approx(float(co2_impact))} in (assistant_msg.annotations or [])
+
+
+def test_no_co2_annotation_when_zero(conversation, service, final_output):
+    """No co2_impact annotation is added when co2_impact is 0."""
+    service._prepare_update_conversation(
+        final_output=final_output,
+        usage={"promptTokens": 10, "completionTokens": 5, "co2_impact": 0},
+        model_response_message_id="msg-1",
+    )
+
+    assistant_msg = conversation.messages[-1]
+    co2_annotations = [a for a in (assistant_msg.annotations or []) if "co2_impact" in a]
+    assert co2_annotations == []
+
+
+# --- _prepare_update_conversation: cumulative usage across runs ---
+
+
+@pytest.mark.parametrize(
+    "run1,run2,expected",
+    [
+        pytest.param(
+            {"promptTokens": 10, "completionTokens": 5, "co2_impact": 1.5e-9},
+            {"promptTokens": 12, "completionTokens": 6, "co2_impact": 2.3e-9},
+            {"co2_impact": 1.5e-9 + 2.3e-9, "promptTokens": 22, "completionTokens": 11},
+            id="both_runs_have_co2",
+        ),
+        pytest.param(
+            {"promptTokens": 10, "completionTokens": 5, "co2_impact": 1.5e-9},
+            {"promptTokens": 10, "completionTokens": 5, "co2_impact": 0},
+            {"co2_impact": 1.5e-9, "promptTokens": 20, "completionTokens": 10},
+            id="second_run_has_no_co2",
+        ),
+    ],
+)
+def test_usage_accumulates_across_runs(  # pylint: disable=too-many-arguments,too-many-positional-arguments  # noqa: PLR0913
+    conversation,
+    service,
+    final_output,
+    run1,
+    run2,
+    expected,
+):
+    """agent_usage accumulates tokens and co2_impact across runs."""
+    service._prepare_update_conversation(
+        final_output=final_output, usage=run1, model_response_message_id="msg-1"
+    )
+    service._prepare_update_conversation(
+        final_output=final_output, usage=run2, model_response_message_id="msg-2"
+    )
+
+    for key, value in expected.items():
+        assert conversation.agent_usage[key] == pytest.approx(value), (
+            f"agent_usage[{key!r}] mismatch"
+        )
+
+
+# --- _finalize_conversation: FinishMessagePart co2_impact ---
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "co2_impact",
+    [
+        pytest.param(300, id="co2_nonzero"),
+        pytest.param(0, id="co2_zero"),
+    ],
+)
+async def test_finalize_emits_finish_message_with_co2(service, co2_impact):
+    """FinishMessagePart always emitted with co2_impact in usage."""
+    service._langfuse_available = False
+    usage = {"promptTokens": 10, "completionTokens": 5, "co2_impact": co2_impact}
+    state = StreamingState(model_response_message_id="test-msg-id")
+
+    with (
+        patch.object(service, "_agent_stop_streaming", new=AsyncMock()),
+        patch.object(service, "_prepare_update_conversation"),
+        patch("chat.clients.pydantic_ai.sync_to_async", side_effect=_fake_sync_to_async),
+    ):
+        events = [
+            event
+            async for event in service._finalize_conversation(
+                new_messages=[], run_output="Hello", usage=usage, state=state, image_key_mapping={}
+            )
+        ]
+
+    finish_events = [e for e in events if isinstance(e, events_v4.FinishMessagePart)]
+    assert len(finish_events) == 1
+    assert finish_events[0].usage.co2_impact == co2_impact

--- a/src/backend/chat/tests/views/chat/conversations/conftest.py
+++ b/src/backend/chat/tests/views/chat/conversations/conftest.py
@@ -47,6 +47,10 @@ def _create_openai_stream_data():
                     "prompt_tokens": 0,
                     "completion_tokens": 0,
                     "total_tokens": 0,
+                    "impacts": {
+                        "kWh": 5.0e-6,
+                        "kgCO2eq": 10.0e-6,
+                    },
                 },
             }
         )
@@ -81,6 +85,30 @@ def fixture_mock_openai_stream():
     See https://platform.openai.com/docs/api-reference/chat-streaming/streaming
     """
     return _create_mock_openai_route(with_delays=False)
+
+
+@pytest.fixture(name="mock_openai_stream_multi_calls")
+@freeze_time("2025-07-25T10:36:35.297675Z")
+def fixture_mock_openai_stream_multi_calls():
+    """
+    Mock the Albert OpenAI-compatible streaming response with CO2 impact data.
+
+    Uses side_effect (not return_value) so a fresh async generator is created
+    for every request — required when the same test makes multiple API calls.
+    """
+
+    def create_fresh_stream(_request):
+        albert_stream = _create_openai_stream_data()
+
+        async def mock_stream():
+            for line in albert_stream.splitlines(keepends=True):
+                yield line.encode()
+
+        return httpx.Response(200, stream=mock_stream())
+
+    return respx.post("https://www.external-ai-service.com/chat/completions").mock(
+        side_effect=create_fresh_stream
+    )
 
 
 @pytest.fixture(name="mock_openai_stream_slow")
@@ -146,7 +174,12 @@ def fixture_mock_openai_stream_with_title_generation():
                         "finish_reason": "stop",
                     }
                 ],
-                "usage": {"prompt_tokens": 50, "completion_tokens": 5, "total_tokens": 55},
+                "usage": {
+                    "prompt_tokens": 50,
+                    "completion_tokens": 5,
+                    "total_tokens": 55,
+                    "impacts": {"kWh": 5.0e-6, "kgCO2eq": 10.0e-6},
+                },
             },
         )
 
@@ -209,6 +242,10 @@ def fixture_mock_openai_no_stream():
                         "kWh": {"min": 0.0, "max": 0.0},
                         "kgCO2eq": {"min": 0.0, "max": 0.0},
                     },
+                    "impacts": {
+                        "kWh": 5.0e-6,
+                        "kgCO2eq": 10.0e-6,
+                    },
                     "details": [
                         {
                             "id": "chatcmpl-92c413bb5a45426299335d0621324654",
@@ -221,6 +258,10 @@ def fixture_mock_openai_no_stream():
                                 "carbon": {
                                     "kWh": {"min": 0.0, "max": 0.0},
                                     "kgCO2eq": {"min": 0.0, "max": 0.0},
+                                },
+                                "impacts": {
+                                    "kWh": 5.0e-6,
+                                    "kgCO2eq": 10.0e-6,
                                 },
                             },
                         }

--- a/src/backend/chat/tests/views/chat/conversations/test_conversation.py
+++ b/src/backend/chat/tests/views/chat/conversations/test_conversation.py
@@ -215,7 +215,8 @@ def test_post_conversation_data_protocol(api_client, mock_openai_stream, hello_c
         '0:"Hello"\n'
         '0:" there"\n'
         'f:{"messageId":"<mocked_uuid>"}\n'
-        'd:{"finishReason":"stop","usage":{"promptTokens":0,"completionTokens":0}}\n'
+        'd:{"finishReason":"stop","usage":{"promptTokens":0,"completionTokens":0'
+        ',"co2Impact":0.0}}\n'
     )
 
     assert mock_openai_stream.called
@@ -257,7 +258,8 @@ def test_post_conversation_data_protocol_triggers_keepalives(
         '0:"Hello"\n'
         '0:" there"\n'
         'f:{"messageId":"<mocked_uuid>"}\n'
-        'd:{"finishReason":"stop","usage":{"promptTokens":0,"completionTokens":0}}\n'
+        'd:{"finishReason":"stop","usage":{"promptTokens":0,"completionTokens":0'
+        ',"co2Impact":0.0}}\n'
         '2:[{"status": "WAITING"}]\n'
     )
 
@@ -349,7 +351,8 @@ def test_post_conversation_with_image(api_client, mock_openai_stream_image):
         '0:"I see a cat"\n'
         '0:" in the picture."\n'
         'f:{"messageId":"<mocked_uuid>"}\n'
-        'd:{"finishReason":"stop","usage":{"promptTokens":0,"completionTokens":0}}\n'
+        'd:{"finishReason":"stop","usage":{"promptTokens":0,"completionTokens":0'
+        ',"co2Impact":0.0}}\n'
     )
 
     # --- Verify the outgoing HTTP request body contains the image ---
@@ -513,7 +516,8 @@ def test_post_conversation_tool_call(api_client, mock_openai_stream_tool, settin
         '"Paris","temperature":22,"unit":"celsius"}}\n'
         '0:"The current weather in Paris is nice"\n'
         'f:{"messageId":"<mocked_uuid>"}\n'
-        'd:{"finishReason":"stop","usage":{"promptTokens":0,"completionTokens":0}}\n'
+        'd:{"finishReason":"stop","usage":{"promptTokens":0,"completionTokens":0'
+        ',"co2Impact":0.0}}\n'
     )
 
     # --- Verify the outgoing HTTP request body ---
@@ -681,7 +685,8 @@ def test_post_conversation_tool_call_fails(api_client, mock_openai_stream_tool, 
         "name: 'get_current_weather'. No tools available.\"}\n"
         '0:"I cannot give you an answer to that."\n'
         'f:{"messageId":"<mocked_uuid>"}\n'
-        'd:{"finishReason":"stop","usage":{"promptTokens":0,"completionTokens":0}}\n'
+        'd:{"finishReason":"stop","usage":{"promptTokens":0,"completionTokens":0'
+        ',"co2Impact":0.0}}\n'
     )
 
     # --- Verify the outgoing HTTP request body ---
@@ -877,7 +882,8 @@ def test_post_conversation_model_selection_new(
         '0:"Hello"\n'
         '0:" there"\n'
         'f:{"messageId":"<mocked_uuid>"}\n'
-        'd:{"finishReason":"stop","usage":{"promptTokens":0,"completionTokens":0}}\n'
+        'd:{"finishReason":"stop","usage":{"promptTokens":0,"completionTokens":0'
+        ',"co2Impact":0.0}}\n'
     )
 
     # We check the model used in the outgoing request to the AI service
@@ -959,13 +965,15 @@ def test_post_conversation_data_protocol_no_stream(
             '0:"tter"\n'
             '0:"ing."\n'
             'f:{"messageId":"<mocked_uuid>"}\n'
-            'd:{"finishReason":"stop","usage":{"promptTokens":0,"completionTokens":135}}\n'
+            'd:{"finishReason":"stop","usage":{"promptTokens":0,"completionTokens":135'
+            ',"co2Impact":0.0}}\n'
         )
     else:
         assert response_content == (
             '0:"The sky appears blue due to a phenomenon called Rayleigh scattering."\n'
             'f:{"messageId":"<mocked_uuid>"}\n'
-            'd:{"finishReason":"stop","usage":{"promptTokens":0,"completionTokens":135}}\n'
+            'd:{"finishReason":"stop","usage":{"promptTokens":0,"completionTokens":135'
+            ',"co2Impact":0.0}}\n'
         )
 
     assert mock_openai_no_stream.called
@@ -1083,7 +1091,8 @@ async def test_post_conversation_async(api_client, mock_openai_stream, monkeypat
         '0:"Hello"\n'
         '0:" there"\n'
         'f:{"messageId":"<mocked_uuid>"}\n'
-        'd:{"finishReason":"stop","usage":{"promptTokens":0,"completionTokens":0}}\n'
+        'd:{"finishReason":"stop","usage":{"promptTokens":0,"completionTokens":0'
+        ',"co2Impact":0.0}}\n'
     )
 
     assert mock_openai_stream.called
@@ -1175,7 +1184,8 @@ async def test_post_conversation_async_triggers_keepalive(
         '2:[{"status": "WAITING"}]\n'
         '0:" there"\n'
         'f:{"messageId":"<mocked_uuid>"}\n'
-        'd:{"finishReason":"stop","usage":{"promptTokens":0,"completionTokens":0}}\n'
+        'd:{"finishReason":"stop","usage":{"promptTokens":0,"completionTokens":0'
+        ',"co2Impact":0.0}}\n'
     )
 
     assert mock_openai_stream_slow.called
@@ -1277,7 +1287,8 @@ def test_post_conversation_oidc_refresh_enabled(  # pylint: disable=unused-argum
         '0:"Hello"\n'
         '0:" there"\n'
         'f:{"messageId":"<mocked_uuid>"}\n'
-        'd:{"finishReason":"stop","usage":{"promptTokens":0,"completionTokens":0}}\n'
+        'd:{"finishReason":"stop","usage":{"promptTokens":0,"completionTokens":0'
+        ',"co2Impact":0.0}}\n'
     )
 
     assert mock_openai_stream.called

--- a/src/backend/chat/tests/views/chat/conversations/test_conversation_with_document_upload.py
+++ b/src/backend/chat/tests/views/chat/conversations/test_conversation_with_document_upload.py
@@ -436,7 +436,8 @@ def test_post_conversation_with_document_upload(
         'is the content of the PDF.","score":0.9}]}\n'
         "0:\"From the document, I can see that it says 'Hello PDF'.\"\n"
         'f:{"messageId":"<mocked_uuid>"}\n'
-        'd:{"finishReason":"stop","usage":{"promptTokens":100,"completionTokens":20}}\n'
+        'd:{"finishReason":"stop","usage":{"promptTokens":100,"completionTokens":20,'
+        '"co2Impact":0.0}}\n'
     )
 
     # Check that the conversation was updated
@@ -693,7 +694,8 @@ def test_post_conversation_with_document_upload_feature_disabled(
         '0:"From the document, I can see that "\n'
         "0:\"it says 'Hello PDF'.\"\n"
         'f:{"messageId":"<mocked_uuid>"}\n'
-        'd:{"finishReason":"stop","usage":{"promptTokens":150,"completionTokens":25}}\n'
+        'd:{"finishReason":"stop","usage":{"promptTokens":150,"completionTokens":25,'
+        '"co2Impact":0.0}}\n'
     )
     # This behavior must be improved in the future to inform the user properly
     assert "Document upload feature is disabled, ignoring input documents." in caplog.text
@@ -779,7 +781,8 @@ def test_post_conversation_with_document_upload_summarize(  # pylint: disable=to
         'document discusses various topics."}\n'
         '0:"The document discusses various topics."\n'
         'f:{"messageId":"<mocked_uuid>"}\n'
-        'd:{"finishReason":"stop","usage":{"promptTokens":287,"completionTokens":19}}\n'
+        'd:{"finishReason":"stop","usage":{"promptTokens":287,"completionTokens":19,'
+        '"co2Impact":0.0}}\n'
     )
 
     # Check that the conversation was updated
@@ -1051,7 +1054,8 @@ def test_post_conversation_with_odt_document_upload(
         'is the content of the ODT.","score":0.9}]}\n'
         "0:\"From the document, I can see that it says 'Hello ODT'.\"\n"
         'f:{"messageId":"<mocked_uuid>"}\n'
-        'd:{"finishReason":"stop","usage":{"promptTokens":100,"completionTokens":20}}\n'
+        'd:{"finishReason":"stop","usage":{"promptTokens":100,"completionTokens":20,'
+        '"co2Impact":0.0}}\n'
     )
 
     # Check that the conversation was updated

--- a/src/backend/chat/tests/views/chat/conversations/test_conversation_with_document_url.py
+++ b/src/backend/chat/tests/views/chat/conversations/test_conversation_with_document_url.py
@@ -187,7 +187,8 @@ def test_post_conversation_with_local_pdf_document_url(
         'a:{"toolCallId":"XXX","result":{"state":"done"}}\n'
         '0:"This is a document about a single pixel."\n'
         'f:{"messageId":"<mocked_uuid>"}\n'
-        'd:{"finishReason":"stop","usage":{"promptTokens":50,"completionTokens":9}}\n'
+        'd:{"finishReason":"stop","usage":{"promptTokens":50,"completionTokens":9,'
+        '"co2Impact":0.0}}\n'
     )
 
     # Check that the conversation was updated
@@ -358,7 +359,8 @@ def test_post_conversation_with_local_document_wrong_url(
         'a:{"toolCallId":"XXX",'
         '"result":{"state":"error","error":"Document '
         'URL does not belong to the conversation."}}\n'
-        'd:{"finishReason":"error","usage":{"promptTokens":0,"completionTokens":0}}\n'
+        'd:{"finishReason":"error","usage":{"promptTokens":0,"completionTokens":0,'
+        '"co2Impact":0.0}}\n'
     )
 
     # Check that the conversation was not updated
@@ -426,7 +428,8 @@ def test_post_conversation_with_remote_document_url(
         'a:{"toolCallId":"XXX",'
         '"result":{"state":"error","error":"External document '
         'URL are not accepted yet."}}\n'
-        'd:{"finishReason":"error","usage":{"promptTokens":0,"completionTokens":0}}\n'
+        'd:{"finishReason":"error","usage":{"promptTokens":0,"completionTokens":0,'
+        '"co2Impact":0.0}}\n'
     )
 
     # Check that the conversation was not updated
@@ -622,7 +625,8 @@ def test_post_conversation_with_local_document_url_in_history(  # pylint: disabl
     assert response_content == (
         '0:"This is a document of square, very small and nice."\n'
         'f:{"messageId":"<mocked_uuid>"}\n'
-        'd:{"finishReason":"stop","usage":{"promptTokens":50,"completionTokens":11}}\n'
+        'd:{"finishReason":"stop","usage":{"promptTokens":50,"completionTokens":11,'
+        '"co2Impact":0.0}}\n'
     )
 
     # Check that the conversation was updated
@@ -931,7 +935,8 @@ def test_post_conversation_with_local_not_pdf_document_url(
         'a:{"toolCallId":"XXX","result":{"state":"done"}}\n'
         '0:"This is a document about you."\n'
         'f:{"messageId":"<mocked_uuid>"}\n'
-        'd:{"finishReason":"stop","usage":{"promptTokens":50,"completionTokens":7}}\n'
+        'd:{"finishReason":"stop","usage":{"promptTokens":50,"completionTokens":7,'
+        '"co2Impact":0.0}}\n'
     )
 
     # Check that the conversation was updated

--- a/src/backend/chat/tests/views/chat/conversations/test_conversation_with_history.py
+++ b/src/backend/chat/tests/views/chat/conversations/test_conversation_with_history.py
@@ -346,7 +346,8 @@ def test_post_conversation_data_protocol_with_history(
         '0:"Hello"\n'
         '0:" there"\n'
         'f:{"messageId":"<mocked_uuid>"}\n'
-        'd:{"finishReason":"stop","usage":{"promptTokens":0,"completionTokens":0}}\n'
+        'd:{"finishReason":"stop","usage":{"promptTokens":0,"completionTokens":0,'
+        '"co2Impact":0.0}}\n'
     )
 
     assert mock_openai_stream.called
@@ -531,7 +532,8 @@ def test_post_conversation_with_image_with_history(
         '0:"I see a cat"\n'
         '0:" in the picture."\n'
         'f:{"messageId":"<mocked_uuid>"}\n'
-        'd:{"finishReason":"stop","usage":{"promptTokens":0,"completionTokens":0}}\n'
+        'd:{"finishReason":"stop","usage":{"promptTokens":0,"completionTokens":0'
+        ',"co2Impact":0.0}}\n'
     )
 
     # --- Verify the outgoing HTTP request body contains the image ---
@@ -660,7 +662,8 @@ def test_post_conversation_tool_call_with_history(
         '"Paris","temperature":22,"unit":"celsius"}}\n'
         '0:"The current weather in Paris is nice"\n'
         'f:{"messageId":"<mocked_uuid>"}\n'
-        'd:{"finishReason":"stop","usage":{"promptTokens":0,"completionTokens":0}}\n'
+        'd:{"finishReason":"stop","usage":{"promptTokens":0,"completionTokens":0'
+        ',"co2Impact":0.0}}\n'
     )
 
     # --- Verify the outgoing HTTP request body ---
@@ -783,7 +786,8 @@ def test_post_conversation_tool_call_fails_with_history(
         "name: 'get_current_weather'. No tools available.\"}\n"
         '0:"I cannot give you an answer to that."\n'
         'f:{"messageId":"<mocked_uuid>"}\n'
-        'd:{"finishReason":"stop","usage":{"promptTokens":0,"completionTokens":0}}\n'
+        'd:{"finishReason":"stop","usage":{"promptTokens":0,"completionTokens":0'
+        ',"co2Impact":0.0}}\n'
     )
 
     # --- Verify the outgoing HTTP request body ---
@@ -1323,7 +1327,8 @@ def test_post_conversation_with_existing_image_history(
         '0:"Hello"\n'
         '0:" there"\n'
         'f:{"messageId":"<mocked_uuid>"}\n'
-        'd:{"finishReason":"stop","usage":{"promptTokens":0,"completionTokens":0}}\n'
+        'd:{"finishReason":"stop","usage":{"promptTokens":0,"completionTokens":0'
+        ',"co2Impact":0.0}}\n'
     )
 
     assert mock_openai_stream.called
@@ -1427,7 +1432,8 @@ def test_post_conversation_with_existing_tool_history(
         '"Paris","temperature":22,"unit":"celsius"}}\n'
         '0:"The current weather in Paris is nice"\n'
         'f:{"messageId":"<mocked_uuid>"}\n'
-        'd:{"finishReason":"stop","usage":{"promptTokens":0,"completionTokens":0}}\n'
+        'd:{"finishReason":"stop","usage":{"promptTokens":0,"completionTokens":0'
+        ',"co2Impact":0.0}}\n'
     )
 
     assert mock_openai_stream_tool.called
@@ -1650,7 +1656,8 @@ def test_post_conversation_add_image_to_conversation_with_tool_history(
         '0:"I see a cat"\n'
         '0:" in the picture."\n'
         'f:{"messageId":"<mocked_uuid>"}\n'
-        'd:{"finishReason":"stop","usage":{"promptTokens":0,"completionTokens":0}}\n'
+        'd:{"finishReason":"stop","usage":{"promptTokens":0,"completionTokens":0,'
+        '"co2Impact":0.0}}\n'
     )
 
     # Verify that the request to OpenAI included both

--- a/src/backend/chat/tests/views/chat/conversations/test_conversation_with_image_url.py
+++ b/src/backend/chat/tests/views/chat/conversations/test_conversation_with_image_url.py
@@ -138,7 +138,8 @@ def test_post_conversation_with_local_image_url(
     assert response_content == (
         '0:"This is an image of a single pixel."\n'
         'f:{"messageId":"<mocked_uuid>"}\n'
-        'd:{"finishReason":"stop","usage":{"promptTokens":50,"completionTokens":9}}\n'
+        'd:{"finishReason":"stop","usage":{"promptTokens":50,"completionTokens":9,'
+        '"co2Impact":0.0}}\n'
     )
 
     # Check that the conversation was updated
@@ -317,7 +318,8 @@ def test_post_conversation_with_local_image_wrong_url(
     assert response_content == (
         '0:"cannot read image."\n'
         'f:{"messageId":"<mocked_uuid>"}\n'
-        'd:{"finishReason":"stop","usage":{"promptTokens":50,"completionTokens":4}}\n'
+        'd:{"finishReason":"stop","usage":{"promptTokens":50,"completionTokens":4,'
+        '"co2Impact":0.0}}\n'
     )
 
     # We don't check conversation messages here because the LLM would
@@ -403,7 +405,8 @@ def test_post_conversation_with_remote_image_url(
     assert response_content == (
         '0:"This is an image of a single pixel."\n'
         'f:{"messageId":"<mocked_uuid>"}\n'
-        'd:{"finishReason":"stop","usage":{"promptTokens":50,"completionTokens":9}}\n'
+        'd:{"finishReason":"stop","usage":{"promptTokens":50,"completionTokens":9,'
+        '"co2Impact":0.0}}\n'
     )
 
     # Check that the conversation was updated
@@ -626,7 +629,8 @@ def test_post_conversation_with_local_image_url_in_history(
     assert response_content == (
         '0:"This is an image of square, very small and nice."\n'
         'f:{"messageId":"<mocked_uuid>"}\n'
-        'd:{"finishReason":"stop","usage":{"promptTokens":50,"completionTokens":11}}\n'
+        'd:{"finishReason":"stop","usage":{"promptTokens":50,"completionTokens":11,'
+        '"co2Impact":0.0}}\n'
     )
 
     # Check that the conversation was updated

--- a/src/backend/chat/tests/views/chat/conversations/test_conversation_with_project.py
+++ b/src/backend/chat/tests/views/chat/conversations/test_conversation_with_project.py
@@ -16,7 +16,8 @@ _HELLO_THERE_STREAM = (
     '0:"Hello"\n'
     '0:" there"\n'
     'f:{"messageId":"<mocked_uuid>"}\n'
-    'd:{"finishReason":"stop","usage":{"promptTokens":0,"completionTokens":0}}\n'
+    'd:{"finishReason":"stop","usage":{"promptTokens":0,"completionTokens":0,'
+    '"co2Impact":0.0}}\n'
 )
 
 

--- a/src/backend/chat/tests/views/chat/conversations/test_conversations_with_co2_impact.py
+++ b/src/backend/chat/tests/views/chat/conversations/test_conversations_with_co2_impact.py
@@ -1,0 +1,243 @@
+"""Integration tests for CO2 impact data in the Albert provider."""
+
+import json
+
+from django.utils import timezone
+
+import httpx
+import pytest
+import respx
+from freezegun import freeze_time
+
+from chat.factories import ChatConversationFactory
+from chat.llm_configuration import LLModel, LLMProvider
+
+pytestmark = pytest.mark.django_db(transaction=True)
+
+EXPECTED_CO2_IMPACT = 1e-05
+
+
+@pytest.fixture(name="albert_settings", autouse=True)
+def albert_settings_fixture(settings):
+    """Configure Django settings to use the Albert LLM provider."""
+    settings.LLM_DEFAULT_MODEL_HRID = "albert-model"
+    settings.LLM_CONFIGURATIONS = {
+        "albert-model": LLModel(
+            hrid="albert-model",
+            model_name="albert-large",
+            human_readable_name="Albert Large",
+            is_active=True,
+            system_prompt="You are a helpful test assistant :)",
+            tools=[],
+            provider=LLMProvider(
+                hrid="albert",
+                kind="openai",
+                base_url="https://www.external-ai-service.com/",
+                api_key="test-api-key",
+                co2_handling="albert",
+            ),
+        ),
+    }
+    return settings
+
+
+@pytest.fixture(name="albert_conversation")
+def albert_conversation_fixture(api_client):
+    """Create an Albert-backed conversation and return (conversation, url)
+    with the client logged in."""
+    chat_conversation = ChatConversationFactory(owner__language="en-us")
+    url = f"/api/v1.0/chats/{chat_conversation.pk}/conversation/?protocol=data"
+    api_client.force_login(chat_conversation.owner)
+    return chat_conversation, url
+
+
+def _make_stream(with_co2: bool) -> str:
+    """Build a minimal Albert-compatible SSE stream, optionally including CO2 data."""
+    usage: dict = {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
+    if with_co2:
+        usage["impacts"] = {"kWh": 5.0e-6, "kgCO2eq": EXPECTED_CO2_IMPACT}
+
+    return (
+        "data: "
+        + json.dumps(
+            {
+                "id": "chatcmpl-1234567890",
+                "created": timezone.make_naive(timezone.now()).timestamp(),
+                "choices": [{"delta": {"content": "Hello"}, "index": 0, "finish_reason": None}],
+                "object": "chat.completion.chunk",
+            }
+        )
+        + "\n\n"
+        "data: "
+        + json.dumps(
+            {
+                "id": "chatcmpl-1234567890",
+                "created": timezone.make_naive(timezone.now()).timestamp(),
+                "choices": [
+                    {
+                        "delta": {"content": " there"},
+                        "index": 0,
+                        "finish_reason": "stop",
+                    }
+                ],
+                "object": "chat.completion.chunk",
+                "usage": usage,
+            }
+        )
+        + "\n\n"
+        "data: [DONE]\n\n"
+    )
+
+
+@freeze_time("2025-07-25T10:36:35.297675Z")
+@respx.mock
+def test_albert_co2_impact_appears_in_annotations_and_stream(
+    api_client,
+    mock_openai_stream_multi_calls,
+    albert_conversation,
+):
+    """
+    CO2 impact from Albert API is stored in messages[1].annotations in the database
+    and accumulated in agent_usage across turns.
+    """
+    chat_conversation, url = albert_conversation
+    data = {
+        "messages": [
+            {
+                "id": "yuPoOuBkKA4FnKvk",
+                "role": "user",
+                "parts": [{"text": "Hello", "type": "text"}],
+                "content": "Hello",
+                "createdAt": "2025-07-03T15:22:17.105Z",
+            }
+        ]
+    }
+
+    response = api_client.post(url, data, format="json")
+    response_content = b"".join(response.streaming_content).decode("utf-8")
+    assert response_content
+    assert mock_openai_stream_multi_calls.called
+    chat_conversation.refresh_from_db()
+
+    # Verify the assistant message carries the CO2 annotation in the DB
+    assert chat_conversation.messages[1].annotations == [
+        {"co2_impact": pytest.approx(EXPECTED_CO2_IMPACT)}
+    ]
+    assert chat_conversation.agent_usage["co2_impact"] == pytest.approx(EXPECTED_CO2_IMPACT)
+
+    # Add new User message to trigger another assistant response and verify
+    # CO2 annotation appears again and is cumulative in agent_usage
+    chat_conversation.refresh_from_db()
+    second_data = {
+        "messages": [
+            data["messages"][0],
+            {
+                "id": chat_conversation.messages[1].id,
+                "role": "assistant",
+                "parts": [{"text": "Hello there", "type": "text"}],
+                "content": "Hello there",
+                "annotations": [{"co2_impact": EXPECTED_CO2_IMPACT}],
+                "createdAt": "2025-07-25T10:36:35.297675Z",
+            },
+            {
+                "id": "newMessageId12345",
+                "role": "user",
+                "parts": [{"text": "And again?", "type": "text"}],
+                "content": "And again?",
+                "createdAt": "2025-07-25T10:36:35.297675Z",
+            },
+        ]
+    }
+
+    second_response = api_client.post(url, second_data, format="json")
+
+    second_response_content = b"".join(second_response.streaming_content).decode("utf-8")
+    assert second_response_content
+    # Verify CO2 annotation appears on the new assistant message
+    chat_conversation.refresh_from_db()
+    assert chat_conversation.messages[3].annotations == [
+        {"co2_impact": pytest.approx(EXPECTED_CO2_IMPACT)}
+    ]
+    # agent_usage is the sum of each request usage
+    assert chat_conversation.agent_usage["co2_impact"] == pytest.approx(2 * EXPECTED_CO2_IMPACT)
+
+
+@freeze_time("2025-07-25T10:36:35.297675Z")
+@respx.mock
+def test_albert_co2_impact_preserved_when_second_request_has_no_co2(
+    api_client,
+    albert_conversation,
+):
+    """
+    When a subsequent request returns no CO2 data (e.g. transient absence of
+    the `impacts` field from Albert API), the previously accumulated co2_impact
+    in agent_usage must not be discarded.
+    """
+    chat_conversation, url = albert_conversation
+    call_count = 0
+
+    def create_response(_request):
+        nonlocal call_count
+        call_count += 1  # add co2 only in first call
+        stream_data = _make_stream(with_co2=call_count == 1)
+
+        async def mock_stream():
+            for line in stream_data.splitlines(keepends=True):
+                yield line.encode()
+
+        return httpx.Response(200, stream=mock_stream())
+
+    respx.post("https://www.external-ai-service.com/chat/completions").mock(
+        side_effect=create_response
+    )
+
+    # First request — Albert returns CO2 data
+    first_data = {
+        "messages": [
+            {
+                "id": "msg-1",
+                "role": "user",
+                "parts": [{"text": "Hello", "type": "text"}],
+                "content": "Hello",
+                "createdAt": "2025-07-25T10:36:35.297675Z",
+            }
+        ]
+    }
+    response = api_client.post(url, first_data, format="json")
+    assert b"".join(response.streaming_content).decode("utf-8")
+    chat_conversation.refresh_from_db()
+
+    assert chat_conversation.messages[1].annotations == [
+        {"co2_impact": pytest.approx(EXPECTED_CO2_IMPACT)}
+    ]
+    assert chat_conversation.agent_usage["co2_impact"] == pytest.approx(EXPECTED_CO2_IMPACT)
+
+    # Second request — Albert returns NO CO2 data
+    second_data = {
+        "messages": [
+            first_data["messages"][0],
+            {
+                "id": chat_conversation.messages[1].id,
+                "role": "assistant",
+                "parts": [{"text": "Hello there", "type": "text"}],
+                "content": "Hello there",
+                "annotations": [{"co2_impact": EXPECTED_CO2_IMPACT}],
+                "createdAt": "2025-07-25T10:36:35.297675Z",
+            },
+            {
+                "id": "msg-3",
+                "role": "user",
+                "parts": [{"text": "Again?", "type": "text"}],
+                "content": "Again?",
+                "createdAt": "2025-07-25T10:36:35.297675Z",
+            },
+        ]
+    }
+    second_response = api_client.post(url, second_data, format="json")
+    assert b"".join(second_response.streaming_content).decode("utf-8")
+    chat_conversation.refresh_from_db()
+
+    # New assistant message should have no CO2 annotation (none returned by API)
+    assert chat_conversation.messages[3].annotations in (None, [])
+    # agent_usage must still carry the CO2 from the first request — not reset to zero
+    assert chat_conversation.agent_usage["co2_impact"] == pytest.approx(EXPECTED_CO2_IMPACT)

--- a/src/backend/chat/vercel_ai_sdk/core/events_v4.py
+++ b/src/backend/chat/vercel_ai_sdk/core/events_v4.py
@@ -135,7 +135,7 @@ class MessageAnnotationPart(BaseEvent):
     annotations: List[JSONValue]
 
     def model_dump_json(self, *args, **kwargs) -> str:
-        return json.dumps(self.data)
+        return json.dumps(self.annotations)
 
 
 class ErrorPart(BaseEvent):
@@ -221,6 +221,7 @@ class Usage(ConfiguredBaseModel):
 
     prompt_tokens: int
     completion_tokens: int
+    co2_impact: Optional[float] = None
 
 
 class FinishStepPart(BaseEvent):

--- a/src/backend/conversations/configuration/llm/default.json
+++ b/src/backend/conversations/configuration/llm/default.json
@@ -37,7 +37,8 @@
       "hrid": "default-provider",
       "base_url": "settings.AI_BASE_URL",
       "api_key": "settings.AI_API_KEY",
-      "kind": "openai"
+      "kind": "openai",
+      "co2_handling": null
     }
   ]
 }


### PR DESCRIPTION
## Purpose

We want to display carbon impact of each message in front.
To do so we need to extract co2 impact data from AlbertAPI response.

Other models shouls keep working even thought they don't provider CO2 impact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CO2 impact tracking to display environmental metrics for chat responses from supported providers
  * Added support for Albert AI provider with integrated carbon emissions monitoring

* **Bug Fixes**
  * Fixed annotation serialization in message responses

* **Documentation**
  * Updated LLM configuration documentation with new CO2 handling provider options
<!-- end of auto-generated comment: release notes by coderabbit.ai -->