### PR TITLE
💄(ui) codeblock light mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to
 ### Changed
 
 - 🐛(fix) source links should open a new tab
+- 💄(ui) codeblock light mode
 - ✨(front) allow typing while LLM is generating a response
 - ⬆️(dependencies) update back and front dependencies
 - 💄(ui) new header

--- a/src/frontend/apps/conversations/src/features/chat/components/Chat.tsx
+++ b/src/frontend/apps/conversations/src/features/chat/components/Chat.tsx
@@ -740,7 +740,7 @@ export const Chat = ({
                       <Box
                         $direction="column"
                         $width="100%"
-                        $maxWidth="750px"
+                        $maxWidth="var(--chat-content-max-width, 750px)"
                         $margin={{ all: 'auto', top: 'base', bottom: '0' }}
                         $padding={{ left: '13px', bottom: 'md' }}
                       >
@@ -766,7 +766,7 @@ export const Chat = ({
             $align="start"
             $gap="6px"
             $width="100%"
-            $maxWidth="750px"
+            $maxWidth="var(--chat-content-max-width, 750px)"
             $margin={{ all: 'auto', top: 'base', bottom: '0' }}
             $padding={{ left: '13px', bottom: 'md' }}
             $css={`

--- a/src/frontend/apps/conversations/src/features/chat/components/ChatError.tsx
+++ b/src/frontend/apps/conversations/src/features/chat/components/ChatError.tsx
@@ -18,7 +18,7 @@ export const ChatError = ({ hasLastSubmission, onRetry }: ChatErrorProps) => {
       $direction="column"
       $gap="6px"
       $width="100%"
-      $maxWidth="750px"
+      $maxWidth="var(--chat-content-max-width, 750px)"
       $margin={{ all: 'auto', top: 'base', bottom: 'md' }}
       $padding={{ left: '13px' }}
     >

--- a/src/frontend/apps/conversations/src/features/chat/components/CodeBlock.tsx
+++ b/src/frontend/apps/conversations/src/features/chat/components/CodeBlock.tsx
@@ -21,24 +21,24 @@ const CopyCodeButton = ({ onCopy }: CopyCodeButtonProps) => {
         top: 8px;
         right: 8px;
         padding: 6px 10px;
-        background: rgba(0, 0, 0, 0.03);
-        border: 1px solid rgba(255, 255, 255, 0.15);
+        background: var(--c--contextuals--background--surface--primary);
+        border: 0px solid var(--c--contextuals--border--semantic--neutral--tertiary);
         border-radius: 4px;
         cursor: pointer;
         font-size: 12px;
+        border: 1px solid var(--c--contextuals--border--semantic--neutral--tertiary);
         font-weight: 500;
-        color: #fff;
+        color: var(--c--contextuals--content--semantic--neutral--tertiary);
         display: flex;
         flex-direction: row;
         align-items: center;
         gap: 4px;
         z-index: 10;
         transition: all 0.2s;
-        box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
         width: fit-content;
         &:hover {
-          background:rgba(255, 255, 255, 0.1);
-          border: 1px solid rgba(255, 255, 255, 0.20);
+          background: var(--c--contextuals--background--semantic--neutral--tertiary);
+          border: 1px solid var(--c--contextuals--border--semantic--neutral--tertiary);
         }
       `}
     >

--- a/src/frontend/apps/conversations/src/features/chat/components/MessageBlock.tsx
+++ b/src/frontend/apps/conversations/src/features/chat/components/MessageBlock.tsx
@@ -7,6 +7,7 @@ import remarkGfm from 'remark-gfm';
 import remarkMath from 'remark-math';
 
 import { Text } from '@/components';
+import { useCunninghamTheme } from '@/cunningham';
 import { CodeBlock } from '@/features/chat/components/CodeBlock';
 
 // Memoized markdown plugins - created once at module level
@@ -19,14 +20,29 @@ import { getHighlighter } from '../utils/shiki';
 const highlighterPromise = getHighlighter();
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const rehypePluginsPromise: Promise<any[]> = highlighterPromise.then(
+const rehypePluginsDarkPromise: Promise<any[]> = highlighterPromise.then(
   (highlighter) => [
     rehypeKatex,
     [
       rehypeShikiFromHighlighter,
       highlighter,
       {
-        theme: 'github-dark-dimmed',
+        theme: 'ayu-dark',
+        fallbackLanguage: 'plaintext',
+      },
+    ],
+  ],
+);
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const rehypePluginsLightPromise: Promise<any[]> = highlighterPromise.then(
+  (highlighter) => [
+    rehypeKatex,
+    [
+      rehypeShikiFromHighlighter,
+      highlighter,
+      {
+        theme: 'ayu-light',
         fallbackLanguage: 'plaintext',
       },
     ],
@@ -61,7 +77,12 @@ const MARKDOWN_COMPONENTS: Components = {
 
 export const CompletedMarkdownBlock = React.memo(
   ({ content }: { content: string }) => {
-    const rehypePlugins = use(rehypePluginsPromise);
+    const { theme } = useCunninghamTheme();
+    const rehypePlugins = use(
+      theme.includes('dark')
+        ? rehypePluginsDarkPromise
+        : rehypePluginsLightPromise,
+    );
     return (
       <MarkdownHooks
         remarkPlugins={REMARK_PLUGINS}

--- a/src/frontend/apps/conversations/src/features/chat/utils/shiki.ts
+++ b/src/frontend/apps/conversations/src/features/chat/utils/shiki.ts
@@ -10,11 +10,12 @@ import langPython from 'shiki/langs/python.mjs';
 import langSql from 'shiki/langs/sql.mjs';
 import langTypescript from 'shiki/langs/typescript.mjs';
 import langYaml from 'shiki/langs/yaml.mjs';
-import themeDimmed from 'shiki/themes/github-dark-dimmed.mjs';
+import themeDimmed from 'shiki/themes/ayu-dark.mjs';
+import themeLight from 'shiki/themes/ayu-light.mjs';
 
 export const getHighlighter = () =>
   createHighlighterCore({
-    themes: [themeDimmed],
+    themes: [themeDimmed, themeLight],
     langs: [
       langJavascript,
       langTypescript,


### PR DESCRIPTION
<img width="1201" height="841" alt="Screenshot 2026-04-08 at 14 20 45" src="https://github.com/user-attachments/assets/0ed996eb-756b-4c76-8f00-b93f7132373c" />


<img width="1207" height="834" alt="Screenshot 2026-04-08 at 14 22 34" src="https://github.com/user-attachments/assets/697b174e-7e0a-446f-8bdf-9cdb7af67f33" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Light-mode support for code blocks with theme-aware syntax highlighting that follows the app theme.

* **Style**
  * Updated code block button visuals to use semantic color variables.
  * Chat content width is now responsive and configurable via a CSS variable.

* **Documentation**
  * Changelog updated to note codeblock light mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->