### PR TITLE
🐛(fix) source links should open a new tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ### Changed
 
+- 🐛(fix) source links should open a new tab
 - ✨(front) allow typing while LLM is generating a response
 - ⬆️(dependencies) update back and front dependencies
 - 💄(ui) new header

--- a/src/frontend/apps/conversations/src/components/Link.tsx
+++ b/src/frontend/apps/conversations/src/components/Link.tsx
@@ -50,11 +50,15 @@ export const StyledLink = memo(function StyledLink({
         return;
       }
 
+      if (props.target === '_blank') {
+        return;
+      }
+
       e.preventDefault();
       onClick?.(e);
       routerRef.current.push(href);
     },
-    [href, onClick],
+    [href, onClick, props.target],
   );
 
   return <Anchor href={href} onClick={handleClick} {...props} />;

--- a/src/frontend/apps/conversations/src/features/footer/Footer.tsx
+++ b/src/frontend/apps/conversations/src/features/footer/Footer.tsx
@@ -123,7 +123,8 @@ export const Footer = () => {
                 <StyledLink
                   key={label}
                   href={href}
-                  target="__blank"
+                  target="_blank"
+                  rel="noopener noreferrer"
                   $css={`
                     gap:0.2rem;
                     transition: box-shadow 0.3s;
@@ -158,6 +159,8 @@ export const Footer = () => {
               <StyledLink
                 key={label}
                 href={href}
+                target="_blank"
+                rel="noopener noreferrer"
                 $css={css`
                   padding-right: 1rem;
                   &:not(:last-child) {
@@ -199,7 +202,8 @@ export const Footer = () => {
             {bottomInformation.link && (
               <StyledLink
                 href={bottomInformation.link.href}
-                target="__blank"
+                target="_blank"
+                rel="noopener noreferrer"
                 $css={css`
                   display: inline-flex;
                   box-shadow: 0px 1px 0 0


### PR DESCRIPTION
fix source links target blank

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * External links now correctly open in a new browser tab instead of navigating within the app.
  * Link click handling updated so new-tab navigation uses the browser’s default behavior and no longer triggers internal routing.
  * Added safer new-tab attributes (rel="noopener noreferrer") to external links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->