### PR TITLE
✨(dev) add dependencies and doc to use debug mode locally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to
 - ✨(front) allow typing while LLM is generating a response
 - ⬆️(dependencies) update back and front dependencies
 - 💄(ui) new header
+- ✨(back) add debug mode setup for local development
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -166,6 +166,8 @@ You first need to create a superuser account:
 $ make superuser
 ```
 
+To run the app locally with breakpoints, read: [Debug Mode](docs/debug_mode.md).
+
 ## Documentation 📚
 
 Additional documentation is available in the `docs/` directory:
@@ -177,6 +179,7 @@ Additional documentation is available in the `docs/` directory:
 - [Installation Guide](docs/installation.md) - Deploy on a Kubernetes cluster
 - [Theming](docs/theming.md) - Customize the application appearance
 - [Architecture](docs/architecture.md) - Technical architecture overview
+
 
 ## Licence 📝
 

--- a/docs/debug_mode.md
+++ b/docs/debug_mode.md
@@ -1,0 +1,83 @@
+# Local Development
+
+## Debug Mode
+
+Run the Django backend with [debugpy](https://github.com/microsoft/debugpy) so you can attach a
+  remote debugger from your IDE.
+
+> **Note:** With `--wait-for-client`, the server **will not start** until a debugger is
+attached. Attach your IDE before expecting the app to respond.
+
+### 1. Create `compose.override.yml` at the project root
+
+```yaml
+name: conversations
+
+services:
+  app-dev:
+    ports:
+      - "8071:8000"  # App accessible at http://localhost:8071
+      - "5678:5678"  # Debugger port
+    command: >
+      python -m debugpy --listen 0.0.0.0:5678 --wait-for-client
+      manage.py runserver 0.0.0.0:8000 --nothreading --noreload
+```
+
+### 2. Start the stack
+
+```shell
+make run
+```
+
+The server will block until a debugger connects on port 5678.
+
+### 3. Attach your debugger
+
+#### VS Code
+
+Create `.vscode/launch.json`:
+
+```json
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Python: Django Docker",
+      "type": "debugpy",
+      "request": "attach",
+      "connect": {
+        "host": "localhost",
+        "port": 5678
+      },
+      "pathMappings": [
+        {
+          "localRoot": "${workspaceFolder}/src/backend",
+          "remoteRoot": "/app"
+        }
+      ]
+    }
+  ]
+}
+```
+
+Then run the **Python: Django Docker** launch configuration (`F5`).
+
+#### PyCharm
+
+> **Note:** debugpy support and Attach to DAP are available since PyCharm 2026.1.
+
+1. Go to **Settings > Python > Debugger** and set **Debugger mode** to `debugpy`
+2. Go to **Run > Edit Configurations...**
+3. Click **+** and select **Attach to DAP**
+4. Configure the following:
+   - **Remote address**: `localhost:5678`
+   - **Local project path**: `<project root>/src/backend`
+   - **Remote project path**: `/app`
+5. Click **OK**, then start the debug configuration (**Debug** button or `Shift+F9`)
+
+### Debug controls
+
+- `F8` - Step Over
+- `F7` - Step Into
+- `Shift+F8` - Step Out
+- `F9` - Resume

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -99,6 +99,7 @@ dev = [
     "respx==0.22.0",
     "ruff==0.14.5",
     "types-requests==2.32.4.20250913",
+    "debugpy>=1.8.20",    
 ]
 
 [tool.setuptools]
@@ -177,3 +178,4 @@ python_files = [
     "test_*.py",
     "tests.py",
 ]
+

--- a/src/backend/uv.lock
+++ b/src/backend/uv.lock
@@ -451,6 +451,7 @@ dependencies = [
 
 [package.optional-dependencies]
 dev = [
+    { name = "debugpy" },
     { name = "dirty-equals" },
     { name = "django-extensions" },
     { name = "django-test-migrations" },
@@ -479,6 +480,7 @@ requires-dist = [
     { name = "beautifulsoup4", specifier = "==4.14.2" },
     { name = "boto3", specifier = "==1.40.73" },
     { name = "brotli", specifier = "==1.2.0" },
+    { name = "debugpy", marker = "extra == 'dev'", specifier = ">=1.8.20" },
     { name = "deprecated" },
     { name = "dirty-equals", marker = "extra == 'dev'", specifier = "==0.10.0" },
     { name = "django", specifier = "==5.2.12" },
@@ -644,6 +646,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a9/30/064144f0df1749e7bb5faaa7f52b007d7c2d08ec08fed8411aba87207f68/dateparser-1.2.2.tar.gz", hash = "sha256:986316f17cb8cdc23ea8ce563027c5ef12fc725b6fb1d137c14ca08777c5ecf7", size = 329840, upload-time = "2025-06-26T09:29:23.211Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/87/22/f020c047ae1346613db9322638186468238bcfa8849b4668a22b97faad65/dateparser-1.2.2-py3-none-any.whl", hash = "sha256:5a5d7211a09013499867547023a2a0c91d5a27d15dd4dbcea676ea9fe66f2482", size = 315453, upload-time = "2025-06-26T09:29:21.412Z" },
+]
+
+[[package]]
+name = "debugpy"
+version = "1.8.20"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/b7/cd8080344452e4874aae67c40d8940e2b4d47b01601a8fd9f44786c757c7/debugpy-1.8.20.tar.gz", hash = "sha256:55bc8701714969f1ab89a6d5f2f3d40c36f91b2cbe2f65d98bf8196f6a6a2c33", size = 1645207, upload-time = "2026-01-29T23:03:28.199Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/e2/fc500524cc6f104a9d049abc85a0a8b3f0d14c0a39b9c140511c61e5b40b/debugpy-1.8.20-cp313-cp313-macosx_15_0_universal2.whl", hash = "sha256:5dff4bb27027821fdfcc9e8f87309a28988231165147c31730128b1c983e282a", size = 2539560, upload-time = "2026-01-29T23:03:48.738Z" },
+    { url = "https://files.pythonhosted.org/packages/90/83/fb33dcea789ed6018f8da20c5a9bc9d82adc65c0c990faed43f7c955da46/debugpy-1.8.20-cp313-cp313-manylinux_2_34_x86_64.whl", hash = "sha256:84562982dd7cf5ebebfdea667ca20a064e096099997b175fe204e86817f64eaf", size = 4293272, upload-time = "2026-01-29T23:03:50.169Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/25/b1e4a01bfb824d79a6af24b99ef291e24189080c93576dfd9b1a2815cd0f/debugpy-1.8.20-cp313-cp313-win32.whl", hash = "sha256:da11dea6447b2cadbf8ce2bec59ecea87cc18d2c574980f643f2d2dfe4862393", size = 5331208, upload-time = "2026-01-29T23:03:51.547Z" },
+    { url = "https://files.pythonhosted.org/packages/13/f7/a0b368ce54ffff9e9028c098bd2d28cfc5b54f9f6c186929083d4c60ba58/debugpy-1.8.20-cp313-cp313-win_amd64.whl", hash = "sha256:eb506e45943cab2efb7c6eafdd65b842f3ae779f020c82221f55aca9de135ed7", size = 5372930, upload-time = "2026-01-29T23:03:53.585Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/c3/7f67dea8ccf8fdcb9c99033bbe3e90b9e7395415843accb81428c441be2d/debugpy-1.8.20-py2.py3-none-any.whl", hash = "sha256:5be9bed9ae3be00665a06acaa48f8329d2b9632f15fd09f6a9a8c8d9907e54d7", size = 5337658, upload-time = "2026-01-29T23:04:17.404Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Purpose

I want to run the app (backend) in debug mode with breakpoints locally.


## Proposal

- [x] Add debugpy to dev 
- [x] Add doc for `vscode` IDE
- [x] Add doc for `PyCharm` IDE


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a local-development guide for running the backend with remote debugger support and IDE attach instructions; README now links to the guide.
* **Bug Fixes**
  * Fixed behavior so source/external links correctly open in a new tab and apply secure link attributes.
* **Changelog**
  * Updated Unreleased notes to mention the link behavior fix and debug-mode setup.
* **Chores**
  * Added a development dependency to enable remote debugging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->