### PR TITLE
✨(documents): make document context hybrid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to
 - ✨(back) add ODT parsing support
 - ✨(back) add self-documentation tool
 - ✅(front) add tests for SourceItem component
+- ✨(documents) make document context hybrid
 
 ### Changed
 

--- a/docs/attachments.md
+++ b/docs/attachments.md
@@ -34,8 +34,9 @@ without routing the file data through the backend server.
 Note about documents: The system uses a tool called **MarkItDown** to convert various document formats 
 (Word, Excel, PowerPoint, text files, etc.) into Markdown text for processing by LLMs. When at least 
 one non-PDF/image document is attached, the system enables:
- - a **Retrieval-Augmented Generation (RAG)** search tool to allow the LLM to query relevant sections of the documents.
- - a **summarization tool** to provide document summaries on user request.
+ - a **hybrid context delivery** that inlines small documents directly into the LLM's system instructions (`full-context`) and exposes the rest via tools (`tool_call_only`). The split is driven by the model's context window size and a configurable budget ratio. See [Other Document Types](#other-document-types).
+ - a **Retrieval-Augmented Generation (RAG)** search tool (`document_search_rag`) to query relevant sections of any attached document. Supports an optional `document_id` argument to target a single attachment.
+ - a **summarization tool** (`summarize`) to provide document summaries on user request, also supporting `document_id` targeting.
    ⚠️ naive implementation at the moment, needs improvement before being used in production.
 
 ## Supported Attachment Types
@@ -279,12 +280,90 @@ When a user sends a message with attachments, the system processes them differen
 
 2. **Conversion to Markdown**: Documents are converted using **MarkItDown** library or using the "Albert API" for PDFs.
 
-3. **RAG (Retrieval-Augmented Generation)**:
-   - Converted text is indexed in a vector database
-   - The LLM uses a `document_rag_search` tool to query relevant sections
-   - Only relevant chunks are sent to the LLM to fit context windows
+3. **Hybrid context delivery**: On every chat turn, each text attachment is exposed to the LLM in one of two modes (described in detail below):
+   - **`full-context`**: small enough documents are inlined directly into the system instructions so the LLM can read them without calling a tool.
+   - **`tool_call_only`**: oversized or evicted documents stay reachable via the `document_search_rag` and `summarize` tools.
 
-4. **Summarization tool** if needed.
+4. **RAG (Retrieval-Augmented Generation)**:
+   - Converted text is indexed in a vector database (Albert collection or Find index).
+   - The LLM uses the `document_search_rag` tool to query relevant chunks. The tool accepts an optional `document_id` argument to target a single attachment.
+
+5. **Summarization tool** if needed (also accepts `document_id`).
+
+#### Documents listing in system instructions
+
+When at least one text attachment exists, the assembled system instruction includes a JSON listing of the attached documents. This is the LLM's "table of contents" — it tells the model which documents are present, which are inlined as full content, and which can only be reached via tools.
+
+Listing shape (sent on every turn):
+
+```json
+{
+  "documents_order": "newest_to_oldest",
+  "documents": [
+    {
+      "document_id": "<UUID>",
+      "title": "report.pdf",
+      "access": "full-context",
+      "content": "<full markdown of the document>",
+      "info": "last_uploaded_document"
+    },
+    {
+      "document_id": "<UUID>",
+      "title": "big_dataset.csv",
+      "access": "tool_call_only",
+      "content": "available via tools",
+      "info": null
+    }
+  ],
+  "note": "Documents marked 'tool_call_only' are accessible through tools like RAG search or summary. Documents marked 'full-context' can be directly manipulated by you, ..."
+}
+```
+
+Notes:
+- `document_id` is the attachment's UUID and is the value the model passes back to `document_search_rag(document_id=...)` or `summarize(document_id=...)` to target a specific document.
+- `info` flags the first and last uploaded documents to help the LLM reason about temporal context.
+- `access` is the per-doc decision made by the inlining policy described below.
+
+#### Inlining policy and FIFO eviction
+
+The decision of which documents are inlined as `full-context` vs left as `tool_call_only` is made by `chat/document_context_builder.py:build_document_context_instruction` on each turn:
+
+1. Compute the `document_budget` in tokens:
+   ```text
+   document_budget = max(int(model.max_token_context * DOCUMENT_CONTEXT_BUDGET_RATIO)
+                         - DOCUMENT_CONTEXT_SECURITY_BUFFER_TOKENS, 0)
+   ```
+2. Iterate documents oldest-first. For each document:
+   - If its token count exceeds the whole budget alone → keep `tool_call_only`.
+   - Otherwise, while adding it would overflow the budget, **evict the oldest currently-inlined document** (FIFO): demote it to `tool_call_only`, free its tokens.
+   - Once it fits, mark it `full-context` and inline its content.
+3. Edge cases:
+   - If the model has no `max_token_context` configured → all documents stay `tool_call_only` (warning logged).
+   - If `DOCUMENT_CONTEXT_BUDGET_RATIO` is `0` → all documents stay `tool_call_only`.
+   - If reading an attachment from object storage fails → that document stays `tool_call_only` and the failure is logged; other documents are not affected.
+
+Token estimation uses `tiktoken` with the `cl100k_base` encoding (GPT-4 tokenizer). For non-OpenAI models (Mistral, Llama, Anthropic) actual usage may run 5-15% higher; the security buffer absorbs that drift.
+
+The assembled instruction is **cached** per turn keyed on:
+`conversation_id`, `user_id`, `model_hrid`, `model.max_token_context`, `DOCUMENT_CONTEXT_BUDGET_RATIO`, `DOCUMENT_CONTEXT_SECURITY_BUFFER_TOKENS`, and a fingerprint of `(attachment.id, attachment.updated_at)` for every text attachment. Any attachment add / remove / edit, or any settings change, invalidates the cache. TTL is 30 minutes (`CACHE_TIMEOUT`).
+
+#### Targeted document operations (`document_id`)
+
+Both RAG-related tools accept an optional `document_id` argument:
+
+- `document_search_rag(query, document_id=None)`
+- `summarize(instructions=None, document_id=None)`
+
+When the model includes `document_id`, the tool:
+1. Validates the value is a UUID.
+2. Looks it up against the conversation's text attachments. **If the UUID does not belong to the current conversation, the tool raises `ModelRetry` ("not found")** — this is the IDOR boundary.
+3. Resolves the attachment's actual `document_name` (stripping a `.md` suffix if the attachment was converted, e.g. `report.pdf.md` → `report.pdf`) and forwards it to the backend.
+
+The Albert backend uses this name as a `metadata_filters` clause on `/v1/search`. The Find backend currently ignores `document_name` filtering — this is a known gap.
+
+#### Empty filtered RAG result → `ModelRetry`
+
+If the model targeted a document via `document_id` and the backend returned no results, `document_search_rag` raises `ModelRetry` with explicit guidance: either retry without `document_id` (and explicitly tell the user the search was broadened) or stop and tell the user the targeted document does not contain the requested information. This replaces an earlier silent fallback that quietly widened scope without informing the model. See `chat/tools/document_search_rag.py` for the exact text.
 
 ### Processing Strategy Decision Tree
 
@@ -292,7 +371,7 @@ When a user sends a message with attachments, the system processes them differen
 - **No documents**: Standard conversation
 - **Images**: Send as direct (presigned) URLs to the LLM
 - **Only PDFs**: Send as direct (presigned) URLs to the LLM
-- **Other documents present**: Enable RAG search tool + convert to Markdown
+- **Other documents present**: Convert to Markdown, build the documents listing for the system instruction, inline what fits the budget as `full-context`, expose the rest via the `document_search_rag` and `summarize` tools (with optional `document_id` targeting).
 
 ---
 
@@ -310,6 +389,8 @@ When a user sends a message with attachments, the system processes them differen
 | `MALWARE_DETECTION_BACKEND`                  | `DummyBackend` | Malware scanning backend class                             |
 | `MALWARE_DETECTION_PARAMETERS`               | `{}`           | Backend-specific configuration                             |
 | `RAG_FILES_ACCEPTED_FORMATS`                 | See below      | List of MIME types accepted for file uploads               |
+| `DOCUMENT_CONTEXT_BUDGET_RATIO`              | `0.5`          | Fraction of `model.max_token_context` reserved for inlined documents (0 disables full-context inlining; everything stays `tool_call_only`) |
+| `DOCUMENT_CONTEXT_SECURITY_BUFFER_TOKENS`    | `1000`         | Tokens subtracted from the inlining budget to absorb tokenizer drift on non-OpenAI models |
 
 #### RAG_FILES_ACCEPTED_FORMATS
 
@@ -354,6 +435,12 @@ RAG_FILES_ACCEPTED_FORMATS = [
 
  - This setting controls frontend validation only. Backend validation should also be implemented for security.
  - Future improvements may include per-model file type restrictions.
+
+### Per-model setting: `max_token_context`
+
+Each entry in `LLM_CONFIGURATIONS` accepts a `max_token_context` integer field declaring the model's context window size. When set, it drives the inlining budget for the documents listing (`document_budget = max_token_context * DOCUMENT_CONTEXT_BUDGET_RATIO - DOCUMENT_CONTEXT_SECURITY_BUFFER_TOKENS`).
+
+If a model has no `max_token_context`, all of its documents are kept `tool_call_only` regardless of size and a warning is logged on every chat turn. Setting the field accurately matters: too low and small documents get pushed to RAG-only when they could be inlined; too high and the LLM may exceed its real window.
 
 ### Storage Configuration
 

--- a/src/backend/chat/agent_rag/document_rag_backends/albert_rag_backend.py
+++ b/src/backend/chat/agent_rag/document_rag_backends/albert_rag_backend.py
@@ -165,42 +165,62 @@ class AlbertRagBackend(BaseRagBackend):  # pylint: disable=too-many-instance-att
             logger.debug(response.json())
             response.raise_for_status()
 
-    def search(self, query: str, results_count: int = 4, **kwargs) -> RAGWebResults:
-        """
-        Perform a search using the Albert API based on the provided query.
-
-        Args:
-            query (str): The search query.
-            results_count (int): The number of results to return.
-            document_name (str, optional): If provided, only return search results from
-            the document whose name exactly matches this value.
-            **kwargs: Additional arguments.
-
-        Returns:
-            RAGWebResults: The search results.
-        """
-        collection_ids = self.get_all_collection_ids()  # might raise RuntimeError
-
-        # Optional : document_names filter
-        document_name = kwargs.get("document_name", None)
+    def _build_search_payload(
+        self,
+        query: str,
+        results_count: int,
+        document_name: Optional[str],
+    ) -> dict:
+        """Assemble the /v1/search request body shared by sync and async paths."""
+        payload: dict = {
+            "collections": self.get_all_collection_ids(),  # might raise RuntimeError
+            "prompt": query,
+            "score_threshold": 0.6,
+            "k": results_count,
+        }
         if document_name:
-            metadata_filter = {
+            payload["metadata_filters"] = {
                 "key": "document_name",
                 "value": document_name,
                 "type": "eq",
             }
-        else:
-            metadata_filter = None
+        return payload
 
-        payload = {
-            "collections": collection_ids,
-            "prompt": query,
-            "score_threshold": 0.6,
-            "k": results_count,  # Number of chunks to return from the search
-        }
-        if metadata_filter is not None:
-            payload["metadata_filters"] = metadata_filter
+    @staticmethod
+    def _parse_search_response(json_body: dict, document_name: Optional[str]) -> RAGWebResults:
+        """Map an Albert /v1/search response into our RAGWebResults shape."""
+        searches = Searches(**json_body)
 
+        if not searches.data and document_name:
+            logger.info(
+                "RAG search with document_name=%r returned no results.",
+                document_name,
+            )
+
+        return RAGWebResults(
+            data=[
+                RAGWebResult(
+                    url=result.chunk.metadata["document_name"],
+                    content=result.chunk.content,
+                    score=result.score,
+                )
+                for result in searches.data
+            ],
+            usage=RAGWebUsage(
+                prompt_tokens=searches.usage.prompt_tokens,
+                completion_tokens=searches.usage.completion_tokens,
+            ),
+        )
+
+    def search(
+        self,
+        query: str,
+        results_count: int = 4,
+        document_name: Optional[str] = None,
+        **kwargs,
+    ) -> RAGWebResults:
+        """Perform a search using the Albert API based on the provided query."""
+        payload = self._build_search_payload(query, results_count, document_name)
         response = requests.post(
             urljoin(self._base_url, self._search_endpoint),
             headers=self._headers,
@@ -208,70 +228,17 @@ class AlbertRagBackend(BaseRagBackend):  # pylint: disable=too-many-instance-att
             timeout=settings.ALBERT_API_TIMEOUT,
         )
         response.raise_for_status()
+        return self._parse_search_response(response.json(), document_name)
 
-        searches = Searches(**response.json())
-
-        if not searches.data and metadata_filter:
-            logger.debug(
-                "No result with document_name filter=%s. Retrying search without filter.",
-                document_name,
-            )
-            kwargs_without_document_name = {
-                key: value for key, value in kwargs.items() if key != "document_name"
-            }
-            return self.search(query, results_count=results_count, **kwargs_without_document_name)
-
-        return RAGWebResults(
-            data=[
-                RAGWebResult(
-                    url=result.chunk.metadata["document_name"],
-                    content=result.chunk.content,
-                    score=result.score,
-                )
-                for result in searches.data
-            ],
-            usage=RAGWebUsage(
-                prompt_tokens=searches.usage.prompt_tokens,
-                completion_tokens=searches.usage.completion_tokens,
-            ),
-        )
-
-    async def asearch(self, query, results_count: int = 4, **kwargs) -> RAGWebResults:
-        """
-        Perform an asynchronous search using the Albert API based on the provided query.
-
-        Args:
-            query (str): The search query.
-            results_count (int): The number of results to return.
-            document_name (str, optional): If provided, only return search results from
-            the document whose name exactly matches this value.
-            **kwargs: Additional arguments.
-
-        Returns:
-            RAGWebResults: The search results.
-        """
-        collection_ids = self.get_all_collection_ids()  # might raise RuntimeError
-
-        # Optional : document_names filter
-        document_name = kwargs.get("document_name", None)
-        if document_name:
-            metadata_filter = {
-                "key": "document_name",
-                "value": document_name,
-                "type": "eq",
-            }
-        else:
-            metadata_filter = None
-
-        payload = {
-            "collections": collection_ids,
-            "prompt": query,
-            "score_threshold": 0.6,
-            "k": results_count,  # Number of chunks to return from the search
-        }
-        if metadata_filter is not None:
-            payload["metadata_filters"] = metadata_filter
-
+    async def asearch(
+        self,
+        query: str,
+        results_count: int = 4,
+        document_name: Optional[str] = None,
+        **kwargs,
+    ) -> RAGWebResults:
+        """Perform an asynchronous search using the Albert API based on the provided query."""
+        payload = self._build_search_payload(query, results_count, document_name)
         async with httpx.AsyncClient(timeout=settings.ALBERT_API_TIMEOUT) as client:
             response = await client.post(
                 urljoin(self._base_url, self._search_endpoint),
@@ -279,36 +246,6 @@ class AlbertRagBackend(BaseRagBackend):  # pylint: disable=too-many-instance-att
                 json=payload,
                 timeout=settings.ALBERT_API_TIMEOUT,
             )
-
             logger.debug("Search response: %s %s", response.text, response.status_code)
-
             response.raise_for_status()
-
-        searches = Searches(**response.json())
-
-        if not searches.data and metadata_filter:
-            logger.debug(
-                "No result with document_name filter=%s. Retrying search without filter.",
-                document_name,
-            )
-            kwargs_without_document_name = {
-                key: value for key, value in kwargs.items() if key != "document_name"
-            }
-            return await self.asearch(
-                query, results_count=results_count, **kwargs_without_document_name
-            )
-
-        return RAGWebResults(
-            data=[
-                RAGWebResult(
-                    url=result.chunk.metadata["document_name"],
-                    content=result.chunk.content,
-                    score=result.score,
-                )
-                for result in searches.data
-            ],
-            usage=RAGWebUsage(
-                prompt_tokens=searches.usage.prompt_tokens,
-                completion_tokens=searches.usage.completion_tokens,
-            ),
-        )
+        return self._parse_search_response(response.json(), document_name)

--- a/src/backend/chat/agent_rag/document_rag_backends/albert_rag_backend.py
+++ b/src/backend/chat/agent_rag/document_rag_backends/albert_rag_backend.py
@@ -172,6 +172,8 @@ class AlbertRagBackend(BaseRagBackend):  # pylint: disable=too-many-instance-att
         Args:
             query (str): The search query.
             results_count (int): The number of results to return.
+            document_name (str, optional): If provided, only return search results from
+            the document whose name exactly matches this value.
             **kwargs: Additional arguments.
 
         Returns:
@@ -179,20 +181,45 @@ class AlbertRagBackend(BaseRagBackend):  # pylint: disable=too-many-instance-att
         """
         collection_ids = self.get_all_collection_ids()  # might raise RuntimeError
 
+        # Optional : document_names filter
+        document_name = kwargs.get("document_name", None)
+        if document_name:
+            metadata_filter = {
+                "key": "document_name",
+                "value": document_name,
+                "type": "eq",
+            }
+        else:
+            metadata_filter = None
+
+        payload = {
+            "collections": collection_ids,
+            "prompt": query,
+            "score_threshold": 0.6,
+            "k": results_count,  # Number of chunks to return from the search
+        }
+        if metadata_filter is not None:
+            payload["metadata_filters"] = metadata_filter
+
         response = requests.post(
             urljoin(self._base_url, self._search_endpoint),
             headers=self._headers,
-            json={
-                "collections": collection_ids,
-                "prompt": query,
-                "score_threshold": 0.6,
-                "k": results_count,  # Number of chunks to return from the search
-            },
+            json=payload,
             timeout=settings.ALBERT_API_TIMEOUT,
         )
         response.raise_for_status()
 
         searches = Searches(**response.json())
+
+        if not searches.data and metadata_filter:
+            logger.debug(
+                "No result with document_name filter=%s. Retrying search without filter.",
+                document_name,
+            )
+            kwargs_without_document_name = {
+                key: value for key, value in kwargs.items() if key != "document_name"
+            }
+            return self.search(query, results_count=results_count, **kwargs_without_document_name)
 
         return RAGWebResults(
             data=[
@@ -216,6 +243,8 @@ class AlbertRagBackend(BaseRagBackend):  # pylint: disable=too-many-instance-att
         Args:
             query (str): The search query.
             results_count (int): The number of results to return.
+            document_name (str, optional): If provided, only return search results from
+            the document whose name exactly matches this value.
             **kwargs: Additional arguments.
 
         Returns:
@@ -223,16 +252,31 @@ class AlbertRagBackend(BaseRagBackend):  # pylint: disable=too-many-instance-att
         """
         collection_ids = self.get_all_collection_ids()  # might raise RuntimeError
 
+        # Optional : document_names filter
+        document_name = kwargs.get("document_name", None)
+        if document_name:
+            metadata_filter = {
+                "key": "document_name",
+                "value": document_name,
+                "type": "eq",
+            }
+        else:
+            metadata_filter = None
+
+        payload = {
+            "collections": collection_ids,
+            "prompt": query,
+            "score_threshold": 0.6,
+            "k": results_count,  # Number of chunks to return from the search
+        }
+        if metadata_filter is not None:
+            payload["metadata_filters"] = metadata_filter
+
         async with httpx.AsyncClient(timeout=settings.ALBERT_API_TIMEOUT) as client:
             response = await client.post(
                 urljoin(self._base_url, self._search_endpoint),
                 headers=self._headers,
-                json={
-                    "collections": collection_ids,
-                    "prompt": query,
-                    "score_threshold": 0.6,
-                    "k": results_count,  # Number of chunks to return from the search
-                },
+                json=payload,
                 timeout=settings.ALBERT_API_TIMEOUT,
             )
 
@@ -241,6 +285,18 @@ class AlbertRagBackend(BaseRagBackend):  # pylint: disable=too-many-instance-att
             response.raise_for_status()
 
         searches = Searches(**response.json())
+
+        if not searches.data and metadata_filter:
+            logger.debug(
+                "No result with document_name filter=%s. Retrying search without filter.",
+                document_name,
+            )
+            kwargs_without_document_name = {
+                key: value for key, value in kwargs.items() if key != "document_name"
+            }
+            return await self.asearch(
+                query, results_count=results_count, **kwargs_without_document_name
+            )
 
         return RAGWebResults(
             data=[

--- a/src/backend/chat/agent_rag/document_rag_backends/base_rag_backend.py
+++ b/src/backend/chat/agent_rag/document_rag_backends/base_rag_backend.py
@@ -161,27 +161,48 @@ class BaseRagBackend(ABC):
         return await sync_to_async(self.delete_collection)(**kwargs)
 
     @abstractmethod
-    def search(self, query: str, results_count: int = 4, **kwargs) -> RAGWebResults:
+    def search(
+        self,
+        query: str,
+        results_count: int = 4,
+        document_name: Optional[str] = None,
+        **kwargs,
+    ) -> RAGWebResults:
         """
         Search the collection for the given query.
 
         Args:
             query: The search query string.
             results_count: Number of results to return.
+            document_name: If set, restrict results to the document with this exact name.
+                Backends that don't support per-document filtering may ignore it.
             **kwargs: Additional arguments. ex: 'session' for OIDC authentication.
         """
         raise NotImplementedError("Must be implemented in subclass.")
 
-    async def asearch(self, query: str, results_count: int = 4, **kwargs) -> RAGWebResults:
+    async def asearch(
+        self,
+        query: str,
+        results_count: int = 4,
+        document_name: Optional[str] = None,
+        **kwargs,
+    ) -> RAGWebResults:
         """
         Search the collection for the given query asynchronously.
 
         Args:
             query: The search query string.
             results_count: Number of results to return.
+            document_name: If set, restrict results to the document with this exact name.
+                Backends that don't support per-document filtering may ignore it.
             **kwargs: Additional arguments. ex: 'session' for OIDC authentication.
         """
-        return await sync_to_async(self.search)(query=query, results_count=results_count, **kwargs)
+        return await sync_to_async(self.search)(
+            query=query,
+            results_count=results_count,
+            document_name=document_name,
+            **kwargs,
+        )
 
     @classmethod
     @contextmanager

--- a/src/backend/chat/agent_rag/document_rag_backends/find_rag_backend.py
+++ b/src/backend/chat/agent_rag/document_rag_backends/find_rag_backend.py
@@ -105,7 +105,9 @@ class FindRagBackend(BaseRagBackend):
         response.raise_for_status()
 
     @with_fresh_access_token
-    def search(self, query: str, results_count: int = 4, **kwargs) -> RAGWebResults:
+    def search(  # pylint: disable=arguments-differ
+        self, query: str, results_count: int = 4, **kwargs
+    ) -> RAGWebResults:
         """
         Perform a search using the Find API.
         Uses the user's OIDC token from the request session.

--- a/src/backend/chat/clients/pydantic_ai.py
+++ b/src/backend/chat/clients/pydantic_ai.py
@@ -95,6 +95,7 @@ from django.db.models import Q
 from django.utils.module_loading import import_string
 from django.utils.translation import gettext_lazy as _
 
+import tiktoken
 from asgiref.sync import sync_to_async
 from langfuse import get_client
 from pydantic_ai import Agent, InstrumentationSettings, RunContext, RunUsage
@@ -142,6 +143,7 @@ from chat.clients.pydantic_ui_message_converter import (
     model_message_to_ui_message,
     ui_message_to_user_content,
 )
+from chat.document_context_builder import build_document_context_instruction
 from chat.mcp_servers import get_mcp_servers
 from chat.tools.descriptions import (
     DOCUMENT_SUMMARIZE_SYSTEM_PROMPT,
@@ -165,6 +167,30 @@ User = get_user_model()
 
 CACHE_TIMEOUT = 30 * 60  # 30 minutes timeout
 DOCUMENT_URL_PREFIX = "/media-key/"
+TOKEN_ENCODING = tiktoken.get_encoding("cl100k_base")
+
+
+def count_approx_tokens(text: str) -> int:
+    """Estimate token count using tiktoken."""
+    if not text:
+        return 0
+    try:
+        tiktoken_len = len(TOKEN_ENCODING.encode(text))
+        logger.debug("Tiktoken length: %s", tiktoken_len)
+        return tiktoken_len
+    except Exception:  # pylint: disable=broad-except #noqa: BLE001
+        logger.warning("Failed to estimate tokens with tiktoken, falling back to heuristic.")
+        non_space_chars = len("".join(text.split()))
+        if non_space_chars == 0:
+            return 0
+        return non_space_chars // 3 + (1 if non_space_chars % 3 else 0)
+
+
+@sync_to_async
+def read_attachment_content(attachment: models.ChatConversationAttachment) -> tuple[str, str]:
+    """Read text attachment content from object storage."""
+    with default_storage.open(attachment.key) as file:
+        return attachment.file_name, file.read().decode("utf-8")
 
 
 @dataclasses.dataclass
@@ -729,7 +755,38 @@ class AIAgentService:  # pylint: disable=too-many-instance-attributes
 
         return user_prompt[0], attachment_images, attachment_documents
 
-    def _setup_rag_tools(self) -> None:
+    def _get_document_context_budget_ratio(self) -> float:
+        """Return a validated document-context ratio from settings."""
+        budget_ratio = getattr(settings, "DOCUMENT_CONTEXT_BUDGET_RATIO", 0.5)
+        if budget_ratio < 0 or budget_ratio > 1:
+            logger.warning(
+                "Invalid DOCUMENT_CONTEXT_BUDGET_RATIO=%s, falling back to 0.5",
+                budget_ratio,
+            )
+            return 0.5
+        return budget_ratio
+
+    async def _build_document_context_instruction(self) -> str:
+        budget_ratio = self._get_document_context_budget_ratio()
+        security_buffer_tokens = getattr(settings, "DOCUMENT_CONTEXT_SECURITY_BUFFER_TOKENS", 1000)
+        text_attachments = await sync_to_async(list)(
+            self.conversation.attachments.filter(content_type__startswith="text/").order_by(
+                "created_at", "id"
+            )
+        )
+        model_max_context = self.conversation_agent.configuration.max_token_context
+        return await build_document_context_instruction(
+            text_attachments=text_attachments,
+            model_hrid=self.model_hrid,
+            model_max_context=model_max_context,
+            budget_ratio=budget_ratio,
+            security_buffer_tokens=security_buffer_tokens,
+            read_attachment_content=read_attachment_content,
+            count_approx_tokens=count_approx_tokens,
+            logger=logger,
+        )
+
+    def _setup_rag_tools(self, document_context_instruction: str = "") -> None:
         """Register RAG-related tools and instructions on the conversation agent."""
         add_document_rag_search_tool(self.conversation_agent)
 
@@ -740,11 +797,14 @@ class AIAgentService:  # pylint: disable=too-many-instance-attributes
         # Inform the model (system-level) that documents are attached and available
         @self.conversation_agent.instructions
         def attached_documents_note() -> str:
-            return (
+            base_note = (
                 "[Internal context] User documents are attached to this conversation. "
                 "Do not request re-upload of documents; consider them already available "
-                "via the internal store."
+                "either here in context or via the internal store."
             )
+            if not document_context_instruction:
+                return base_note
+            return f"{base_note}\n\n{document_context_instruction}"
 
         @self.conversation_agent.tool(
             name="summarize",
@@ -1136,7 +1196,8 @@ class AIAgentService:  # pylint: disable=too-many-instance-attributes
         self._setup_web_search(force_web_search)
 
         if await self._check_should_enable_rag(conversation_has_documents):
-            self._setup_rag_tools()
+            document_context_instruction = await self._build_document_context_instruction()
+            self._setup_rag_tools(document_context_instruction=document_context_instruction)
 
         async with AsyncExitStack() as stack:
             # MCP servers (if any) can be initialized here

--- a/src/backend/chat/clients/pydantic_ai.py
+++ b/src/backend/chat/clients/pydantic_ai.py
@@ -77,6 +77,7 @@ and raises `StreamCancelException` to abort the generator.
 import asyncio
 import dataclasses
 import functools
+import hashlib
 import json
 import logging
 import os
@@ -95,7 +96,6 @@ from django.db.models import Q
 from django.utils.module_loading import import_string
 from django.utils.translation import gettext_lazy as _
 
-import tiktoken
 from asgiref.sync import sync_to_async
 from langfuse import get_client
 from pydantic_ai import Agent, InstrumentationSettings, RunContext, RunUsage
@@ -143,6 +143,7 @@ from chat.clients.pydantic_ui_message_converter import (
     model_message_to_ui_message,
     ui_message_to_user_content,
 )
+from chat.constants import TEXT_MIME_PREFIX
 from chat.document_context_builder import build_document_context_instruction
 from chat.mcp_servers import get_mcp_servers
 from chat.tools.descriptions import (
@@ -167,30 +168,6 @@ User = get_user_model()
 
 CACHE_TIMEOUT = 30 * 60  # 30 minutes timeout
 DOCUMENT_URL_PREFIX = "/media-key/"
-TOKEN_ENCODING = tiktoken.get_encoding("cl100k_base")
-
-
-def count_approx_tokens(text: str) -> int:
-    """Estimate token count using tiktoken."""
-    if not text:
-        return 0
-    try:
-        tiktoken_len = len(TOKEN_ENCODING.encode(text))
-        logger.debug("Tiktoken length: %s", tiktoken_len)
-        return tiktoken_len
-    except Exception:  # pylint: disable=broad-except #noqa: BLE001
-        logger.warning("Failed to estimate tokens with tiktoken, falling back to heuristic.")
-        non_space_chars = len("".join(text.split()))
-        if non_space_chars == 0:
-            return 0
-        return non_space_chars // 3 + (1 if non_space_chars % 3 else 0)
-
-
-@sync_to_async
-def read_attachment_content(attachment: models.ChatConversationAttachment) -> tuple[str, str]:
-    """Read text attachment content from object storage."""
-    with default_storage.open(attachment.key) as file:
-        return attachment.file_name, file.read().decode("utf-8")
 
 
 @dataclasses.dataclass
@@ -508,7 +485,7 @@ class AIAgentService:  # pylint: disable=too-many-instance-attributes
             or bool(
                 await models.ChatConversationAttachment.objects.filter(
                     conversation=self.conversation,
-                    content_type__startswith="text/",
+                    content_type__startswith=TEXT_MIME_PREFIX,
                 ).aexists()
             )
         )
@@ -691,7 +668,7 @@ class AIAgentService:  # pylint: disable=too-many-instance-attributes
                     user_sub=self.user.sub,
                 )
 
-            if not document.media_type.startswith("text/"):
+            if not document.media_type.startswith(TEXT_MIME_PREFIX):
                 md_attachment = await models.ChatConversationAttachment.objects.acreate(
                     conversation=self.conversation,
                     uploaded_by=self.user,
@@ -755,36 +732,47 @@ class AIAgentService:  # pylint: disable=too-many-instance-attributes
 
         return user_prompt[0], attachment_images, attachment_documents
 
-    def _get_document_context_budget_ratio(self) -> float:
-        """Return a validated document-context ratio from settings."""
-        budget_ratio = getattr(settings, "DOCUMENT_CONTEXT_BUDGET_RATIO", 0.5)
-        if budget_ratio < 0 or budget_ratio > 1:
-            logger.warning(
-                "Invalid DOCUMENT_CONTEXT_BUDGET_RATIO=%s, falling back to 0.5",
-                budget_ratio,
-            )
-            return 0.5
-        return budget_ratio
-
     async def _build_document_context_instruction(self) -> str:
-        budget_ratio = self._get_document_context_budget_ratio()
-        security_buffer_tokens = getattr(settings, "DOCUMENT_CONTEXT_SECURITY_BUFFER_TOKENS", 1000)
+        budget_ratio = settings.DOCUMENT_CONTEXT_BUDGET_RATIO
+        security_buffer_tokens = settings.DOCUMENT_CONTEXT_SECURITY_BUFFER_TOKENS
         text_attachments = await sync_to_async(list)(
-            self.conversation.attachments.filter(content_type__startswith="text/").order_by(
-                "created_at", "id"
-            )
+            self.conversation.attachments.filter(
+                content_type__startswith=TEXT_MIME_PREFIX
+            ).order_by("created_at", "id")
         )
-        model_max_context = self.conversation_agent.configuration.max_token_context
-        return await build_document_context_instruction(
+        max_token_context = self.conversation_agent.configuration.max_token_context
+
+        # Cache the assembled instruction: building it requires reading every text
+        # attachment from object storage and tokenizing it. The fingerprint includes
+        # each attachment's updated_at so any edit invalidates the cache.
+        fingerprint_parts = [
+            f"conv={self.conversation.id}",
+            f"user={getattr(self.user, 'id', None)}",
+            f"model={self.model_hrid}",
+            f"max_ctx={max_token_context}",
+            f"ratio={budget_ratio}",
+            f"buffer={security_buffer_tokens}",
+            *(f"{att.id}:{att.updated_at.isoformat()}" for att in text_attachments),
+        ]
+        cache_key = (
+            "doc_ctx_instr:"
+            + hashlib.sha256("|".join(fingerprint_parts).encode("utf-8")).hexdigest()
+        )
+
+        cached = await sync_to_async(cache.get)(cache_key)
+        if cached is not None:
+            return cached
+
+        instruction = await build_document_context_instruction(
+            conversation_id=str(self.conversation.id),
             text_attachments=text_attachments,
             model_hrid=self.model_hrid,
-            model_max_context=model_max_context,
+            max_token_context=max_token_context,
             budget_ratio=budget_ratio,
             security_buffer_tokens=security_buffer_tokens,
-            read_attachment_content=read_attachment_content,
-            count_approx_tokens=count_approx_tokens,
-            logger=logger,
         )
+        await sync_to_async(cache.set)(cache_key, instruction, CACHE_TIMEOUT)
+        return instruction
 
     def _setup_rag_tools(self, document_context_instruction: str = "") -> None:
         """Register RAG-related tools and instructions on the conversation agent."""

--- a/src/backend/chat/constants.py
+++ b/src/backend/chat/constants.py
@@ -1,0 +1,12 @@
+"""Shared constants for the chat application."""
+
+# MIME prefix used to identify attachments whose content can be fed to the LLM
+# as raw text (markdown, plain, csv, ...). Excludes images and PDFs, which
+# the LLM consumes through different channels.
+TEXT_MIME_PREFIX = "text/"
+
+# Access values exposed to the model in the documents listing. Keep in sync
+# with the `Access` Literal in chat.document_context_builder (Python's Literal
+# can't reference module-level constants).
+ACCESS_FULL_CONTEXT = "full-context"
+ACCESS_TOOL_CALL_ONLY = "tool_call_only"

--- a/src/backend/chat/document_context_builder.py
+++ b/src/backend/chat/document_context_builder.py
@@ -1,0 +1,202 @@
+"""Document-context instruction builder with FIFO inlining policy."""
+
+import asyncio
+import json
+import logging
+import sys
+from collections import deque
+from typing import Awaitable, Callable, Sequence
+
+from chat import models
+
+
+def _display_title_from_name(file_name: str | None, is_converted: bool) -> str:
+    """Return user-facing title, preserving real markdown filenames."""
+    title = file_name or ""
+    return title.removesuffix(".md") if is_converted else title
+
+
+def _build_payload(
+    docs: list[dict],
+    tool_call_only: bool,
+) -> dict:
+    """Build a payload with ordering and note."""
+    note = (
+        "Documents marked 'tool_call_only' are accessible through tools like "
+        "RAG search or summary. "
+    )
+    if not tool_call_only:
+        note += (
+            "Documents marked 'full-context' can be directly "
+            "manipulated by you, either for referencing, analysis or summarization. "
+            "Do not use a tool to access a document marked 'full-context', this is "
+            "counterproductive as the content is already available here."
+        )
+    payload = {
+        "documents_order": "newest_to_oldest",
+        "documents": [
+            {
+                "document_id": doc["document_id"],
+                "title": doc["title"],
+                "access": "tool_call_only" if tool_call_only else doc["access"],
+                "content": None if tool_call_only else doc.get("content"),
+                "info": doc.get("info"),
+            }
+            for doc in reversed(docs)
+        ],
+        "note": note,
+    }
+
+    return payload
+
+
+async def build_document_context_instruction(  # noqa: PLR0913 # pylint: disable=too-many-arguments,too-many-locals
+    *,
+    text_attachments: Sequence[models.ChatConversationAttachment],
+    model_hrid: str,
+    model_max_context: int | None,
+    budget_ratio: float,
+    security_buffer_tokens: int,
+    read_attachment_content: Callable[
+        [models.ChatConversationAttachment], Awaitable[tuple[str, str]]
+    ],
+    count_approx_tokens: Callable[[str], int],
+    logger: logging.Logger,
+) -> str:
+    """
+    Build document instructions with a rolling full-context FIFO window.
+
+    Rules:
+    - Reserve a ratio of max model context for full document inclusion.
+    - Keep all documents listed with an explicit accessibility status.
+    - Apply FIFO eviction on inlined documents when budget is exceeded.
+    """
+    docs = [
+        {
+            "document_id": str(attachment.id),
+            "title": _display_title_from_name(
+                attachment.file_name, bool(getattr(attachment, "conversion_from", None))
+            ),
+        }
+        for attachment in text_attachments
+    ]
+    if not text_attachments:
+        return ""
+
+    if not model_max_context:
+        logger.warning(
+            "Model '%s' has no max_token_context; skipping full document inlining.",
+            model_hrid,
+        )
+        payload = _build_payload(docs=docs, tool_call_only=True)
+        return (
+            "List of documents attached to this conversation:\n"
+            f"{json.dumps(payload, ensure_ascii=False, indent=2)}"
+        )
+
+    if budget_ratio == 0:
+        logger.info(
+            "DOCUMENT_CONTEXT_BUDGET_RATIO is 0 for model '%s'; disabling full document inlining.",
+            model_hrid,
+        )
+        payload = _build_payload(docs=docs, tool_call_only=True)
+        return (
+            "List of documents attached to this conversation:\n"
+            f"{json.dumps(payload, ensure_ascii=False, indent=2)}"
+        )
+
+    document_budget = max(int(model_max_context * budget_ratio) - security_buffer_tokens, 0)
+
+    async def _load_document(index: int, attachment: models.ChatConversationAttachment) -> dict:
+        try:
+            title, content = await read_attachment_content(attachment)
+            token_count = count_approx_tokens(content)
+            access = "tool_call_only"
+        except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
+            logger.warning(
+                "Could not inline attachment '%s'; keeping it tool_call_only: %s",
+                getattr(attachment, "file_name", "<unknown>"),
+                exc,
+                exc_info=True,
+            )
+            title = getattr(attachment, "file_name", None)
+            content = "available via tools"
+            # Keep failed reads non-inlineable so they cannot be promoted later.
+            access = "tool_call_only"
+            token_count = sys.maxsize
+        title = _display_title_from_name(title, bool(getattr(attachment, "conversion_from", None)))
+        return {
+            "document_id": str(getattr(attachment, "id", "")),
+            "title": title,
+            "content": content,
+            "token_count": token_count,
+            "access": access,
+            "info": (
+                "first_uploaded_document"
+                if index == 1
+                else "last_uploaded_document"
+                if index == len(text_attachments)
+                else None
+            ),
+        }
+
+    docs = list(
+        await asyncio.gather(
+            *(
+                _load_document(index, attachment)
+                for index, attachment in enumerate(text_attachments, start=1)
+            )
+        )
+    )
+
+    inlined_docs = deque()  # More efficient than list for FIFO operations
+    inlined_total = 0  # Total token count of inlined documents
+    for doc in docs:
+        token_count = doc["token_count"]
+        if token_count > document_budget:
+            # Document exceeds budget, keep it as tool_call_only
+            doc["content"] = "available via tools"
+            logger.debug(
+                "Document '%s' (%s tokens) exceeds budget (%s); keeping tool_call_only.",
+                doc["title"],
+                token_count,
+                document_budget,
+            )
+            continue
+
+        # Evict documents until the new document fits within the budget
+        while inlined_docs and inlined_total + token_count > document_budget:
+            evicted = inlined_docs.popleft()  # Evict the oldest document
+            inlined_total -= evicted["token_count"]  # update the total
+            evicted["access"] = "tool_call_only"
+            evicted["content"] = "available via tools"
+            logger.debug("Evicted! Document title:%s", evicted["title"])
+
+        # If the new document fits within the budget, add it to the inlined documents
+        if inlined_total + token_count <= document_budget:
+            logger.debug("Inlined! Document title:%s", doc["title"])
+            doc["access"] = "full-context"
+            inlined_docs.append(doc)
+            inlined_total += token_count
+
+    filled_ratio = (inlined_total / document_budget) if document_budget else 0
+    logger.debug(
+        (
+            "Document context window usage - model=%s budget_ratio=%s "
+            "document_budget_tokens=%s inlined_tokens=%s filled_ratio=%.4f "
+            "total_documents=%s inlined_documents=%s"
+        ),
+        model_hrid,
+        budget_ratio,
+        document_budget,
+        inlined_total,
+        filled_ratio,
+        len(docs),
+        len(inlined_docs),
+    )
+
+    payload = _build_payload(docs=docs, tool_call_only=False)
+    return (
+        "List of documents attached to this conversation:\n"
+        f"{json.dumps(payload, ensure_ascii=False, indent=2)}"
+    )

--- a/src/backend/chat/document_context_builder.py
+++ b/src/backend/chat/document_context_builder.py
@@ -1,13 +1,105 @@
 """Document-context instruction builder with FIFO inlining policy."""
 
 import asyncio
+import dataclasses
+import functools
 import json
 import logging
-import sys
 from collections import deque
-from typing import Awaitable, Callable, Sequence
+from typing import Literal, Sequence
+
+from django.core.files.storage import default_storage
+
+import tiktoken
+from asgiref.sync import sync_to_async
 
 from chat import models
+from chat.constants import ACCESS_FULL_CONTEXT, ACCESS_TOOL_CALL_ONLY
+
+logger = logging.getLogger(__name__)
+
+
+@functools.lru_cache(maxsize=1)
+def _get_token_encoding():
+    """Lazily load and cache the tiktoken encoding."""
+    return tiktoken.get_encoding("cl100k_base")
+
+
+def count_approx_tokens(text: str) -> int:
+    """Estimate token count using tiktoken."""
+    if not text:
+        return 0
+    try:
+        tiktoken_len = len(_get_token_encoding().encode(text))
+        logger.debug("Tiktoken length: %s", tiktoken_len)
+        return tiktoken_len
+    except Exception:  # pylint: disable=broad-except #noqa: BLE001
+        logger.warning("Failed to estimate tokens with tiktoken, falling back to heuristic.")
+        non_space_chars = len("".join(text.split()))
+        if non_space_chars == 0:
+            return 0
+        return non_space_chars // 3 + (1 if non_space_chars % 3 else 0)
+
+
+@sync_to_async
+def read_attachment_content(attachment: models.ChatConversationAttachment) -> tuple[str, str]:
+    """Read text attachment content from object storage."""
+    with default_storage.open(attachment.key) as file:
+        return attachment.file_name, file.read().decode("utf-8")
+
+
+# Keep these literals in sync with chat.constants.ACCESS_* (Literal can't
+# reference module-level constants).
+Access = Literal["full-context", "tool_call_only"]
+DocumentInfoLabel = Literal["first_uploaded_document", "last_uploaded_document"]
+TOOL_CALL_ONLY_CONTENT = "available via tools"
+
+
+@dataclasses.dataclass
+class DocumentInfo:
+    """LLM-visible shape for one document entry in the listing."""
+
+    document_id: str
+    title: str
+    access: Access
+    content: str | None
+    info: DocumentInfoLabel | None = None
+
+
+@dataclasses.dataclass
+class DocumentsListing:
+    """LLM-visible shape for the full attached-documents listing."""
+
+    documents: list[DocumentInfo]
+    note: str
+    documents_order: Literal["newest_to_oldest"] = "newest_to_oldest"
+
+
+@dataclasses.dataclass
+class _DocumentEntry:
+    """Internal working state for a document during inlining/eviction.
+
+    Carries the same identity/title fields as DocumentInfo, plus the
+    bookkeeping needed by the FIFO policy (token_count, inlineable).
+    """
+
+    document_id: str
+    title: str
+    content: str
+    token_count: int
+    inlineable: bool
+    access: Access = ACCESS_TOOL_CALL_ONLY
+    info: DocumentInfoLabel | None = None
+
+    def to_info(self, *, force_tool_call_only: bool) -> DocumentInfo:
+        """Project this internal entry to its LLM-visible shape."""
+        return DocumentInfo(
+            document_id=self.document_id,
+            title=self.title,
+            access=ACCESS_TOOL_CALL_ONLY if force_tool_call_only else self.access,
+            content=None if force_tool_call_only else self.content,
+            info=self.info,
+        )
 
 
 def _display_title_from_name(file_name: str | None, is_converted: bool) -> str:
@@ -16,52 +108,116 @@ def _display_title_from_name(file_name: str | None, is_converted: bool) -> str:
     return title.removesuffix(".md") if is_converted else title
 
 
-def _build_payload(
-    docs: list[dict],
-    tool_call_only: bool,
-) -> dict:
-    """Build a payload with ordering and note."""
+def _build_documents_listing(
+    docs: list[_DocumentEntry],
+    force_tool_call_only: bool,
+) -> DocumentsListing:
+    """Build the ordered documents listing (with access note) for the model."""
     note = (
-        "Documents marked 'tool_call_only' are accessible through tools like "
+        f"Documents marked '{ACCESS_TOOL_CALL_ONLY}' are accessible through tools like "
         "RAG search or summary. "
     )
-    if not tool_call_only:
+    if not force_tool_call_only:
         note += (
-            "Documents marked 'full-context' can be directly "
+            f"Documents marked '{ACCESS_FULL_CONTEXT}' can be directly "
             "manipulated by you, either for referencing, analysis or summarization. "
-            "Do not use a tool to access a document marked 'full-context', this is "
+            f"Do not use a tool to access a document marked '{ACCESS_FULL_CONTEXT}', this is "
             "counterproductive as the content is already available here."
         )
-    payload = {
-        "documents_order": "newest_to_oldest",
-        "documents": [
-            {
-                "document_id": doc["document_id"],
-                "title": doc["title"],
-                "access": "tool_call_only" if tool_call_only else doc["access"],
-                "content": None if tool_call_only else doc.get("content"),
-                "info": doc.get("info"),
-            }
-            for doc in reversed(docs)
+    return DocumentsListing(
+        documents=[
+            doc.to_info(force_tool_call_only=force_tool_call_only) for doc in reversed(docs)
         ],
-        "note": note,
-    }
+        note=note,
+    )
 
-    return payload
+
+def _render_listing(listing: DocumentsListing) -> str:
+    """Serialize the listing as the JSON-prefixed instruction snippet."""
+    return (
+        "List of documents attached to this conversation:\n"
+        f"{json.dumps(dataclasses.asdict(listing), ensure_ascii=False, indent=2)}"
+    )
+
+
+def _info_label_for(index: int, total: int) -> DocumentInfoLabel | None:
+    """Position label - first wins when there is a single document."""
+    if index == 1:
+        return "first_uploaded_document"
+    if index == total:
+        return "last_uploaded_document"
+    return None
+
+
+def _apply_fifo_inlining(
+    docs: list[_DocumentEntry],
+    document_budget: int,
+    conversation_id: str,
+) -> list[_DocumentEntry]:
+    """Return a new list with access/content updated per FIFO budget policy.
+
+    Inline what fits, evict oldest on overflow; oversize docs stay tool_call_only.
+    """
+    inlined: set[int] = set()
+    inlined_order: deque[int] = deque()
+    inlined_total = 0
+
+    for i, doc in enumerate(docs):
+        if not doc.inlineable:
+            # Failed reads stay tool_call_only and are excluded from budget math.
+            continue
+        if doc.token_count > document_budget:
+            logger.debug(
+                "conversation=%s document '%s' (%s tokens) exceeds budget (%s); "
+                "keeping tool_call_only.",
+                conversation_id,
+                doc.title,
+                doc.token_count,
+                document_budget,
+            )
+            continue
+
+        while inlined_order and inlined_total + doc.token_count > document_budget:
+            evicted_idx = inlined_order.popleft()
+            inlined.discard(evicted_idx)
+            inlined_total -= docs[evicted_idx].token_count
+            logger.debug(
+                "conversation=%s evicted document title=%s",
+                conversation_id,
+                docs[evicted_idx].title,
+            )
+
+        if inlined_total + doc.token_count <= document_budget:
+            inlined.add(i)
+            inlined_order.append(i)
+            inlined_total += doc.token_count
+            logger.debug(
+                "conversation=%s inlined document title=%s",
+                conversation_id,
+                doc.title,
+            )
+
+    result: list[_DocumentEntry] = []
+    for i, doc in enumerate(docs):
+        if i in inlined:
+            result.append(dataclasses.replace(doc, access=ACCESS_FULL_CONTEXT))
+        elif doc.inlineable:
+            # Inlineable but didn't make the cut (oversize or evicted) - scrub content.
+            result.append(dataclasses.replace(doc, content=TOOL_CALL_ONLY_CONTENT))
+        else:
+            # Failed reads already carry TOOL_CALL_ONLY_CONTENT - pass through.
+            result.append(doc)
+    return result
 
 
 async def build_document_context_instruction(  # noqa: PLR0913 # pylint: disable=too-many-arguments,too-many-locals
     *,
+    conversation_id: str,
     text_attachments: Sequence[models.ChatConversationAttachment],
     model_hrid: str,
-    model_max_context: int | None,
+    max_token_context: int | None,
     budget_ratio: float,
     security_buffer_tokens: int,
-    read_attachment_content: Callable[
-        [models.ChatConversationAttachment], Awaitable[tuple[str, str]]
-    ],
-    count_approx_tokens: Callable[[str], int],
-    logger: logging.Logger,
 ) -> str:
     """
     Build document instructions with a rolling full-context FIFO window.
@@ -71,76 +227,76 @@ async def build_document_context_instruction(  # noqa: PLR0913 # pylint: disable
     - Keep all documents listed with an explicit accessibility status.
     - Apply FIFO eviction on inlined documents when budget is exceeded.
     """
-    docs = [
-        {
-            "document_id": str(attachment.id),
-            "title": _display_title_from_name(
-                attachment.file_name, bool(getattr(attachment, "conversion_from", None))
-            ),
-        }
-        for attachment in text_attachments
-    ]
     if not text_attachments:
         return ""
 
-    if not model_max_context:
+    placeholder_docs = [
+        _DocumentEntry(
+            document_id=str(attachment.id),
+            title=_display_title_from_name(
+                attachment.file_name, bool(getattr(attachment, "conversion_from", None))
+            ),
+            content=TOOL_CALL_ONLY_CONTENT,
+            token_count=0,
+            inlineable=False,
+        )
+        for attachment in text_attachments
+    ]
+
+    if not max_token_context:
         logger.warning(
-            "Model '%s' has no max_token_context; skipping full document inlining.",
+            "conversation=%s model='%s' has no max_token_context; skipping full document inlining.",
+            conversation_id,
             model_hrid,
         )
-        payload = _build_payload(docs=docs, tool_call_only=True)
-        return (
-            "List of documents attached to this conversation:\n"
-            f"{json.dumps(payload, ensure_ascii=False, indent=2)}"
+        return _render_listing(
+            _build_documents_listing(docs=placeholder_docs, force_tool_call_only=True)
         )
 
     if budget_ratio == 0:
         logger.info(
-            "DOCUMENT_CONTEXT_BUDGET_RATIO is 0 for model '%s'; disabling full document inlining.",
+            "conversation=%s DOCUMENT_CONTEXT_BUDGET_RATIO is 0 for model '%s'; "
+            "disabling full document inlining.",
+            conversation_id,
             model_hrid,
         )
-        payload = _build_payload(docs=docs, tool_call_only=True)
-        return (
-            "List of documents attached to this conversation:\n"
-            f"{json.dumps(payload, ensure_ascii=False, indent=2)}"
+        return _render_listing(
+            _build_documents_listing(docs=placeholder_docs, force_tool_call_only=True)
         )
 
-    document_budget = max(int(model_max_context * budget_ratio) - security_buffer_tokens, 0)
+    document_budget = max(int(max_token_context * budget_ratio) - security_buffer_tokens, 0)
 
-    async def _load_document(index: int, attachment: models.ChatConversationAttachment) -> dict:
+    async def _load_document(
+        index: int, attachment: models.ChatConversationAttachment
+    ) -> _DocumentEntry:
         try:
             title, content = await read_attachment_content(attachment)
             token_count = count_approx_tokens(content)
-            access = "tool_call_only"
+            inlineable = True
         except Exception as exc:  # pylint: disable=broad-except  # noqa: BLE001
             logger.warning(
-                "Could not inline attachment '%s'; keeping it tool_call_only: %s",
+                "conversation=%s could not inline attachment '%s'; keeping it tool_call_only: %s",
+                conversation_id,
                 getattr(attachment, "file_name", "<unknown>"),
                 exc,
                 exc_info=True,
             )
             title = getattr(attachment, "file_name", None)
-            content = "available via tools"
-            # Keep failed reads non-inlineable so they cannot be promoted later.
-            access = "tool_call_only"
-            token_count = sys.maxsize
-        title = _display_title_from_name(title, bool(getattr(attachment, "conversion_from", None)))
-        return {
-            "document_id": str(getattr(attachment, "id", "")),
-            "title": title,
-            "content": content,
-            "token_count": token_count,
-            "access": access,
-            "info": (
-                "first_uploaded_document"
-                if index == 1
-                else "last_uploaded_document"
-                if index == len(text_attachments)
-                else None
+            content = TOOL_CALL_ONLY_CONTENT
+            token_count = 0
+            inlineable = False
+        return _DocumentEntry(
+            document_id=str(getattr(attachment, "id", "")),
+            title=_display_title_from_name(
+                title, bool(getattr(attachment, "conversion_from", None))
             ),
-        }
+            content=content,
+            token_count=token_count,
+            inlineable=inlineable,
+            info=_info_label_for(index, len(text_attachments)),
+        )
 
-    docs = list(
+    docs: list[_DocumentEntry] = list(
         await asyncio.gather(
             *(
                 _load_document(index, attachment)
@@ -149,54 +305,25 @@ async def build_document_context_instruction(  # noqa: PLR0913 # pylint: disable
         )
     )
 
-    inlined_docs = deque()  # More efficient than list for FIFO operations
-    inlined_total = 0  # Total token count of inlined documents
-    for doc in docs:
-        token_count = doc["token_count"]
-        if token_count > document_budget:
-            # Document exceeds budget, keep it as tool_call_only
-            doc["content"] = "available via tools"
-            logger.debug(
-                "Document '%s' (%s tokens) exceeds budget (%s); keeping tool_call_only.",
-                doc["title"],
-                token_count,
-                document_budget,
-            )
-            continue
-
-        # Evict documents until the new document fits within the budget
-        while inlined_docs and inlined_total + token_count > document_budget:
-            evicted = inlined_docs.popleft()  # Evict the oldest document
-            inlined_total -= evicted["token_count"]  # update the total
-            evicted["access"] = "tool_call_only"
-            evicted["content"] = "available via tools"
-            logger.debug("Evicted! Document title:%s", evicted["title"])
-
-        # If the new document fits within the budget, add it to the inlined documents
-        if inlined_total + token_count <= document_budget:
-            logger.debug("Inlined! Document title:%s", doc["title"])
-            doc["access"] = "full-context"
-            inlined_docs.append(doc)
-            inlined_total += token_count
+    docs = _apply_fifo_inlining(docs, document_budget, conversation_id)
+    inlined_total = sum(doc.token_count for doc in docs if doc.access == ACCESS_FULL_CONTEXT)
+    inlined_count = sum(1 for doc in docs if doc.access == ACCESS_FULL_CONTEXT)
 
     filled_ratio = (inlined_total / document_budget) if document_budget else 0
     logger.debug(
         (
-            "Document context window usage - model=%s budget_ratio=%s "
+            "Document context window usage - conversation=%s model=%s budget_ratio=%s "
             "document_budget_tokens=%s inlined_tokens=%s filled_ratio=%.4f "
             "total_documents=%s inlined_documents=%s"
         ),
+        conversation_id,
         model_hrid,
         budget_ratio,
         document_budget,
         inlined_total,
         filled_ratio,
         len(docs),
-        len(inlined_docs),
+        inlined_count,
     )
 
-    payload = _build_payload(docs=docs, tool_call_only=False)
-    return (
-        "List of documents attached to this conversation:\n"
-        f"{json.dumps(payload, ensure_ascii=False, indent=2)}"
-    )
+    return _render_listing(_build_documents_listing(docs=docs, force_tool_call_only=False))

--- a/src/backend/chat/llm_configuration.py
+++ b/src/backend/chat/llm_configuration.py
@@ -180,6 +180,10 @@ class LLModel(BaseModel):
         """Accept integer-like values from JSON for model context size."""
         if value is None or value == "":
             return None
+        if isinstance(value, bool):
+            # bool is an int subclass in Python, reject explicitly so True/False
+            # don't become 1/0.
+            raise ValueError("max_token_context must be an integer value.")
         if isinstance(value, int):
             parsed_value = value
         elif isinstance(value, str):

--- a/src/backend/chat/llm_configuration.py
+++ b/src/backend/chat/llm_configuration.py
@@ -145,6 +145,7 @@ class LLModel(BaseModel):
     tools: list[str]
     web_search: SettingEnvValue | None = None
     concatenate_instruction_messages: bool | None = None
+    max_token_context: int | None = None
 
     @field_validator("tools", mode="before")
     @classmethod
@@ -172,6 +173,24 @@ class LLModel(BaseModel):
         if isinstance(value, str):
             return _get_setting_or_env_or_value(value)
         return value
+
+    @field_validator("max_token_context", mode="before")
+    @classmethod
+    def validate_max_token_context(cls, value: int | str | None) -> int | None:
+        """Accept integer-like values from JSON for model context size."""
+        if value is None or value == "":
+            return None
+        if isinstance(value, int):
+            parsed_value = value
+        elif isinstance(value, str):
+            parsed_value = int(value)
+        else:
+            raise ValueError("max_token_context must be an integer value.")
+
+        if parsed_value <= 0:
+            raise ValueError("max_token_context must be a positive integer")
+
+        return parsed_value
 
     @model_validator(mode="after")
     def check_provider_or_provider_name(self) -> Self:

--- a/src/backend/chat/tests/agent_rag/document_rag_backends/test_albert_rag_backend.py
+++ b/src/backend/chat/tests/agent_rag/document_rag_backends/test_albert_rag_backend.py
@@ -1,0 +1,199 @@
+"""
+HTTP-level tests for AlbertRagBackend.search / asearch.
+
+Mocks the Albert API at the wire level (responses for requests, respx for httpx)
+and exercises the real backend class. Verifies:
+
+- Correct payload construction (with/without document_name filter)
+- Empty filtered results return empty RAGWebResults (no recursive retry)
+  -> regression test for the silent-fallback removal
+- Non-empty results map to the right RAGWebResult shape and propagate usage
+"""
+
+import json
+
+import pytest
+import responses
+import respx
+from httpx import Response
+
+from chat.agent_rag.document_rag_backends.albert_rag_backend import AlbertRagBackend
+
+ALBERT_BASE_URL = "https://albert.test"
+SEARCH_URL = f"{ALBERT_BASE_URL}/v1/search"
+
+
+@pytest.fixture(name="albert_backend")
+def albert_backend_fixture(settings):
+    """A backend pointing at a test API and a fixed collection."""
+    settings.ALBERT_API_URL = ALBERT_BASE_URL
+    settings.ALBERT_API_KEY = "test-key"
+    return AlbertRagBackend(collection_id="123")
+
+
+def _empty_albert_response():
+    return {"data": [], "usage": {"prompt_tokens": 1, "completion_tokens": 0}}
+
+
+def _one_result_albert_response():
+    return {
+        "data": [
+            {
+                "method": "semantic",
+                "chunk": {
+                    "id": 1,
+                    "content": "snippet from doc",
+                    "metadata": {"document_name": "report.pdf"},
+                },
+                "score": 0.9,
+            }
+        ],
+        "usage": {"prompt_tokens": 10, "completion_tokens": 20},
+    }
+
+
+# Sync search
+
+
+@responses.activate
+def test_search_without_filter_does_not_send_metadata_filters(albert_backend):
+    """No document_name -> request body has no metadata_filters key."""
+    responses.post(
+        url=SEARCH_URL,
+        json=_one_result_albert_response(),
+        status=200,
+    )
+
+    albert_backend.search("any query")
+
+    assert len(responses.calls) == 1
+    payload = json.loads(responses.calls[0].request.body)
+    assert "metadata_filters" not in payload
+    assert payload["prompt"] == "any query"
+    assert payload["collections"] == [123]
+
+
+@responses.activate
+def test_search_with_filter_sends_metadata_filters(albert_backend):
+    """document_name -> request body carries the metadata_filters dict."""
+    responses.post(
+        url=SEARCH_URL,
+        json=_one_result_albert_response(),
+        status=200,
+    )
+
+    albert_backend.search("any query", document_name="report.pdf")
+
+    payload = json.loads(responses.calls[0].request.body)
+    assert payload["metadata_filters"] == {
+        "key": "document_name",
+        "value": "report.pdf",
+        "type": "eq",
+    }
+
+
+@responses.activate
+def test_search_with_filter_empty_returns_empty_no_recursion(albert_backend, caplog):
+    """
+    Filtered search returning empty must NOT recurse into an unfiltered call.
+    Regression test for the silent-fallback removal.
+    """
+    responses.post(
+        url=SEARCH_URL,
+        json=_empty_albert_response(),
+        status=200,
+    )
+
+    with caplog.at_level("INFO", logger="chat.agent_rag.document_rag_backends.albert_rag_backend"):
+        results = albert_backend.search("any query", document_name="missing.pdf")
+
+    assert results.data == []
+    # Exactly one HTTP call: no recursive unfiltered retry.
+    assert len(responses.calls) == 1
+    # And the empty-with-filter case is announced at info level.
+    assert any("returned no results" in r.message for r in caplog.records)
+
+
+@responses.activate
+def test_search_without_filter_empty_returns_empty(albert_backend, caplog):
+    """Unfiltered empty result returns empty RAGWebResults; no info log."""
+    responses.post(
+        url=SEARCH_URL,
+        json=_empty_albert_response(),
+        status=200,
+    )
+
+    with caplog.at_level("INFO", logger="chat.agent_rag.document_rag_backends.albert_rag_backend"):
+        results = albert_backend.search("any query")
+
+    assert results.data == []
+    assert len(responses.calls) == 1
+    # The "returned no results" info log is only for filtered searches.
+    assert not any("returned no results" in r.message for r in caplog.records)
+
+
+@responses.activate
+def test_search_returns_results_with_usage(albert_backend):
+    """A successful search maps Albert chunks to RAGWebResult and propagates usage."""
+    responses.post(
+        url=SEARCH_URL,
+        json=_one_result_albert_response(),
+        status=200,
+    )
+
+    results = albert_backend.search("any query")
+
+    assert len(results.data) == 1
+    assert results.data[0].url == "report.pdf"
+    assert results.data[0].content == "snippet from doc"
+    assert results.data[0].score == pytest.approx(0.9)
+    assert results.usage.prompt_tokens == 10
+    assert results.usage.completion_tokens == 20
+
+
+# Async search
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_asearch_with_filter_empty_returns_empty_no_recursion(albert_backend, caplog):
+    """Same regression check as the sync variant, on the async path."""
+    route = respx.post(SEARCH_URL).mock(return_value=Response(200, json=_empty_albert_response()))
+
+    with caplog.at_level("INFO", logger="chat.agent_rag.document_rag_backends.albert_rag_backend"):
+        results = await albert_backend.asearch("any query", document_name="missing.pdf")
+
+    assert results.data == []
+    assert route.call_count == 1  # no recursive retry
+    assert any("returned no results" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_asearch_with_filter_sends_metadata_filters(albert_backend):
+    """Async path: metadata_filters present when document_name given."""
+    route = respx.post(SEARCH_URL).mock(
+        return_value=Response(200, json=_one_result_albert_response())
+    )
+
+    await albert_backend.asearch("any query", document_name="report.pdf")
+
+    payload = json.loads(route.calls[0].request.content)
+    assert payload["metadata_filters"] == {
+        "key": "document_name",
+        "value": "report.pdf",
+        "type": "eq",
+    }
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_asearch_returns_results_with_usage(albert_backend):
+    """Async path: results map and usage propagates."""
+    respx.post(SEARCH_URL).mock(return_value=Response(200, json=_one_result_albert_response()))
+
+    results = await albert_backend.asearch("any query")
+
+    assert len(results.data) == 1
+    assert results.data[0].url == "report.pdf"
+    assert results.usage.prompt_tokens == 10

--- a/src/backend/chat/tests/clients/pydantic_ai/test_document_context_window.py
+++ b/src/backend/chat/tests/clients/pydantic_ai/test_document_context_window.py
@@ -1,0 +1,174 @@
+"""Tests for document context rolling window instructions."""
+
+import pytest
+from asgiref.sync import async_to_sync
+
+from chat.clients.pydantic_ai import AIAgentService
+from chat.factories import ChatConversationAttachmentFactory, ChatConversationFactory, UserFactory
+from chat.llm_configuration import LLModel, LLMProvider
+
+pytestmark = pytest.mark.django_db()
+
+
+@pytest.fixture()
+def _llm_config_with_context(settings):
+    """Configure a model with max_token_context for context window tests."""
+    settings.DOCUMENT_CONTEXT_BUDGET_RATIO = 0.5
+    settings.LLM_CONFIGURATIONS = {
+        "default-model": LLModel(
+            hrid="default-model",
+            model_name="amazing-llm",
+            human_readable_name="Amazing LLM",
+            is_active=True,
+            icon=None,
+            system_prompt="You are an amazing assistant.",
+            tools=[],
+            # Keep context large enough so tests can exercise rolling-window behavior
+            # despite the fixed security buffer applied by the service.
+            max_token_context=4000,
+            provider=LLMProvider(
+                hrid="unused",
+                base_url="https://example.com",
+                api_key="key",
+            ),
+        ),
+    }
+
+
+def test_document_context_marks_oversized_docs_as_rag_only(_llm_config_with_context, monkeypatch):
+    """Oversized documents must stay accessible only through rag/summarize tools."""
+    user = UserFactory()
+    conversation = ChatConversationFactory(owner=user)
+    service = AIAgentService(conversation, user=user)
+
+    ChatConversationAttachmentFactory(
+        conversation=conversation,
+        uploaded_by=user,
+        file_name="big.md",
+        content_type="text/markdown",
+        conversion_from="markdown",
+    )
+
+    async def fake_read_attachment_content(_attachment):
+        return "big.md", "a" * 999
+
+    monkeypatch.setattr(
+        "chat.clients.pydantic_ai.read_attachment_content",
+        fake_read_attachment_content,
+    )
+    monkeypatch.setattr(
+        "chat.clients.pydantic_ai.count_approx_tokens",
+        lambda _text: 1201,
+    )
+
+    instruction = async_to_sync(service._build_document_context_instruction)()  # pylint: disable=protected-access
+    assert '"title": "big"' in instruction
+    assert '"access": "tool_call_only"' in instruction
+    assert '"content": "available via tools"' in instruction
+    assert "List of documents attached to this conversation" in instruction
+
+
+def test_document_context_uses_fifo_rolling_window(_llm_config_with_context, monkeypatch):
+    """When budget overflows, oldest inlined documents must be evicted first."""
+    user = UserFactory()
+    conversation = ChatConversationFactory(owner=user)
+    service = AIAgentService(conversation, user=user)
+
+    ChatConversationAttachmentFactory(
+        conversation=conversation,
+        uploaded_by=user,
+        file_name="doc-1.md",
+        content_type="text/markdown",
+        conversion_from="markdown",
+    )
+    ChatConversationAttachmentFactory(
+        conversation=conversation,
+        uploaded_by=user,
+        file_name="doc-2.md",
+        content_type="text/markdown",
+        conversion_from="markdown",
+    )
+    ChatConversationAttachmentFactory(
+        conversation=conversation,
+        uploaded_by=user,
+        file_name="doc-3.md",
+        content_type="text/markdown",
+        conversion_from="markdown",
+    )
+
+    content_by_name = {
+        "doc-1.md": "a" * 6,  # 2 tokens (ceil(6/3))
+        "doc-2.md": "b" * 6,  # 2 tokens (ceil(6/3))
+        "doc-3.md": "c" * 9,  # 3 tokens (ceil(9/3))
+    }
+
+    async def fake_read_attachment_content(attachment):
+        return attachment.file_name, content_by_name[attachment.file_name]
+
+    monkeypatch.setattr(
+        "chat.clients.pydantic_ai.read_attachment_content",
+        fake_read_attachment_content,
+    )
+
+    monkeypatch.setattr(
+        "chat.clients.pydantic_ai.count_approx_tokens",
+        lambda _text: 400,
+    )
+
+    instruction = async_to_sync(service._build_document_context_instruction)()  # pylint: disable=protected-access
+
+    # max_token_context=4000, ratio=0.5 => budget=1000 after buffer.
+    # With 3 docs at 400 tokens each, rolling outcome should inline doc-2 + doc-3.
+    assert '"title": "doc-1"' in instruction
+    assert '"title": "doc-2"' in instruction
+    assert '"title": "doc-3"' in instruction
+    assert '"access": "tool_call_only"' in instruction
+    assert instruction.count('"access": "full-context"') == 2
+    assert '"content": "available via tools"' in instruction
+
+
+def test_document_context_uses_configurable_ratio(_llm_config_with_context, monkeypatch, settings):
+    """Budget ratio comes from Django settings and changes inlining behavior."""
+    settings.DOCUMENT_CONTEXT_BUDGET_RATIO = 0.3  # max_token_context=10 => budget=3
+
+    user = UserFactory()
+    conversation = ChatConversationFactory(owner=user)
+    service = AIAgentService(conversation, user=user)
+
+    ChatConversationAttachmentFactory(
+        conversation=conversation,
+        uploaded_by=user,
+        file_name="doc-1.md",
+        content_type="text/markdown",
+        conversion_from="markdown",
+    )
+    ChatConversationAttachmentFactory(
+        conversation=conversation,
+        uploaded_by=user,
+        file_name="doc-2.md",
+        content_type="text/markdown",
+        conversion_from="markdown",
+    )
+
+    content_by_name = {
+        "doc-1.md": "a" * 6,  # 2 tokens (ceil(6/3))
+        "doc-2.md": "b" * 6,  # 2 tokens (ceil(6/3))
+    }
+
+    async def fake_read_attachment_content(attachment):
+        return attachment.file_name, content_by_name[attachment.file_name]
+
+    monkeypatch.setattr(
+        "chat.clients.pydantic_ai.read_attachment_content",
+        fake_read_attachment_content,
+    )
+    monkeypatch.setattr(
+        "chat.clients.pydantic_ai.count_approx_tokens",
+        lambda _text: 150,
+    )
+
+    instruction = async_to_sync(service._build_document_context_instruction)()  # pylint: disable=protected-access
+    assert '"title": "doc-1"' in instruction
+    assert '"title": "doc-2"' in instruction
+    assert '"access": "tool_call_only"' in instruction
+    assert '"access": "full-context"' in instruction

--- a/src/backend/chat/tests/clients/pydantic_ai/test_document_context_window.py
+++ b/src/backend/chat/tests/clients/pydantic_ai/test_document_context_window.py
@@ -1,13 +1,30 @@
 """Tests for document context rolling window instructions."""
 
+import json
+from unittest import mock
+
+from django.core.cache import cache
+from django.core.files.base import ContentFile
+from django.core.files.storage import default_storage
+
 import pytest
 from asgiref.sync import async_to_sync
 
 from chat.clients.pydantic_ai import AIAgentService
+from chat.constants import ACCESS_FULL_CONTEXT, ACCESS_TOOL_CALL_ONLY
 from chat.factories import ChatConversationAttachmentFactory, ChatConversationFactory, UserFactory
 from chat.llm_configuration import LLModel, LLMProvider
 
 pytestmark = pytest.mark.django_db()
+
+LISTING_PREFIX = "List of documents attached to this conversation:\n"
+TOOL_CALL_ONLY_CONTENT = "available via tools"
+
+
+def _parse_listing(instruction: str) -> dict:
+    """Extract and parse the JSON listing from the instruction string."""
+    assert LISTING_PREFIX in instruction, f"missing prefix in: {instruction!r}"
+    return json.loads(instruction.split(LISTING_PREFIX, 1)[1])
 
 
 @pytest.fixture()
@@ -49,23 +66,25 @@ def test_document_context_marks_oversized_docs_as_rag_only(_llm_config_with_cont
         conversion_from="markdown",
     )
 
-    async def fake_read_attachment_content(_attachment):
+    async def fake_read_attachment_content(_attachment):  # NOSONAR
         return "big.md", "a" * 999
 
     monkeypatch.setattr(
-        "chat.clients.pydantic_ai.read_attachment_content",
+        "chat.document_context_builder.read_attachment_content",
         fake_read_attachment_content,
     )
     monkeypatch.setattr(
-        "chat.clients.pydantic_ai.count_approx_tokens",
+        "chat.document_context_builder.count_approx_tokens",
         lambda _text: 1201,
     )
 
     instruction = async_to_sync(service._build_document_context_instruction)()  # pylint: disable=protected-access
-    assert '"title": "big"' in instruction
-    assert '"access": "tool_call_only"' in instruction
-    assert '"content": "available via tools"' in instruction
-    assert "List of documents attached to this conversation" in instruction
+    listing = _parse_listing(instruction)
+    assert len(listing["documents"]) == 1
+    doc = listing["documents"][0]
+    assert doc["title"] == "big"
+    assert doc["access"] == ACCESS_TOOL_CALL_ONLY
+    assert doc["content"] == TOOL_CALL_ONLY_CONTENT
 
 
 def test_document_context_uses_fifo_rolling_window(_llm_config_with_context, monkeypatch):
@@ -102,34 +121,36 @@ def test_document_context_uses_fifo_rolling_window(_llm_config_with_context, mon
         "doc-3.md": "c" * 9,  # 3 tokens (ceil(9/3))
     }
 
-    async def fake_read_attachment_content(attachment):
+    async def fake_read_attachment_content(attachment):  # NOSONAR
         return attachment.file_name, content_by_name[attachment.file_name]
 
     monkeypatch.setattr(
-        "chat.clients.pydantic_ai.read_attachment_content",
+        "chat.document_context_builder.read_attachment_content",
         fake_read_attachment_content,
     )
 
     monkeypatch.setattr(
-        "chat.clients.pydantic_ai.count_approx_tokens",
+        "chat.document_context_builder.count_approx_tokens",
         lambda _text: 400,
     )
 
     instruction = async_to_sync(service._build_document_context_instruction)()  # pylint: disable=protected-access
+    listing = _parse_listing(instruction)
 
     # max_token_context=4000, ratio=0.5 => budget=1000 after buffer.
     # With 3 docs at 400 tokens each, rolling outcome should inline doc-2 + doc-3.
-    assert '"title": "doc-1"' in instruction
-    assert '"title": "doc-2"' in instruction
-    assert '"title": "doc-3"' in instruction
-    assert '"access": "tool_call_only"' in instruction
-    assert instruction.count('"access": "full-context"') == 2
-    assert '"content": "available via tools"' in instruction
+    assert listing["documents_order"] == "newest_to_oldest"
+    by_title = {d["title"]: d for d in listing["documents"]}
+    assert set(by_title) == {"doc-1", "doc-2", "doc-3"}
+    assert by_title["doc-1"]["access"] == ACCESS_TOOL_CALL_ONLY
+    assert by_title["doc-1"]["content"] == TOOL_CALL_ONLY_CONTENT
+    assert by_title["doc-2"]["access"] == ACCESS_FULL_CONTEXT
+    assert by_title["doc-3"]["access"] == ACCESS_FULL_CONTEXT
 
 
 def test_document_context_uses_configurable_ratio(_llm_config_with_context, monkeypatch, settings):
     """Budget ratio comes from Django settings and changes inlining behavior."""
-    settings.DOCUMENT_CONTEXT_BUDGET_RATIO = 0.3  # max_token_context=10 => budget=3
+    settings.DOCUMENT_CONTEXT_BUDGET_RATIO = 0.3  # max_token_context=4000 => budget=200
 
     user = UserFactory()
     conversation = ChatConversationFactory(owner=user)
@@ -155,20 +176,209 @@ def test_document_context_uses_configurable_ratio(_llm_config_with_context, monk
         "doc-2.md": "b" * 6,  # 2 tokens (ceil(6/3))
     }
 
-    async def fake_read_attachment_content(attachment):
+    async def fake_read_attachment_content(attachment):  # NOSONAR
         return attachment.file_name, content_by_name[attachment.file_name]
 
     monkeypatch.setattr(
-        "chat.clients.pydantic_ai.read_attachment_content",
+        "chat.document_context_builder.read_attachment_content",
         fake_read_attachment_content,
     )
     monkeypatch.setattr(
-        "chat.clients.pydantic_ai.count_approx_tokens",
+        "chat.document_context_builder.count_approx_tokens",
         lambda _text: 150,
     )
 
     instruction = async_to_sync(service._build_document_context_instruction)()  # pylint: disable=protected-access
-    assert '"title": "doc-1"' in instruction
-    assert '"title": "doc-2"' in instruction
-    assert '"access": "tool_call_only"' in instruction
-    assert '"access": "full-context"' in instruction
+    listing = _parse_listing(instruction)
+
+    by_title = {d["title"]: d for d in listing["documents"]}
+    assert set(by_title) == {"doc-1", "doc-2"}
+    # ratio=0.3, max_context=4000, buffer=1000 => budget=200; only newest fits.
+    assert by_title["doc-1"]["access"] == ACCESS_TOOL_CALL_ONLY
+    assert by_title["doc-2"]["access"] == ACCESS_FULL_CONTEXT
+
+
+# Cache-behavior tests for AIAgentService._build_document_context_instruction.
+#
+# These tests use REAL components: real default_storage, real Django cache
+# (LocMem in tests), real ORM. The cache-hit signal is "did we re-read from
+# storage?" - spied via mock.patch.object on default_storage.open.
+
+
+@pytest.fixture()
+def _llm_config_two_models(settings):
+    """Two LLM configs so cache-key-by-model can be exercised."""
+    settings.DOCUMENT_CONTEXT_BUDGET_RATIO = 0.5
+    settings.DOCUMENT_CONTEXT_SECURITY_BUFFER_TOKENS = 0
+    provider = LLMProvider(hrid="p", base_url="https://example.com", api_key="key")
+    settings.LLM_CONFIGURATIONS = {
+        "model-a": LLModel(
+            hrid="model-a",
+            model_name="m-a",
+            human_readable_name="Model A",
+            is_active=True,
+            icon=None,
+            system_prompt="A",
+            tools=[],
+            max_token_context=4000,
+            provider=provider,
+        ),
+        "model-b": LLModel(
+            hrid="model-b",
+            model_name="m-b",
+            human_readable_name="Model B",
+            is_active=True,
+            icon=None,
+            system_prompt="B",
+            tools=[],
+            max_token_context=8000,
+            provider=provider,
+        ),
+    }
+    settings.LLM_DEFAULT_MODEL_HRID = "model-a"
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    """Cache state must not leak between tests."""
+    cache.clear()
+    yield
+    cache.clear()
+
+
+def _make_text_attachment(*, conversation, user, file_name, content):
+    """Create an attachment and persist content under default_storage."""
+    attachment = ChatConversationAttachmentFactory(
+        conversation=conversation,
+        uploaded_by=user,
+        file_name=file_name,
+        content_type="text/markdown",
+        conversion_from=None,
+    )
+    default_storage.save(attachment.key, ContentFile(content.encode("utf-8")))
+    return attachment
+
+
+def _build(service):
+    return async_to_sync(service._build_document_context_instruction)()  # pylint: disable=protected-access
+
+
+def _spy_storage_open():
+    """Wrap default_storage.open so we can count calls without changing behavior."""
+    return mock.patch.object(default_storage, "open", wraps=default_storage.open)
+
+
+def test_first_call_reads_storage_once_per_attachment(_llm_config_two_models):
+    """B#1: cold cache -> default_storage.open called once per text attachment."""
+    user = UserFactory()
+    conversation = ChatConversationFactory(owner=user)
+    _make_text_attachment(conversation=conversation, user=user, file_name="a.md", content="alpha")
+    _make_text_attachment(conversation=conversation, user=user, file_name="b.md", content="beta")
+    service = AIAgentService(conversation, user=user)
+
+    with _spy_storage_open() as spy:
+        _build(service)
+
+    assert spy.call_count == 2
+
+
+def test_second_call_hits_cache_no_storage_reads(_llm_config_two_models):
+    """B#2: identical second call returns cached instruction with zero storage opens."""
+    user = UserFactory()
+    conversation = ChatConversationFactory(owner=user)
+    _make_text_attachment(conversation=conversation, user=user, file_name="a.md", content="alpha")
+    service = AIAgentService(conversation, user=user)
+
+    first = _build(service)  # warms cache
+    with _spy_storage_open() as spy:
+        second = _build(service)
+
+    assert spy.call_count == 0
+    assert first == second
+
+
+def test_new_attachment_invalidates_cache(_llm_config_two_models):
+    """B#3: adding an attachment changes the fingerprint -> cache miss + new doc shown."""
+    user = UserFactory()
+    conversation = ChatConversationFactory(owner=user)
+    _make_text_attachment(
+        conversation=conversation, user=user, file_name="first.md", content="alpha"
+    )
+    service = AIAgentService(conversation, user=user)
+    _build(service)  # warm
+
+    _make_text_attachment(
+        conversation=conversation, user=user, file_name="second.md", content="beta"
+    )
+    with _spy_storage_open() as spy:
+        instruction = _build(service)
+
+    # Cache miss: BOTH attachments re-read since the fingerprint covers all of them.
+    assert spy.call_count == 2
+    assert "first.md" in instruction
+    assert "second.md" in instruction
+
+
+def test_updated_at_change_invalidates_cache(_llm_config_two_models):
+    """B#4: bumping an attachment's updated_at must invalidate the cache."""
+    user = UserFactory()
+    conversation = ChatConversationFactory(owner=user)
+    attachment = _make_text_attachment(
+        conversation=conversation, user=user, file_name="a.md", content="alpha"
+    )
+    service = AIAgentService(conversation, user=user)
+    _build(service)  # warm
+
+    # save() refreshes updated_at via auto_now=True on BaseModel.
+    attachment.save()
+    with _spy_storage_open() as spy:
+        _build(service)
+
+    assert spy.call_count == 1
+
+
+def test_different_model_uses_different_cache_entry(_llm_config_two_models):
+    """B#5: switching model_hrid produces a separate cache entry."""
+    user = UserFactory()
+    conversation = ChatConversationFactory(owner=user)
+    _make_text_attachment(conversation=conversation, user=user, file_name="a.md", content="alpha")
+    service_a = AIAgentService(conversation, user=user, model_hrid="model-a")
+    service_b = AIAgentService(conversation, user=user, model_hrid="model-b")
+
+    _build(service_a)  # warm cache for model-a
+    with _spy_storage_open() as spy:
+        _build(service_b)
+
+    assert spy.call_count == 1  # model-b is its own entry
+
+
+def test_budget_ratio_change_invalidates_cache(_llm_config_two_models, settings):
+    """B#6: changing DOCUMENT_CONTEXT_BUDGET_RATIO must invalidate the cache."""
+    user = UserFactory()
+    conversation = ChatConversationFactory(owner=user)
+    _make_text_attachment(conversation=conversation, user=user, file_name="a.md", content="alpha")
+    service = AIAgentService(conversation, user=user)
+
+    _build(service)
+    settings.DOCUMENT_CONTEXT_BUDGET_RATIO = 0.25
+    with _spy_storage_open() as spy:
+        _build(service)
+
+    assert spy.call_count == 1
+
+
+def test_different_user_uses_different_cache_entry(_llm_config_two_models):
+    """B#7: same conversation accessed as a different user is a separate cache entry."""
+    owner = UserFactory()
+    other_user = UserFactory()
+    conversation = ChatConversationFactory(owner=owner)
+    _make_text_attachment(conversation=conversation, user=owner, file_name="a.md", content="alpha")
+
+    service_owner = AIAgentService(conversation, user=owner)
+    service_other = AIAgentService(conversation, user=other_user)
+
+    _build(service_owner)
+    with _spy_storage_open() as spy:
+        _build(service_other)
+
+    assert spy.call_count == 1

--- a/src/backend/chat/tests/test_document_context_builder.py
+++ b/src/backend/chat/tests/test_document_context_builder.py
@@ -1,0 +1,310 @@
+"""
+Real-component tests for build_document_context_instruction.
+
+These tests exercise the full builder logic with:
+- Real Django ORM (factory-created attachments)
+- Real default_storage (writes/reads actual content)
+- A deterministic token counter (whitespace word count) monkeypatched onto the
+  builder module so budget math is precise.
+"""
+
+import datetime
+import json
+
+from django.core.files.base import ContentFile
+from django.core.files.storage import default_storage
+
+import pytest
+from asgiref.sync import sync_to_async
+
+from chat.constants import ACCESS_FULL_CONTEXT, ACCESS_TOOL_CALL_ONLY
+from chat.document_context_builder import build_document_context_instruction
+from chat.factories import ChatConversationAttachmentFactory, ChatConversationFactory
+from chat.models import ChatConversationAttachment
+
+# transaction=True is required so writes done via sync_to_async (which run on
+# threadpool connections distinct from the test's wrapping transaction) commit
+# and are flushed via TRUNCATE between tests instead of leaking across them.
+pytestmark = pytest.mark.django_db(transaction=True)
+
+
+def _word_count(text: str) -> int:
+    """Deterministic token count - one 'token' per whitespace-separated word."""
+    return len(text.split())
+
+
+@pytest.fixture(autouse=True)
+def deterministic_token_counter(monkeypatch):
+    """Swap the builder's token counter for a deterministic word count."""
+    monkeypatch.setattr(
+        "chat.document_context_builder.count_approx_tokens",
+        _word_count,
+    )
+
+
+def _make_attachment(  # pylint: disable=too-many-arguments  # noqa: PLR0913
+    conversation, *, file_name, content, conversion_from=None, write=True, created_at=None
+):
+    """Create an attachment and (optionally) write its content to default_storage.
+
+    `created_at` lets tests pin a deterministic timestamp; auto_now_add otherwise
+    sets it at INSERT time and consecutive creates can collide on microseconds,
+    making the ("created_at", "id") ordering unstable.
+    """
+    attachment = ChatConversationAttachmentFactory(
+        conversation=conversation,
+        file_name=file_name,
+        content_type="text/markdown",
+        conversion_from=conversion_from,
+    )
+    if created_at is not None:
+        ChatConversationAttachment.objects.filter(pk=attachment.pk).update(created_at=created_at)
+        attachment.refresh_from_db(fields=["created_at"])
+    if write:
+        default_storage.save(attachment.key, ContentFile(content.encode("utf-8")))
+    return attachment
+
+
+def _ts(offset_seconds: int):
+    """Build a deterministic timestamp anchored at a fixed base + offset seconds."""
+    year = datetime.datetime.now().year
+    base = datetime.datetime(year, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc)
+    return base + datetime.timedelta(seconds=offset_seconds)
+
+
+_acreate_conversation = sync_to_async(ChatConversationFactory)
+_amake_attachment = sync_to_async(_make_attachment)
+
+
+def _parse_listing(instruction: str) -> dict:
+    """Extract and parse the JSON listing from the instruction string."""
+    prefix = "List of documents attached to this conversation:\n"
+    assert prefix in instruction, f"missing prefix in: {instruction!r}"
+    return json.loads(instruction.split(prefix, 1)[1])
+
+
+async def _build(conversation, *, max_token_context=100, budget_ratio=0.5, security_buffer=0):
+    """Run build_document_context_instruction with real components."""
+    text_attachments = await sync_to_async(list)(
+        conversation.attachments.filter(content_type__startswith="text/").order_by(
+            "created_at", "id"
+        )
+    )
+    return await build_document_context_instruction(
+        conversation_id=str(conversation.id),
+        text_attachments=text_attachments,
+        model_hrid="test-model",
+        max_token_context=max_token_context,
+        budget_ratio=budget_ratio,
+        security_buffer_tokens=security_buffer,
+    )
+
+
+@pytest.mark.asyncio
+async def test_empty_attachments_returns_empty_string():
+    """Conversation with no text attachments returns an empty instruction."""
+    conversation = await _acreate_conversation()
+    instruction = await _build(conversation)
+    assert instruction == ""
+
+
+@pytest.mark.asyncio
+async def test_single_small_doc_is_inlined():
+    """A small doc fits in budget and is inlined as full-context with content."""
+    conversation = await _acreate_conversation()
+    attachment = await _amake_attachment(
+        conversation,
+        file_name="notes.md",
+        content="ten words " * 5,  # 10 words
+    )
+
+    instruction = await _build(conversation)  # budget = 50 tokens
+    listing = _parse_listing(instruction)
+
+    assert listing["documents_order"] == "newest_to_oldest"
+    assert len(listing["documents"]) == 1
+    doc = listing["documents"][0]
+    assert doc["document_id"] == str(attachment.id)
+    assert doc["title"] == "notes.md"  # not converted, suffix kept
+    assert doc["access"] == ACCESS_FULL_CONTEXT
+    assert doc["content"] == "ten words " * 5
+    # Single doc: index == 1 wins over the index == len check, so first_uploaded_document.
+    assert doc["info"] == "first_uploaded_document"
+
+
+@pytest.mark.asyncio
+async def test_oversized_doc_kept_tool_call_only():
+    """A doc whose token count exceeds the budget stays tool_call_only."""
+    conversation = await _acreate_conversation()
+    await _amake_attachment(
+        conversation,
+        file_name="big.md",
+        content="word " * 60,  # 60 > budget 50
+    )
+
+    instruction = await _build(conversation)
+    listing = _parse_listing(instruction)
+
+    doc = listing["documents"][0]
+    assert doc["title"] == "big.md"
+    assert doc["access"] == ACCESS_TOOL_CALL_ONLY
+    assert doc["content"] == "available via tools"
+
+
+@pytest.mark.asyncio
+async def test_multiple_small_docs_all_inlined():
+    """Three small docs fit; payload ordered newest-to-oldest with info labels."""
+    conversation = await _acreate_conversation()
+    a1 = await _amake_attachment(
+        conversation, file_name="doc-1.md", content="alpha " * 10, created_at=_ts(1)
+    )  # oldest
+    a2 = await _amake_attachment(
+        conversation, file_name="doc-2.md", content="beta " * 10, created_at=_ts(2)
+    )
+    a3 = await _amake_attachment(
+        conversation, file_name="doc-3.md", content="gamma " * 10, created_at=_ts(3)
+    )  # newest
+
+    instruction = await _build(conversation)  # budget 50, total 30
+    listing = _parse_listing(instruction)
+
+    docs = listing["documents"]
+    # Newest first in the rendered listing.
+    assert [d["document_id"] for d in docs] == [str(a3.id), str(a2.id), str(a1.id)]
+    assert all(d["access"] == ACCESS_FULL_CONTEXT for d in docs)
+    content_by_id = {d["document_id"]: d["content"] for d in docs}
+    assert content_by_id[str(a1.id)] == "alpha " * 10
+    assert content_by_id[str(a2.id)] == "beta " * 10
+    assert content_by_id[str(a3.id)] == "gamma " * 10
+    # info labels are based on upload order (oldest = first, newest = last)
+    info_by_id = {d["document_id"]: d["info"] for d in docs}
+    assert info_by_id[str(a1.id)] == "first_uploaded_document"
+    assert info_by_id[str(a3.id)] == "last_uploaded_document"
+    assert info_by_id[str(a2.id)] is None
+
+
+@pytest.mark.asyncio
+async def test_fifo_eviction_evicts_oldest_when_budget_overflows():
+    """When a new doc would overflow the budget, the oldest inlined doc is evicted."""
+    conversation = await _acreate_conversation()
+    a1 = await _amake_attachment(
+        conversation, file_name="doc-1.md", content="alpha " * 25, created_at=_ts(1)
+    )  # oldest
+    a2 = await _amake_attachment(
+        conversation, file_name="doc-2.md", content="beta " * 25, created_at=_ts(2)
+    )
+    a3 = await _amake_attachment(
+        conversation, file_name="doc-3.md", content="gamma " * 25, created_at=_ts(3)
+    )  # newest
+
+    instruction = await _build(conversation)  # budget 50; 3 * 25 = 75
+    listing = _parse_listing(instruction)
+
+    by_id = {d["document_id"]: d for d in listing["documents"]}
+    # Oldest evicted, two newest inlined.
+    assert by_id[str(a1.id)]["access"] == ACCESS_TOOL_CALL_ONLY
+    assert by_id[str(a1.id)]["content"] == "available via tools"
+    assert by_id[str(a2.id)]["access"] == ACCESS_FULL_CONTEXT
+    assert by_id[str(a2.id)]["content"] == "beta " * 25
+    assert by_id[str(a3.id)]["access"] == ACCESS_FULL_CONTEXT
+    assert by_id[str(a3.id)]["content"] == "gamma " * 25
+
+
+@pytest.mark.asyncio
+async def test_oversized_and_small_docs_processed_independently():
+    """An oversized doc stays tool_call_only; smalls compete for budget normally."""
+    conversation = await _acreate_conversation()
+    a1 = await _amake_attachment(conversation, file_name="small-1.md", content="alpha " * 20)
+    a2 = await _amake_attachment(
+        conversation,
+        file_name="huge.md",
+        content="huge " * 60,  # exceeds budget alone
+    )
+    a3 = await _amake_attachment(conversation, file_name="small-2.md", content="gamma " * 20)
+
+    instruction = await _build(conversation)  # budget 50
+    listing = _parse_listing(instruction)
+
+    by_id = {d["document_id"]: d for d in listing["documents"]}
+    # Smalls inline (20 + 20 = 40 <= 50). Huge stays tool_call_only and does not
+    # consume budget - it would never have fit anyway.
+    assert by_id[str(a1.id)]["access"] == ACCESS_FULL_CONTEXT
+    assert by_id[str(a1.id)]["content"] == "alpha " * 20
+    assert by_id[str(a2.id)]["access"] == ACCESS_TOOL_CALL_ONLY
+    assert by_id[str(a2.id)]["content"] == "available via tools"
+    assert by_id[str(a3.id)]["access"] == ACCESS_FULL_CONTEXT
+    assert by_id[str(a3.id)]["content"] == "gamma " * 20
+
+
+@pytest.mark.asyncio
+async def test_failed_storage_read_isolated_from_other_docs():
+    """If one attachment fails to read, others must still inline correctly."""
+    conversation = await _acreate_conversation()
+    a1 = await _amake_attachment(conversation, file_name="ok-1.md", content="alpha " * 15)
+    # No content written for this one; default_storage.open will raise.
+    a_broken = await _amake_attachment(
+        conversation, file_name="missing.md", content="(unused)", write=False
+    )
+    a3 = await _amake_attachment(conversation, file_name="ok-2.md", content="gamma " * 15)
+
+    instruction = await _build(conversation)  # budget 50
+    listing = _parse_listing(instruction)
+
+    by_id = {d["document_id"]: d for d in listing["documents"]}
+    # Failed read kept tool_call_only with sentinel content; never inlined.
+    assert by_id[str(a_broken.id)]["access"] == ACCESS_TOOL_CALL_ONLY
+    assert by_id[str(a_broken.id)]["content"] == "available via tools"
+    # Other docs still inline (15 + 15 = 30 <= 50). The failed doc must NOT have
+    # consumed any budget - regression test for the inlineable-flag fix.
+    assert by_id[str(a1.id)]["access"] == ACCESS_FULL_CONTEXT
+    assert by_id[str(a1.id)]["content"] == "alpha " * 15
+    assert by_id[str(a3.id)]["access"] == ACCESS_FULL_CONTEXT
+    assert by_id[str(a3.id)]["content"] == "gamma " * 15
+
+
+@pytest.mark.asyncio
+async def test_fifo_eviction_can_evict_multiple_oldest_for_one_new_doc():
+    """A single new doc may evict 2+ older inlined docs to make room."""
+    conversation = await _acreate_conversation()
+    a1 = await _amake_attachment(
+        conversation, file_name="doc-1.md", content="alpha " * 15, created_at=_ts(1)
+    )  # 15 tokens, oldest
+    a2 = await _amake_attachment(
+        conversation, file_name="doc-2.md", content="beta " * 15, created_at=_ts(2)
+    )
+    a3 = await _amake_attachment(
+        conversation, file_name="doc-3.md", content="gamma " * 15, created_at=_ts(3)
+    )
+    a4 = await _amake_attachment(
+        conversation, file_name="doc-4.md", content="delta " * 40, created_at=_ts(4)
+    )  # 40 tokens, newest - evicts a1, a2, a3 to fit (40 + 15 = 55 > 50)
+
+    instruction = await _build(conversation)  # budget = 50
+    listing = _parse_listing(instruction)
+
+    by_id = {d["document_id"]: d for d in listing["documents"]}
+    # a1, a2, a3 all evicted to make room for a4.
+    for evicted in (a1, a2, a3):
+        assert by_id[str(evicted.id)]["access"] == ACCESS_TOOL_CALL_ONLY
+        assert by_id[str(evicted.id)]["content"] == "available via tools"
+    assert by_id[str(a4.id)]["access"] == ACCESS_FULL_CONTEXT
+    assert by_id[str(a4.id)]["content"] == "delta " * 40
+
+
+@pytest.mark.asyncio
+async def test_doc_exactly_filling_budget_is_inlined():
+    """Boundary: a doc whose token count equals the remaining budget still fits (<=)."""
+    conversation = await _acreate_conversation()
+    attachment = await _amake_attachment(
+        conversation,
+        file_name="exact.md",
+        content="word " * 50,  # exactly equal to budget=50
+    )
+
+    instruction = await _build(conversation)
+    listing = _parse_listing(instruction)
+
+    doc = listing["documents"][0]
+    assert doc["document_id"] == str(attachment.id)
+    assert doc["access"] == ACCESS_FULL_CONTEXT
+    assert doc["content"] == "word " * 50

--- a/src/backend/chat/tests/test_llm_configuration.py
+++ b/src/backend/chat/tests/test_llm_configuration.py
@@ -224,3 +224,31 @@ def test_llm_profile_concatenate_instruction_messages_from_json():
     )
     config = LLMConfiguration.model_validate_json(config_json)
     assert config.models[0].concatenate_instruction_messages is True
+
+
+def test_llmodel_max_token_context_parses_string():
+    """Test max_token_context accepts string values from JSON config."""
+    model = LLModel(
+        hrid="gpt-4",
+        model_name="openai:gpt-4",
+        human_readable_name="GPT-4",
+        is_active=True,
+        system_prompt="direct",
+        tools=[],
+        max_token_context="128000",
+    )
+    assert model.max_token_context == 128000
+
+
+def test_llmodel_max_token_context_rejects_invalid_value():
+    """Test max_token_context rejects non integer-like values."""
+    with pytest.raises(ValueError):
+        LLModel(
+            hrid="gpt-4",
+            model_name="openai:gpt-4",
+            human_readable_name="GPT-4",
+            is_active=True,
+            system_prompt="direct",
+            tools=[],
+            max_token_context="abc",
+        )

--- a/src/backend/chat/tests/tools/test_document_search_rag.py
+++ b/src/backend/chat/tests/tools/test_document_search_rag.py
@@ -1,0 +1,91 @@
+"""Unit tests for document_search_rag tool."""
+
+import uuid
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+from pydantic_ai import Agent, RunContext
+from pydantic_ai.usage import RunUsage
+
+from chat.tools.document_search_rag import add_document_rag_search_tool
+
+
+def test_document_search_rag_schema_accepts_document_id():
+    """The tool schema must expose document_id as an optional argument."""
+    agent = Agent("test")
+    add_document_rag_search_tool(agent)
+
+    schema = agent._function_toolset.tools["document_search_rag"].function_schema.json_schema  # pylint: disable=protected-access
+
+    assert "query" in schema["properties"]
+    assert "document_id" in schema["properties"]
+    assert schema["required"] == ["query"]
+
+
+@pytest.mark.asyncio
+async def test_document_search_rag_forwards_document_id_to_backend(settings):
+    """The optional document_id argument must target and forward selected document."""
+    settings.RAG_DOCUMENT_SEARCH_BACKEND = (
+        "chat.agent_rag.document_rag_backends.albert_rag_backend.AlbertRagBackend"
+    )
+
+    mock_backend = mock.Mock()
+    mock_backend.search.return_value = SimpleNamespace(
+        data=[SimpleNamespace(url="doc1.pdf", content="snippet")],
+        usage=SimpleNamespace(prompt_tokens=3, completion_tokens=4),
+    )
+    mock_backend_factory = mock.Mock(return_value=mock_backend)
+
+    agent = Agent("test")
+    add_document_rag_search_tool(agent)
+
+    attachment_1_id = uuid.uuid4()
+    attachment_2_id = uuid.uuid4()
+    run_ctx = RunContext(
+        model="test",
+        usage=RunUsage(),
+        deps=SimpleNamespace(
+            conversation=SimpleNamespace(
+                collection_id="123",
+                attachments=SimpleNamespace(
+                    filter=mock.Mock(
+                        return_value=SimpleNamespace(
+                            order_by=mock.Mock(
+                                return_value=[
+                                    SimpleNamespace(
+                                        id=attachment_1_id,
+                                        file_name="doc_a.md",
+                                        conversion_from=None,
+                                    ),
+                                    SimpleNamespace(
+                                        id=attachment_2_id,
+                                        file_name="dark_matter.pdf.md",
+                                        conversion_from="123/attachments/dark_matter.pdf",
+                                    ),
+                                ]
+                            )
+                        )
+                    )
+                ),
+            ),
+            session={"trace": "abc"},
+        ),
+    )
+
+    with mock.patch(
+        "chat.tools.document_search_rag.import_string", return_value=mock_backend_factory
+    ):
+        result = agent._function_toolset.tools["document_search_rag"].function(  # pylint: disable=protected-access
+            run_ctx,
+            query="test query",
+            document_id=str(attachment_2_id),
+        )
+
+    mock_backend_factory.assert_called_once_with("123")
+    mock_backend.search.assert_called_once_with(
+        "test query",
+        session={"trace": "abc"},
+        document_name="dark_matter.pdf",
+    )
+    assert result.metadata == {"sources": {"doc1.pdf"}}

--- a/src/backend/chat/tests/tools/test_document_search_rag.py
+++ b/src/backend/chat/tests/tools/test_document_search_rag.py
@@ -1,22 +1,111 @@
-"""Unit tests for document_search_rag tool."""
+"""
+Tests for the document_search_rag tool.
 
+Real components: Django ORM (factory-built conversation + attachments), real
+AlbertRagBackend instance, RunContext built from a real ContextDeps.
+The Albert HTTP endpoint is mocked at the wire level via respx.
+"""
+
+import json
 import uuid
-from types import SimpleNamespace
-from unittest import mock
+from urllib.parse import urljoin
 
 import pytest
+import respx
+from asgiref.sync import sync_to_async
+from httpx import Response
 from pydantic_ai import Agent, RunContext
+from pydantic_ai.exceptions import ModelRetry
 from pydantic_ai.usage import RunUsage
 
+from chat.clients.pydantic_ai import ContextDeps
+from chat.factories import (
+    ChatConversationAttachmentFactory,
+    ChatConversationFactory,
+    UserFactory,
+)
 from chat.tools.document_search_rag import add_document_rag_search_tool
+
+# transaction=True is required so writes done via sync_to_async (which run on
+# threadpool connections distinct from the test's wrapping transaction) commit
+# and are flushed via TRUNCATE between tests instead of leaking across them.
+pytestmark = pytest.mark.django_db(transaction=True)
+
+
+def _albert_response(*, data=None, usage=None):
+    """Build an Albert /v1/search response body."""
+    return {
+        "data": data if data is not None else [],
+        "usage": usage if usage is not None else {"prompt_tokens": 1, "completion_tokens": 0},
+    }
+
+
+def _albert_chunk(content="snippet", document_name="doc.pdf", score=0.9):
+    return {
+        "method": "semantic",
+        "chunk": {"id": 1, "content": content, "metadata": {"document_name": document_name}},
+        "score": score,
+    }
+
+
+@pytest.fixture(name="albert_settings")
+def albert_settings_fixture(settings):
+    """Point the RAG backend setting + Albert API at deterministic test values."""
+    settings.RAG_DOCUMENT_SEARCH_BACKEND = (
+        "chat.agent_rag.document_rag_backends.albert_rag_backend.AlbertRagBackend"
+    )
+    settings.ALBERT_API_URL = "https://albert.test"
+    settings.ALBERT_API_KEY = "test-key"
+    return settings
+
+
+def _search_url(settings):
+    return urljoin(settings.ALBERT_API_URL, "/v1/search")
+
+
+@sync_to_async
+def _make_conversation_and_attachments():
+    user = UserFactory()
+    conversation = ChatConversationFactory(owner=user, collection_id="123")
+    other = ChatConversationAttachmentFactory(
+        conversation=conversation,
+        uploaded_by=user,
+        file_name="other.md",
+        content_type="text/markdown",
+        conversion_from=None,
+    )
+    target = ChatConversationAttachmentFactory(
+        conversation=conversation,
+        uploaded_by=user,
+        file_name="report.pdf.md",
+        content_type="text/markdown",
+        conversion_from="123/attachments/report.pdf",
+    )
+    return user, conversation, other, target
+
+
+def _run_context(conversation, user, *, session=None):
+    return RunContext(
+        model="test",
+        usage=RunUsage(),
+        deps=ContextDeps(conversation=conversation, user=user, session=session or {"trace": "x"}),
+    )
+
+
+def _tool_function():
+    agent = Agent("test")
+    add_document_rag_search_tool(agent)
+    # pylint: disable=protected-access
+    return agent._function_toolset.tools["document_search_rag"].function
 
 
 def test_document_search_rag_schema_accepts_document_id():
     """The tool schema must expose document_id as an optional argument."""
     agent = Agent("test")
     add_document_rag_search_tool(agent)
-
-    schema = agent._function_toolset.tools["document_search_rag"].function_schema.json_schema  # pylint: disable=protected-access
+    schema = agent._function_toolset.tools[  # pylint: disable=protected-access
+        "document_search_rag"
+    ].function_schema.json_schema
 
     assert "query" in schema["properties"]
     assert "document_id" in schema["properties"]
@@ -24,68 +113,164 @@ def test_document_search_rag_schema_accepts_document_id():
 
 
 @pytest.mark.asyncio
-async def test_document_search_rag_forwards_document_id_to_backend(settings):
-    """The optional document_id argument must target and forward selected document."""
-    settings.RAG_DOCUMENT_SEARCH_BACKEND = (
-        "chat.agent_rag.document_rag_backends.albert_rag_backend.AlbertRagBackend"
+@respx.mock
+async def test_forwards_document_name_for_converted_attachment(albert_settings):
+    """document_id resolves to the original (.md-stripped) file name in the request."""
+    _, conversation, _, target = await _make_conversation_and_attachments()
+    route = respx.post(_search_url(albert_settings)).mock(
+        return_value=Response(200, json=_albert_response(data=[_albert_chunk()]))
     )
 
-    mock_backend = mock.Mock()
-    mock_backend.search.return_value = SimpleNamespace(
-        data=[SimpleNamespace(url="doc1.pdf", content="snippet")],
-        usage=SimpleNamespace(prompt_tokens=3, completion_tokens=4),
+    result = await _tool_function()(
+        _run_context(conversation, conversation.owner),
+        query="what is the deadline?",
+        document_id=str(target.id),
     )
-    mock_backend_factory = mock.Mock(return_value=mock_backend)
 
-    agent = Agent("test")
-    add_document_rag_search_tool(agent)
+    payload = json.loads(route.calls[0].request.content)
+    assert payload["metadata_filters"] == {
+        "key": "document_name",
+        "value": "report.pdf",  # ".md" suffix stripped because conversion_from is set
+        "type": "eq",
+    }
+    assert result.metadata == {"sources": {"doc.pdf"}}
 
-    attachment_1_id = uuid.uuid4()
-    attachment_2_id = uuid.uuid4()
-    run_ctx = RunContext(
-        model="test",
-        usage=RunUsage(),
-        deps=SimpleNamespace(
-            conversation=SimpleNamespace(
-                collection_id="123",
-                attachments=SimpleNamespace(
-                    filter=mock.Mock(
-                        return_value=SimpleNamespace(
-                            order_by=mock.Mock(
-                                return_value=[
-                                    SimpleNamespace(
-                                        id=attachment_1_id,
-                                        file_name="doc_a.md",
-                                        conversion_from=None,
-                                    ),
-                                    SimpleNamespace(
-                                        id=attachment_2_id,
-                                        file_name="dark_matter.pdf.md",
-                                        conversion_from="123/attachments/dark_matter.pdf",
-                                    ),
-                                ]
-                            )
-                        )
-                    )
-                ),
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_forwards_document_name_for_non_converted_attachment(albert_settings):
+    """For a native markdown doc (not converted) the file name is sent as-is."""
+    _, conversation, other, _ = await _make_conversation_and_attachments()
+    route = respx.post(_search_url(albert_settings)).mock(
+        return_value=Response(200, json=_albert_response(data=[_albert_chunk()]))
+    )
+
+    await _tool_function()(
+        _run_context(conversation, conversation.owner),
+        query="q",
+        document_id=str(other.id),
+    )
+
+    payload = json.loads(route.calls[0].request.content)
+    assert payload["metadata_filters"]["value"] == "other.md"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_no_document_id_sends_no_filter(albert_settings):
+    """Without document_id the request body has no metadata_filters key."""
+    _, conversation, _, _ = await _make_conversation_and_attachments()
+    route = respx.post(_search_url(albert_settings)).mock(
+        return_value=Response(200, json=_albert_response(data=[_albert_chunk()]))
+    )
+
+    await _tool_function()(_run_context(conversation, conversation.owner), query="q")
+
+    payload = json.loads(route.calls[0].request.content)
+    assert "metadata_filters" not in payload
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_filtered_search_empty_raises_model_retry(albert_settings):
+    """When document_id is set and Albert returns no results, raise ModelRetry."""
+    _, conversation, _, target = await _make_conversation_and_attachments()
+    respx.post(_search_url(albert_settings)).mock(
+        return_value=Response(200, json=_albert_response(data=[]))
+    )
+
+    with pytest.raises(ModelRetry) as exc:
+        await _tool_function()(
+            _run_context(conversation, conversation.owner),
+            query="q",
+            document_id=str(target.id),
+        )
+    msg = str(exc.value).lower()
+    # Message must guide the model: retry without doc_id OR disclaim to user.
+    assert "without document_id" in msg
+    assert "does not contain" in msg
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_unfiltered_search_empty_returns_empty_tool_return(albert_settings):
+    """No document_id + no results = ordinary empty ToolReturn, NOT ModelRetry."""
+    _, conversation, _, _ = await _make_conversation_and_attachments()
+    respx.post(_search_url(albert_settings)).mock(
+        return_value=Response(200, json=_albert_response(data=[]))
+    )
+
+    result = await _tool_function()(_run_context(conversation, conversation.owner), query="q")
+
+    assert result.return_value == []
+    assert result.metadata == {"sources": set()}
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_usage_tokens_propagated_to_run_context(albert_settings):
+    """Usage tokens reported by Albert are added to ctx.usage."""
+    _, conversation, _, _ = await _make_conversation_and_attachments()
+    respx.post(_search_url(albert_settings)).mock(
+        return_value=Response(
+            200,
+            json=_albert_response(
+                data=[_albert_chunk()], usage={"prompt_tokens": 42, "completion_tokens": 7}
             ),
-            session={"trace": "abc"},
-        ),
+        )
+    )
+    ctx = _run_context(conversation, conversation.owner)
+
+    await _tool_function()(ctx, query="q")
+
+    assert ctx.usage.input_tokens == 42
+    assert ctx.usage.output_tokens == 7
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_document_id_accepts_canonical_uuid_variants(albert_settings):
+    """document_id matches regardless of hyphens/case (uuid.UUID canonicalizes)."""
+    _, conversation, _, target = await _make_conversation_and_attachments()
+    route = respx.post(_search_url(albert_settings)).mock(
+        return_value=Response(200, json=_albert_response(data=[_albert_chunk()]))
     )
 
-    with mock.patch(
-        "chat.tools.document_search_rag.import_string", return_value=mock_backend_factory
-    ):
-        result = agent._function_toolset.tools["document_search_rag"].function(  # pylint: disable=protected-access
-            run_ctx,
-            query="test query",
-            document_id=str(attachment_2_id),
+    # Hyphen-less uppercase form
+    weird = str(target.id).replace("-", "").upper()
+
+    result = await _tool_function()(
+        _run_context(conversation, conversation.owner),
+        query="q",
+        document_id=weird,
+    )
+
+    payload = json.loads(route.calls[0].request.content)
+    assert payload["metadata_filters"]["value"] == "report.pdf"
+    assert result.metadata == {"sources": {"doc.pdf"}}
+
+
+@pytest.mark.asyncio
+async def test_invalid_document_id_raises_model_retry(albert_settings):  # pylint: disable=unused-argument
+    """Non-UUID document_id raises ModelRetry before any HTTP call."""
+    _, conversation, _, _ = await _make_conversation_and_attachments()
+
+    with pytest.raises(ModelRetry, match="Expected a valid UUID"):
+        await _tool_function()(
+            _run_context(conversation, conversation.owner),
+            query="q",
+            document_id="not-a-uuid",
         )
 
-    mock_backend_factory.assert_called_once_with("123")
-    mock_backend.search.assert_called_once_with(
-        "test query",
-        session={"trace": "abc"},
-        document_name="dark_matter.pdf",
-    )
-    assert result.metadata == {"sources": {"doc1.pdf"}}
+
+@pytest.mark.asyncio
+async def test_unknown_document_id_raises_model_retry(albert_settings):  # pylint: disable=unused-argument
+    """Valid UUID that doesn't match any attachment raises ModelRetry."""
+    _, conversation, _, _ = await _make_conversation_and_attachments()
+
+    with pytest.raises(ModelRetry, match="not found"):
+        await _tool_function()(
+            _run_context(conversation, conversation.owner),
+            query="q",
+            document_id=str(uuid.uuid4()),
+        )

--- a/src/backend/chat/tests/tools/test_document_summarize.py
+++ b/src/backend/chat/tests/tools/test_document_summarize.py
@@ -1,6 +1,7 @@
 """Tests for document_summarize functionality."""
 
 import io
+import uuid
 from unittest import mock
 
 from django.core.files.storage import default_storage
@@ -51,6 +52,16 @@ def fixture_mocked_context():
 def mocked_summary(_messages, _info=None):
     """Mocked summary response."""
     return ModelResponse(parts=[TextPart(content="This is a summary of the test chunk.")])
+
+
+def _queryset_like(attachments):
+    """Return a queryset-like mock supporting order_by and iteration."""
+    queryset = mock.MagicMock()
+    queryset.order_by.return_value = queryset
+    queryset.__iter__.side_effect = lambda: iter(attachments)
+    queryset.__len__.side_effect = lambda: len(attachments)
+    queryset.__getitem__.side_effect = attachments.__getitem__
+    return queryset
 
 
 @pytest.mark.asyncio
@@ -119,7 +130,7 @@ async def test_document_summarize_single_document(
     mock_attachment.file_name = "test_doc.txt"
     mock_attachment.content_type = "text/plain"
 
-    mock_conversation.attachments.filter.return_value = [mock_attachment]
+    mock_conversation.attachments.filter.return_value = _queryset_like([mock_attachment])
 
     # Mock file storage
     file_content = "This is a test document. " * 20  # Create a document with some content
@@ -176,7 +187,9 @@ async def test_document_summarize_multiple_documents(
     mock_attachment2.file_name = "doc2.txt"
     mock_attachment2.content_type = "text/plain"
 
-    mock_conversation.attachments.filter.return_value = [mock_attachment1, mock_attachment2]
+    mock_conversation.attachments.filter.return_value = _queryset_like(
+        [mock_attachment1, mock_attachment2]
+    )
 
     file_content1 = "Content of document one. " * 10
     file_content2 = "Content of document two. " * 10
@@ -209,6 +222,59 @@ async def test_document_summarize_multiple_documents(
 
 
 @pytest.mark.asyncio
+async def test_document_summarize_document_id_selects_attachment(
+    settings, mocked_context, mock_summarization_agent
+):
+    """document_id must select the matching attachment from context."""
+    settings.SUMMARIZATION_CHUNK_SIZE = 50
+    settings.SUMMARIZATION_OVERLAP_SIZE = 5
+    settings.SUMMARIZATION_CONCURRENT_REQUESTS = 2
+
+    mock_conversation = mock.Mock()
+    mock_attachment1 = mock.Mock()
+    mock_attachment1.id = uuid.uuid4()
+    mock_attachment1.key = "doc1.txt"
+    mock_attachment1.file_name = "doc1.txt"
+    mock_attachment1.content_type = "text/plain"
+
+    mock_attachment2 = mock.Mock()
+    mock_attachment2.id = uuid.uuid4()
+    mock_attachment2.key = "doc2.txt"
+    mock_attachment2.file_name = "doc2.txt"
+    mock_attachment2.content_type = "text/plain"
+
+    mock_conversation.attachments.filter.return_value = _queryset_like(
+        [mock_attachment1, mock_attachment2]
+    )
+
+    file_content1 = "Content of document one. " * 10
+    file_content2 = "Content of document two. " * 10
+
+    def mock_open_side_effect(key):
+        if key == "doc1.txt":
+            return io.BytesIO(file_content1.encode("utf-8"))
+        return io.BytesIO(file_content2.encode("utf-8"))
+
+    with mock.patch.object(default_storage, "open", side_effect=mock_open_side_effect):
+        mocked_context.deps = mock.Mock()
+        mocked_context.deps.conversation = mock_conversation
+
+        def mocked_summary_for_selected_doc(messages, _info=None):
+            messages_text = messages[0].parts[-1].content
+            if "Produce a coherent synthesis" in messages_text:
+                return ModelResponse(parts=[TextPart(content="Summary for selected document")])
+            return ModelResponse(parts=[TextPart(content="Chunk summary")])
+
+        with mock_summarization_agent(FunctionModel(mocked_summary_for_selected_doc)):
+            result = await document_summarize(
+                mocked_context, instructions=None, document_id=str(mock_attachment2.id)
+            )
+
+        assert result.return_value == "Summary for selected document"
+        assert result.metadata["sources"] == {"doc2.txt"}
+
+
+@pytest.mark.asyncio
 async def test_document_summarize_with_custom_instructions(
     settings, mocked_context, mock_summarization_agent
 ):
@@ -223,7 +289,7 @@ async def test_document_summarize_with_custom_instructions(
     mock_attachment.file_name = "test.txt"
     mock_attachment.content_type = "text/plain"
 
-    mock_conversation.attachments.filter.return_value = [mock_attachment]
+    mock_conversation.attachments.filter.return_value = _queryset_like([mock_attachment])
 
     file_content = "Test content " * 20
 
@@ -260,7 +326,7 @@ async def test_document_summarize_with_custom_instructions(
 async def test_document_summarize_no_text_attachments(mocked_context, mock_summarization_agent):
     """Test document_summarize returns error message when no text documents found."""
     mock_conversation = mock.Mock()
-    mock_conversation.attachments.filter.return_value = []
+    mock_conversation.attachments.filter.return_value = _queryset_like([])
 
     # Set up mocked_context with conversation
     mocked_context.deps = mock.Mock()
@@ -283,7 +349,7 @@ async def test_document_summarize_error_reading_document(mocked_context, mock_su
     mock_attachment.file_name = "test.txt"
     mock_attachment.content_type = "text/plain"
 
-    mock_conversation.attachments.filter.return_value = [mock_attachment]
+    mock_conversation.attachments.filter.return_value = _queryset_like([mock_attachment])
 
     with mock.patch.object(default_storage, "open", side_effect=IOError("File read error")):
         # Set up mocked_context with conversation
@@ -313,7 +379,7 @@ async def test_document_summarize_error_during_chunk_summarization(
     mock_attachment.file_name = "test.txt"
     mock_attachment.content_type = "text/plain"
 
-    mock_conversation.attachments.filter.return_value = [mock_attachment]
+    mock_conversation.attachments.filter.return_value = _queryset_like([mock_attachment])
 
     file_content = "Test content " * 20
 
@@ -353,7 +419,7 @@ async def test_document_summarize_error_during_merge(
     mock_attachment.file_name = "test.txt"
     mock_attachment.content_type = "text/plain"
 
-    mock_conversation.attachments.filter.return_value = [mock_attachment]
+    mock_conversation.attachments.filter.return_value = _queryset_like([mock_attachment])
 
     file_content = "Test content " * 20
 
@@ -394,7 +460,7 @@ async def test_document_summarize_empty_result(settings, mocked_context, mock_su
     mock_attachment.file_name = "test.txt"
     mock_attachment.content_type = "text/plain"
 
-    mock_conversation.attachments.filter.return_value = [mock_attachment]
+    mock_conversation.attachments.filter.return_value = _queryset_like([mock_attachment])
 
     file_content = "Test content " * 20
 
@@ -437,7 +503,7 @@ async def test_document_summarize_large_document_multiple_chunks(
     mock_attachment.file_name = "large_doc.txt"
     mock_attachment.content_type = "text/plain"
 
-    mock_conversation.attachments.filter.return_value = [mock_attachment]
+    mock_conversation.attachments.filter.return_value = _queryset_like([mock_attachment])
 
     # Create a large document
     file_content = "This is a word. " * 100  # Should create multiple chunks

--- a/src/backend/chat/tests/tools/test_document_summarize.py
+++ b/src/backend/chat/tests/tools/test_document_summarize.py
@@ -1,25 +1,48 @@
-"""Tests for document_summarize functionality."""
+"""
+Tests for document_summarize.
 
-import io
+Real components: Django ORM (factory-built conversation + attachments), real
+default_storage (actual content read/write), real RunContext + ContextDeps.
+
+The only thing mocked is the SummarizationAgent's LLM (via FunctionModel) -
+the standard pydantic-ai test idiom for driving deterministic model output.
+"""
+
 import uuid
 from unittest import mock
 
+from django.core.files.base import ContentFile
 from django.core.files.storage import default_storage
 
 import pytest
+from asgiref.sync import sync_to_async
 from pydantic_ai import ModelResponse, RunContext, TextPart
 from pydantic_ai.exceptions import ModelRetry
 from pydantic_ai.models.function import FunctionModel
 from pydantic_ai.usage import RunUsage
 
 from chat.agents.summarize import SummarizationAgent
+from chat.clients.pydantic_ai import ContextDeps
+from chat.factories import (
+    ChatConversationAttachmentFactory,
+    ChatConversationFactory,
+    UserFactory,
+)
 from chat.llm_configuration import LLModel, LLMProvider
 from chat.tools.document_summarize import document_summarize, summarize_chunk
+
+# transaction=True is required so writes done via sync_to_async (which run on
+# threadpool connections distinct from the test's wrapping transaction) commit
+# and are flushed via TRUNCATE between tests instead of leaking across them.
+pytestmark = pytest.mark.django_db(transaction=True)
+
+
+# Setup
 
 
 @pytest.fixture(autouse=True)
 def fixture_summarization_agent_config(settings):
-    """Fixture to set used settings for agent configuration."""
+    """Configure the LLM model used by SummarizationAgent."""
     settings.LLM_CONFIGURATIONS = {
         settings.LLM_SUMMARIZATION_MODEL_HRID: LLModel(
             hrid="mistral-model",
@@ -39,14 +62,46 @@ def fixture_summarization_agent_config(settings):
     }
 
 
-@pytest.fixture(name="mocked_context")
-def fixture_mocked_context():
-    """Fixture for a mocked RunContext."""
-    mock_ctx = mock.Mock(spec=RunContext)
-    mock_ctx.usage = RunUsage(input_tokens=0, output_tokens=0)
-    mock_ctx.max_retries = 2
-    mock_ctx.retries = {}
-    return mock_ctx
+@pytest.fixture(autouse=True)
+def summarization_settings(settings):
+    """Sensible defaults for chunking-related settings used by document_summarize."""
+    settings.SUMMARIZATION_CHUNK_SIZE = 100
+    settings.SUMMARIZATION_OVERLAP_SIZE = 10
+    settings.SUMMARIZATION_CONCURRENT_REQUESTS = 2
+    return settings
+
+
+@sync_to_async
+def _setup_conversation(attachment_specs):
+    """
+    Build a conversation, attachments, and a real RunContext in one sync block.
+
+    `attachment_specs` is a list of dicts with keys: file_name, content,
+    write (optional, default True).
+    Returns (ctx, attachments) where attachments preserves the input order.
+    """
+    user = UserFactory()
+    conversation = ChatConversationFactory(owner=user)
+    attachments = []
+    for spec in attachment_specs:
+        attachment = ChatConversationAttachmentFactory(
+            conversation=conversation,
+            uploaded_by=user,
+            file_name=spec["file_name"],
+            content_type="text/plain",
+        )
+        if spec.get("write", True):
+            default_storage.save(attachment.key, ContentFile(spec["content"].encode("utf-8")))
+        attachments.append(attachment)
+    ctx = RunContext(
+        model="test",
+        usage=RunUsage(input_tokens=0, output_tokens=0),
+        deps=ContextDeps(conversation=conversation, user=user),
+        max_retries=2,
+        retries={},
+        tool_name="document_summarize",
+    )
+    return ctx, attachments
 
 
 def mocked_summary(_messages, _info=None):
@@ -54,32 +109,31 @@ def mocked_summary(_messages, _info=None):
     return ModelResponse(parts=[TextPart(content="This is a summary of the test chunk.")])
 
 
-def _queryset_like(attachments):
-    """Return a queryset-like mock supporting order_by and iteration."""
-    queryset = mock.MagicMock()
-    queryset.order_by.return_value = queryset
-    queryset.__iter__.side_effect = lambda: iter(attachments)
-    queryset.__len__.side_effect = lambda: len(attachments)
-    queryset.__getitem__.side_effect = attachments.__getitem__
-    return queryset
+#  pure unit tests
+
+
+@pytest.fixture(name="mocked_context")
+def mocked_context_fixture():
+    """Lightweight RunContext stand-in for summarize_chunk - no DB needed."""
+    mock_ctx = mock.Mock(spec=RunContext)
+    mock_ctx.usage = RunUsage(input_tokens=0, output_tokens=0)
+    mock_ctx.max_retries = 2
+    mock_ctx.retries = {}
+    return mock_ctx
 
 
 @pytest.mark.asyncio
 async def test_summarize_chunk_returns_summary(mocked_context):
-    """Test that summarize_chunk returns a summary."""
+    """summarize_chunk returns the model's summary for a chunk."""
     summarization_agent = SummarizationAgent()
-
     with summarization_agent.override(model=FunctionModel(mocked_summary)):
-        chunk = "This is a test chunk of text that needs to be summarized."
-
-        result = await summarize_chunk(1, chunk, 1, summarization_agent, mocked_context)
-
-        assert result == "This is a summary of the test chunk."
+        result = await summarize_chunk(1, "test chunk", 1, summarization_agent, mocked_context)
+    assert result == "This is a summary of the test chunk."
 
 
 @pytest.mark.asyncio
 async def test_summarize_chunk_raises_model_retry_on_error(mocked_context):
-    """Test that summarize_chunk raises ModelRetry when agent fails."""
+    """If the agent raises mid-chunk, summarize_chunk surfaces a ModelRetry."""
     summarization_agent = SummarizationAgent()
 
     def mocked_summary_error(_messages, _info=None):
@@ -87,19 +141,13 @@ async def test_summarize_chunk_raises_model_retry_on_error(mocked_context):
         raise ValueError("Simulated LLM error")
 
     with summarization_agent.override(model=FunctionModel(mocked_summary_error)):
-        chunk = "This is a test chunk."
-
-        with pytest.raises(ModelRetry) as exc_info:
-            await summarize_chunk(1, chunk, 1, summarization_agent, mocked_context)
-
-        assert "An error occurred while summarizing a part of the document chunk" in str(
-            exc_info.value
-        )
+        with pytest.raises(ModelRetry, match="An error occurred while summarizing"):
+            await summarize_chunk(1, "chunk", 1, summarization_agent, mocked_context)
 
 
 @pytest.mark.asyncio
 async def test_summarize_chunk_handles_empty_response(mocked_context):
-    """Test that summarize_chunk handles empty responses from the agent."""
+    """Empty model output is treated as a retryable failure by pydantic-ai."""
     summarization_agent = SummarizationAgent()
 
     def mocked_empty_summary(_messages, _info=None):
@@ -107,432 +155,224 @@ async def test_summarize_chunk_handles_empty_response(mocked_context):
         return ModelResponse(parts=[TextPart(content="")])
 
     with summarization_agent.override(model=FunctionModel(mocked_empty_summary)):
-        chunk = "This is a test chunk."
-
-        # Empty responses cause ModelRetry since pydantic-ai considers them invalid
         with pytest.raises(ModelRetry):
-            await summarize_chunk(1, chunk, 1, summarization_agent, mocked_context)
+            await summarize_chunk(1, "chunk", 1, summarization_agent, mocked_context)
+
+
+#  tests with real components
 
 
 @pytest.mark.asyncio
-async def test_document_summarize_single_document(
-    settings, mocked_context, mock_summarization_agent
-):
-    """Test document_summarize with a single document."""
-    settings.SUMMARIZATION_CHUNK_SIZE = 100
-    settings.SUMMARIZATION_OVERLAP_SIZE = 10
-    settings.SUMMARIZATION_CONCURRENT_REQUESTS = 2
+async def test_document_summarize_single_document(mock_summarization_agent):
+    """A single document yields a final merged summary; sources include its file name."""
+    ctx, _ = await _setup_conversation([{"file_name": "report.txt", "content": "Lorem " * 200}])
 
-    # Create mock conversation with a text attachment
-    mock_conversation = mock.Mock()
-    mock_attachment = mock.Mock()
-    mock_attachment.key = "test_doc.txt"
-    mock_attachment.file_name = "test_doc.txt"
-    mock_attachment.content_type = "text/plain"
+    def mocked_summary_full(messages, _info=None):
+        """Mocked summary for full flow."""
+        prompt = messages[0].parts[-1].content
+        if "Produce a coherent synthesis" in prompt:
+            return ModelResponse(parts=[TextPart(content="Final merged summary")])
+        return ModelResponse(parts=[TextPart(content="Chunk summary")])
 
-    mock_conversation.attachments.filter.return_value = _queryset_like([mock_attachment])
+    with mock_summarization_agent(FunctionModel(mocked_summary_full)):
+        result = await document_summarize(ctx, instructions=None)
 
-    # Mock file storage
-    file_content = "This is a test document. " * 20  # Create a document with some content
-    with mock.patch.object(
-        default_storage, "open", return_value=io.BytesIO(file_content.encode("utf-8"))
-    ):
-        # Set up mocked_context with conversation
-        mocked_context.deps = mock.Mock()
-        mocked_context.deps.conversation = mock_conversation
-
-        call_count = {"chunk": 0, "merge": 0}
-
-        def mocked_summary_full(messages, _info=None):
-            """Mocked summary for full flow."""
-            messages_text = messages[0].parts[-1].content
-
-            if "Produce a coherent synthesis" in messages_text:
-                call_count["merge"] += 1
-                return ModelResponse(
-                    parts=[TextPart(content="# Final Summary\n\nThis is the final merged summary.")]
-                )
-
-            call_count["chunk"] += 1
-            return ModelResponse(
-                parts=[TextPart(content=f"Summary of chunk {call_count['chunk']}")]
-            )
-
-        with mock_summarization_agent(FunctionModel(mocked_summary_full)):
-            result = await document_summarize(mocked_context, instructions=None)
-
-        assert result.return_value == "# Final Summary\n\nThis is the final merged summary."
-        assert result.metadata["sources"] == {"test_doc.txt"}
-        assert call_count["merge"] == 1
+    assert result.return_value == "Final merged summary"
+    assert result.metadata["sources"] == {"report.txt"}
 
 
 @pytest.mark.asyncio
-async def test_document_summarize_multiple_documents(
-    settings, mocked_context, mock_summarization_agent
-):
-    """Test document_summarize with multiple documents."""
-    settings.SUMMARIZATION_CHUNK_SIZE = 50
-    settings.SUMMARIZATION_OVERLAP_SIZE = 5
-    settings.SUMMARIZATION_CONCURRENT_REQUESTS = 2
-
-    # Create mock conversation with multiple text attachments
-    mock_conversation = mock.Mock()
-    mock_attachment1 = mock.Mock()
-    mock_attachment1.key = "doc1.txt"
-    mock_attachment1.file_name = "doc1.txt"
-    mock_attachment1.content_type = "text/plain"
-
-    mock_attachment2 = mock.Mock()
-    mock_attachment2.key = "doc2.txt"
-    mock_attachment2.file_name = "doc2.txt"
-    mock_attachment2.content_type = "text/plain"
-
-    mock_conversation.attachments.filter.return_value = _queryset_like(
-        [mock_attachment1, mock_attachment2]
+async def test_document_summarize_multiple_documents(mock_summarization_agent):
+    """All text attachments contribute their content; sources contain every file name."""
+    ctx, _ = await _setup_conversation(
+        [
+            {"file_name": "doc1.txt", "content": "alpha " * 50},
+            {"file_name": "doc2.txt", "content": "beta " * 50},
+        ]
     )
 
-    file_content1 = "Content of document one. " * 10
-    file_content2 = "Content of document two. " * 10
+    def mocked_summary_multi(messages, _info=None):
+        """Mocked summary for multiple documents."""
+        prompt = messages[0].parts[-1].content
+        if "Produce a coherent synthesis" in prompt:
+            return ModelResponse(parts=[TextPart(content="Combined summary")])
+        return ModelResponse(parts=[TextPart(content="Chunk summary")])
 
-    def mock_open_side_effect(key):
-        """Mock file opening based on key."""
-        if key == "doc1.txt":
-            return io.BytesIO(file_content1.encode("utf-8"))
-        return io.BytesIO(file_content2.encode("utf-8"))
+    with mock_summarization_agent(FunctionModel(mocked_summary_multi)):
+        result = await document_summarize(ctx, instructions=None)
 
-    with mock.patch.object(default_storage, "open", side_effect=mock_open_side_effect):
-        # Set up mocked_context with conversation
-        mocked_context.deps = mock.Mock()
-        mocked_context.deps.conversation = mock_conversation
-
-        def mocked_summary_multi(messages, _info=None):
-            """Mocked summary for multiple documents."""
-            messages_text = messages[0].parts[-1].content
-
-            if "Produce a coherent synthesis" in messages_text:
-                return ModelResponse(parts=[TextPart(content="Combined summary of all documents")])
-
-            return ModelResponse(parts=[TextPart(content="Chunk summary")])
-
-        with mock_summarization_agent(FunctionModel(mocked_summary_multi)):
-            result = await document_summarize(mocked_context, instructions=None)
-
-        assert result.return_value == "Combined summary of all documents"
-        assert result.metadata["sources"] == {"doc1.txt", "doc2.txt"}
+    assert result.return_value == "Combined summary"
+    assert result.metadata["sources"] == {"doc1.txt", "doc2.txt"}
 
 
 @pytest.mark.asyncio
-async def test_document_summarize_document_id_selects_attachment(
-    settings, mocked_context, mock_summarization_agent
-):
-    """document_id must select the matching attachment from context."""
-    settings.SUMMARIZATION_CHUNK_SIZE = 50
-    settings.SUMMARIZATION_OVERLAP_SIZE = 5
-    settings.SUMMARIZATION_CONCURRENT_REQUESTS = 2
-
-    mock_conversation = mock.Mock()
-    mock_attachment1 = mock.Mock()
-    mock_attachment1.id = uuid.uuid4()
-    mock_attachment1.key = "doc1.txt"
-    mock_attachment1.file_name = "doc1.txt"
-    mock_attachment1.content_type = "text/plain"
-
-    mock_attachment2 = mock.Mock()
-    mock_attachment2.id = uuid.uuid4()
-    mock_attachment2.key = "doc2.txt"
-    mock_attachment2.file_name = "doc2.txt"
-    mock_attachment2.content_type = "text/plain"
-
-    mock_conversation.attachments.filter.return_value = _queryset_like(
-        [mock_attachment1, mock_attachment2]
+async def test_document_summarize_document_id_selects_attachment(mock_summarization_agent):
+    """document_id restricts summarization to a single attachment."""
+    ctx, attachments = await _setup_conversation(
+        [
+            {"file_name": "doc1.txt", "content": "alpha " * 30},
+            {"file_name": "doc2.txt", "content": "beta " * 30},
+        ]
     )
+    target = attachments[1]
 
-    file_content1 = "Content of document one. " * 10
-    file_content2 = "Content of document two. " * 10
+    def mocked_summary_for_selected_doc(messages, _info=None):
+        prompt = messages[0].parts[-1].content
+        if "Produce a coherent synthesis" in prompt:
+            return ModelResponse(parts=[TextPart(content="Selected document summary")])
+        return ModelResponse(parts=[TextPart(content="Chunk summary")])
 
-    def mock_open_side_effect(key):
-        if key == "doc1.txt":
-            return io.BytesIO(file_content1.encode("utf-8"))
-        return io.BytesIO(file_content2.encode("utf-8"))
+    with mock_summarization_agent(FunctionModel(mocked_summary_for_selected_doc)):
+        result = await document_summarize(ctx, instructions=None, document_id=str(target.id))
 
-    with mock.patch.object(default_storage, "open", side_effect=mock_open_side_effect):
-        mocked_context.deps = mock.Mock()
-        mocked_context.deps.conversation = mock_conversation
-
-        def mocked_summary_for_selected_doc(messages, _info=None):
-            messages_text = messages[0].parts[-1].content
-            if "Produce a coherent synthesis" in messages_text:
-                return ModelResponse(parts=[TextPart(content="Summary for selected document")])
-            return ModelResponse(parts=[TextPart(content="Chunk summary")])
-
-        with mock_summarization_agent(FunctionModel(mocked_summary_for_selected_doc)):
-            result = await document_summarize(
-                mocked_context, instructions=None, document_id=str(mock_attachment2.id)
-            )
-
-        assert result.return_value == "Summary for selected document"
-        assert result.metadata["sources"] == {"doc2.txt"}
+    assert result.return_value == "Selected document summary"
+    # Only the targeted document appears in sources.
+    assert result.metadata["sources"] == {"doc2.txt"}
 
 
 @pytest.mark.asyncio
-async def test_document_summarize_with_custom_instructions(
-    settings, mocked_context, mock_summarization_agent
-):
-    """Test document_summarize with custom instructions."""
-    settings.SUMMARIZATION_CHUNK_SIZE = 100
-    settings.SUMMARIZATION_OVERLAP_SIZE = 10
-    settings.SUMMARIZATION_CONCURRENT_REQUESTS = 2
+async def test_document_summarize_invalid_document_id(mock_summarization_agent):
+    """A non-UUID document_id raises ModelRetry before any chunking begins."""
+    ctx, _ = await _setup_conversation([{"file_name": "doc.txt", "content": "ignored"}])
 
-    mock_conversation = mock.Mock()
-    mock_attachment = mock.Mock()
-    mock_attachment.key = "test.txt"
-    mock_attachment.file_name = "test.txt"
-    mock_attachment.content_type = "text/plain"
-
-    mock_conversation.attachments.filter.return_value = _queryset_like([mock_attachment])
-
-    file_content = "Test content " * 20
-
-    with mock.patch.object(
-        default_storage, "open", return_value=io.BytesIO(file_content.encode("utf-8"))
-    ):
-        # Set up mocked_context with conversation
-        mocked_context.deps = mock.Mock()
-        mocked_context.deps.conversation = mock_conversation
-
-        captured_merge_prompt = []
-
-        def mocked_summary_with_instructions(messages, _info=None):
-            """Mocked summary that captures merge prompt."""
-            messages_text = messages[0].parts[-1].content
-
-            if "Produce a coherent synthesis" in messages_text:
-                captured_merge_prompt.append(messages_text)
-                return ModelResponse(parts=[TextPart(content="Summary in 2 paragraphs")])
-
-            return ModelResponse(parts=[TextPart(content="Chunk summary")])
-
-        with mock_summarization_agent(FunctionModel(mocked_summary_with_instructions)):
-            result = await document_summarize(
-                mocked_context, instructions="summary in 2 paragraphs"
-            )
-
-        assert result.return_value == "Summary in 2 paragraphs"
-        assert len(captured_merge_prompt) == 1
-        assert "summary in 2 paragraphs" in captured_merge_prompt[0]
-
-
-@pytest.mark.asyncio
-async def test_document_summarize_no_text_attachments(mocked_context, mock_summarization_agent):
-    """Test document_summarize returns error message when no text documents found."""
-    mock_conversation = mock.Mock()
-    mock_conversation.attachments.filter.return_value = _queryset_like([])
-
-    # Set up mocked_context with conversation
-    mocked_context.deps = mock.Mock()
-    mocked_context.deps.conversation = mock_conversation
-
-    # The decorator @last_model_retry_soft_fail catches ModelCannotRetry and returns a message
-    # We still need to provide a mock agent even if it won't be called
     with mock_summarization_agent(FunctionModel(mocked_summary)):
-        result = await document_summarize(mocked_context, instructions=None)
+        with pytest.raises(ModelRetry, match="Expected a valid UUID"):
+            await document_summarize(ctx, instructions=None, document_id="not-a-uuid")
+
+
+@pytest.mark.asyncio
+async def test_document_summarize_unknown_document_id(mock_summarization_agent):
+    """A valid UUID that doesn't match any attachment raises ModelRetry."""
+    ctx, _ = await _setup_conversation([{"file_name": "doc.txt", "content": "ignored"}])
+
+    with mock_summarization_agent(FunctionModel(mocked_summary)):
+        with pytest.raises(ModelRetry, match="not found"):
+            await document_summarize(ctx, instructions=None, document_id=str(uuid.uuid4()))
+
+
+@pytest.mark.asyncio
+async def test_document_summarize_with_custom_instructions(mock_summarization_agent):
+    """User-provided instructions are forwarded into the merge prompt."""
+    ctx, _ = await _setup_conversation([{"file_name": "doc.txt", "content": "data " * 80}])
+
+    captured_merge_prompt = []
+
+    def mocked_summary_with_instructions(messages, _info=None):
+        """Mocked summary that captures merge prompt."""
+        prompt = messages[0].parts[-1].content
+        if "Produce a coherent synthesis" in prompt:
+            captured_merge_prompt.append(prompt)
+            return ModelResponse(parts=[TextPart(content="Summary in 2 paragraphs")])
+        return ModelResponse(parts=[TextPart(content="Chunk summary")])
+
+    with mock_summarization_agent(FunctionModel(mocked_summary_with_instructions)):
+        result = await document_summarize(ctx, instructions="summary in 2 paragraphs")
+
+    assert result.return_value == "Summary in 2 paragraphs"
+    assert len(captured_merge_prompt) == 1
+    assert "summary in 2 paragraphs" in captured_merge_prompt[0]
+
+
+@pytest.mark.asyncio
+async def test_document_summarize_no_text_attachments(mock_summarization_agent):
+    """Conversation without text attachments returns a ModelCannotRetry message."""
+    ctx, _ = await _setup_conversation([])  # no attachments
+
+    with mock_summarization_agent(FunctionModel(mocked_summary)):
+        result = await document_summarize(ctx, instructions=None)
 
     assert "No text documents found in the conversation" in result
 
 
 @pytest.mark.asyncio
-async def test_document_summarize_error_reading_document(mocked_context, mock_summarization_agent):
-    """Test document_summarize handles errors when reading documents."""
-    mock_conversation = mock.Mock()
-    mock_attachment = mock.Mock()
-    mock_attachment.key = "test.txt"
-    mock_attachment.file_name = "test.txt"
-    mock_attachment.content_type = "text/plain"
+async def test_document_summarize_error_reading_document(mock_summarization_agent):
+    """If reading the attachment fails (no content in storage), surface a soft-fail message."""
+    # Attachment exists in DB but no bytes were written to storage -> open() raises.
+    ctx, _ = await _setup_conversation(
+        [{"file_name": "missing.txt", "content": "(unused)", "write": False}]
+    )
 
-    mock_conversation.attachments.filter.return_value = _queryset_like([mock_attachment])
+    with mock_summarization_agent(FunctionModel(mocked_summary)):
+        result = await document_summarize(ctx, instructions=None)
 
-    with mock.patch.object(default_storage, "open", side_effect=IOError("File read error")):
-        # Set up mocked_context with conversation
-        mocked_context.deps = mock.Mock()
-        mocked_context.deps.conversation = mock_conversation
-
-        # The decorator @last_model_retry_soft_fail catches ModelCannotRetry and returns a message
-        # We still need to provide a mock agent even if it won't be called
-        with mock_summarization_agent(FunctionModel(mocked_summary)):
-            result = await document_summarize(mocked_context, instructions=None)
-
-        assert "An unexpected error occurred during document summarization" in result
+    assert "None of the attached documents could be read" in result
 
 
 @pytest.mark.asyncio
-async def test_document_summarize_error_during_chunk_summarization(
-    settings, mocked_context, mock_summarization_agent
-):
-    """Test document_summarize handles ModelRetry during chunk summarization."""
-    settings.SUMMARIZATION_CHUNK_SIZE = 100
-    settings.SUMMARIZATION_OVERLAP_SIZE = 10
-    settings.SUMMARIZATION_CONCURRENT_REQUESTS = 2
+async def test_document_summarize_error_during_chunk_summarization(mock_summarization_agent):
+    """An error during chunk summarization propagates as ModelRetry."""
+    ctx, _ = await _setup_conversation([{"file_name": "doc.txt", "content": "data " * 80}])
 
-    mock_conversation = mock.Mock()
-    mock_attachment = mock.Mock()
-    mock_attachment.key = "test.txt"
-    mock_attachment.file_name = "test.txt"
-    mock_attachment.content_type = "text/plain"
+    def mocked_summary_error(messages, _info=None):
+        """Mocked summary that raises an error during chunks."""
+        prompt = messages[0].parts[-1].content
+        if "Produce a coherent synthesis" not in prompt:
+            raise ValueError("Chunk processing error")
+        return ModelResponse(parts=[TextPart(content="Final summary")])
 
-    mock_conversation.attachments.filter.return_value = _queryset_like([mock_attachment])
-
-    file_content = "Test content " * 20
-
-    with mock.patch.object(
-        default_storage, "open", return_value=io.BytesIO(file_content.encode("utf-8"))
-    ):
-        # Set up mocked_context with conversation
-        mocked_context.deps = mock.Mock()
-        mocked_context.deps.conversation = mock_conversation
-
-        def mocked_summary_error(messages, _info=None):
-            """Mocked summary that raises an error during chunks."""
-            messages_text = messages[0].parts[-1].content
-
-            if "Produce a coherent synthesis" not in messages_text:
-                raise ValueError("Chunk processing error")
-
-            return ModelResponse(parts=[TextPart(content="Final summary")])
-
-        with mock_summarization_agent(FunctionModel(mocked_summary_error)):
-            with pytest.raises(ModelRetry):
-                await document_summarize(mocked_context, instructions=None)
+    with mock_summarization_agent(FunctionModel(mocked_summary_error)):
+        with pytest.raises(ModelRetry):
+            await document_summarize(ctx, instructions=None)
 
 
 @pytest.mark.asyncio
-async def test_document_summarize_error_during_merge(
-    settings, mocked_context, mock_summarization_agent
-):
-    """Test document_summarize handles errors during final merge."""
-    settings.SUMMARIZATION_CHUNK_SIZE = 100
-    settings.SUMMARIZATION_OVERLAP_SIZE = 10
-    settings.SUMMARIZATION_CONCURRENT_REQUESTS = 2
+async def test_document_summarize_error_during_merge(mock_summarization_agent):
+    """An error during the final merge propagates as ModelRetry."""
+    ctx, _ = await _setup_conversation([{"file_name": "doc.txt", "content": "data " * 80}])
 
-    mock_conversation = mock.Mock()
-    mock_attachment = mock.Mock()
-    mock_attachment.key = "test.txt"
-    mock_attachment.file_name = "test.txt"
-    mock_attachment.content_type = "text/plain"
+    def mocked_summary_merge_error(messages, _info=None):
+        """Mocked summary that raises an error during merge."""
+        prompt = messages[0].parts[-1].content
+        if "Produce a coherent synthesis" in prompt:
+            raise ValueError("Merge error")
+        return ModelResponse(parts=[TextPart(content="Chunk summary")])
 
-    mock_conversation.attachments.filter.return_value = _queryset_like([mock_attachment])
-
-    file_content = "Test content " * 20
-
-    with mock.patch.object(
-        default_storage, "open", return_value=io.BytesIO(file_content.encode("utf-8"))
-    ):
-        # Set up mocked_context with conversation
-        mocked_context.deps = mock.Mock()
-        mocked_context.deps.conversation = mock_conversation
-
-        def mocked_summary_merge_error(messages, _info=None):
-            """Mocked summary that raises an error during merge."""
-            messages_text = messages[0].parts[-1].content
-
-            if "Produce a coherent synthesis" in messages_text:
-                raise ValueError("Merge error")
-
-            return ModelResponse(parts=[TextPart(content="Chunk summary")])
-
-        with mock_summarization_agent(FunctionModel(mocked_summary_merge_error)):
-            with pytest.raises(ModelRetry) as exc_info:
-                await document_summarize(mocked_context, instructions=None)
-
-            # Should raise ModelRetry regardless of which phase failed
-            assert "An error occurred" in str(exc_info.value)
+    with mock_summarization_agent(FunctionModel(mocked_summary_merge_error)):
+        with pytest.raises(ModelRetry, match="An error occurred"):
+            await document_summarize(ctx, instructions=None)
 
 
 @pytest.mark.asyncio
-async def test_document_summarize_empty_result(settings, mocked_context, mock_summarization_agent):
-    """Test document_summarize raises ModelRetry when summarization produces empty result."""
-    settings.SUMMARIZATION_CHUNK_SIZE = 100
-    settings.SUMMARIZATION_OVERLAP_SIZE = 10
-    settings.SUMMARIZATION_CONCURRENT_REQUESTS = 2
+async def test_document_summarize_empty_result(mock_summarization_agent):
+    """A whitespace-only merge output is treated as empty and raises ModelRetry."""
+    ctx, _ = await _setup_conversation([{"file_name": "doc.txt", "content": "data " * 80}])
 
-    mock_conversation = mock.Mock()
-    mock_attachment = mock.Mock()
-    mock_attachment.key = "test.txt"
-    mock_attachment.file_name = "test.txt"
-    mock_attachment.content_type = "text/plain"
+    def mocked_empty_summary(messages, _info=None):
+        """Mocked summary that returns empty for merge."""
+        prompt = messages[0].parts[-1].content
+        if "Produce a coherent synthesis" in prompt:
+            return ModelResponse(parts=[TextPart(content="   ")])
+        return ModelResponse(parts=[TextPart(content="Chunk summary")])
 
-    mock_conversation.attachments.filter.return_value = _queryset_like([mock_attachment])
-
-    file_content = "Test content " * 20
-
-    with mock.patch.object(
-        default_storage, "open", return_value=io.BytesIO(file_content.encode("utf-8"))
-    ):
-        # Set up mocked_context with conversation
-        mocked_context.deps = mock.Mock()
-        mocked_context.deps.conversation = mock_conversation
-
-        def mocked_empty_summary(messages, _info=None):
-            """Mocked summary that returns empty for merge."""
-            messages_text = messages[0].parts[-1].content
-
-            if "Produce a coherent synthesis" in messages_text:
-                return ModelResponse(parts=[TextPart(content="   ")])
-
-            return ModelResponse(parts=[TextPart(content="Chunk summary")])
-
-        with mock_summarization_agent(FunctionModel(mocked_empty_summary)):
-            with pytest.raises(ModelRetry) as exc_info:
-                await document_summarize(mocked_context, instructions=None)
-
-            # Should raise ModelRetry with the specific message
-            assert "The summarization produced an empty result" in str(exc_info.value)
+    with mock_summarization_agent(FunctionModel(mocked_empty_summary)):
+        with pytest.raises(ModelRetry, match="The summarization produced an empty result"):
+            await document_summarize(ctx, instructions=None)
 
 
 @pytest.mark.asyncio
 async def test_document_summarize_large_document_multiple_chunks(
-    settings, mocked_context, mock_summarization_agent
+    mock_summarization_agent, settings
 ):
-    """Test document_summarize with a large document requiring multiple chunks."""
-    settings.SUMMARIZATION_CHUNK_SIZE = 20  # Small chunk size to force multiple chunks
+    """A large document is split into multiple chunks; the merge sees all of them."""
+    settings.SUMMARIZATION_CHUNK_SIZE = 20  # Force many chunks.
     settings.SUMMARIZATION_OVERLAP_SIZE = 5
-    settings.SUMMARIZATION_CONCURRENT_REQUESTS = 2
 
-    mock_conversation = mock.Mock()
-    mock_attachment = mock.Mock()
-    mock_attachment.key = "large_doc.txt"
-    mock_attachment.file_name = "large_doc.txt"
-    mock_attachment.content_type = "text/plain"
+    ctx, _ = await _setup_conversation([{"file_name": "big.txt", "content": "word " * 200}])
 
-    mock_conversation.attachments.filter.return_value = _queryset_like([mock_attachment])
+    chunk_count = {"n": 0}
 
-    # Create a large document
-    file_content = "This is a word. " * 100  # Should create multiple chunks
-
-    with mock.patch.object(
-        default_storage, "open", return_value=io.BytesIO(file_content.encode("utf-8"))
-    ):
-        # Set up mocked_context with conversation
-        mocked_context.deps = mock.Mock()
-        mocked_context.deps.conversation = mock_conversation
-
-        chunk_count = {"count": 0}
-
-        def mocked_summary_multi_chunks(messages, _info=None):
-            """Mocked summary that counts chunks."""
-            messages_text = messages[0].parts[-1].content
-
-            if "Produce a coherent synthesis" in messages_text:
-                return ModelResponse(
-                    parts=[TextPart(content=f"Final summary of {chunk_count['count']} chunks")]
-                )
-
-            chunk_count["count"] += 1
+    def mocked_summary_multi_chunks(messages, _info=None):
+        """Mocked summary that counts chunks."""
+        prompt = messages[0].parts[-1].content
+        if "Produce a coherent synthesis" in prompt:
             return ModelResponse(
-                parts=[TextPart(content=f"Summary of chunk {chunk_count['count']}")]
+                parts=[TextPart(content=f"Final summary of {chunk_count['n']} chunks")]
             )
+        chunk_count["n"] += 1
+        return ModelResponse(parts=[TextPart(content=f"Summary of chunk {chunk_count['n']}")])
 
-        with mock_summarization_agent(FunctionModel(mocked_summary_multi_chunks)):
-            result = await document_summarize(mocked_context, instructions=None)
+    with mock_summarization_agent(FunctionModel(mocked_summary_multi_chunks)):
+        result = await document_summarize(ctx, instructions=None)
 
-        assert "Final summary of" in result.return_value
-        assert chunk_count["count"] > 1  # Ensure multiple chunks were processed
+    assert "Final summary of" in result.return_value
+    assert chunk_count["n"] > 1

--- a/src/backend/chat/tests/views/chat/conversations/test_conversation_search_with_document_id.py
+++ b/src/backend/chat/tests/views/chat/conversations/test_conversation_search_with_document_id.py
@@ -1,0 +1,161 @@
+"""
+Test model targets a specific document via document_search_rag(document_id=X)
+and the filter propagates all the way to the Albert /v1/search HTTP request body.
+"""
+
+import json
+from unittest import mock
+
+from django.contrib.sessions.backends.cache import SessionStore
+from django.core.files.base import ContentFile
+from django.core.files.storage import default_storage
+
+import httpx
+import pytest
+import respx
+from freezegun import freeze_time
+from pydantic_ai.messages import ModelMessage
+from pydantic_ai.models.function import AgentInfo, DeltaToolCall, FunctionModel
+from rest_framework import status
+
+from chat.ai_sdk_types import TextUIPart, UIMessage
+from chat.factories import ChatConversationAttachmentFactory, ChatConversationFactory
+
+pytestmark = pytest.mark.django_db(transaction=True)
+
+
+@pytest.fixture(autouse=True)
+def ai_settings(settings):
+    """Configure AI service URLs and the Albert backend."""
+    settings.RAG_DOCUMENT_SEARCH_BACKEND = (
+        "chat.agent_rag.document_rag_backends.albert_rag_backend.AlbertRagBackend"
+    )
+    settings.AI_BASE_URL = "https://www.external-ai-service.com/"
+    settings.AI_API_KEY = "test-api-key"
+    settings.AI_MODEL = "test-model"
+    settings.AI_AGENT_INSTRUCTIONS = "You are a helpful test assistant :)"
+    settings.ALBERT_API_URL = "https://albert.api.etalab.gouv.fr"
+    settings.ALBERT_API_KEY = "albert-api-key"
+    return settings
+
+
+@pytest.fixture(autouse=True)
+def mock_refresh_access_token():
+    """Bypass token refresh during the request."""
+    with mock.patch("utils.oidc.refresh_access_token") as mocked:
+        session = SessionStore()
+        session["oidc_access_token"] = "mocked-access-token"
+        mocked.return_value = session
+        yield mocked
+
+
+@respx.mock
+@freeze_time()
+def test_post_conversation_search_with_document_id_filters_albert_request(
+    api_client,
+    mock_ai_agent_service,
+):
+    """
+    The model picks one of the attached documents from the listing JSON and emits
+    document_search_rag(document_id=X). Albert receives a /v1/search POST whose
+    body carries metadata_filters with that document's name.
+    """
+    chat_conversation = ChatConversationFactory(owner__language="en-us", collection_id="123")
+    api_client.force_authenticate(user=chat_conversation.owner)
+
+    # Two pre-existing converted attachments. Order_by(created_at, id) makes
+    # alpha the older one and beta the newer; the listing reverses to newest-first,
+    # so listing.documents[0] is beta.
+    alpha = ChatConversationAttachmentFactory(
+        conversation=chat_conversation,
+        uploaded_by=chat_conversation.owner,
+        file_name="alpha.pdf.md",
+        content_type="text/markdown",
+        conversion_from="123/attachments/alpha.pdf",
+    )
+    beta = ChatConversationAttachmentFactory(
+        conversation=chat_conversation,
+        uploaded_by=chat_conversation.owner,
+        file_name="beta.pdf.md",
+        content_type="text/markdown",
+        conversion_from="123/attachments/beta.pdf",
+    )
+    default_storage.save(alpha.key, ContentFile(b"alpha document content"))
+    default_storage.save(beta.key, ContentFile(b"beta document content"))
+
+    # Mock Albert /v1/search at the wire level so we can inspect the outgoing body.
+    albert_search_route = respx.post("https://albert.api.etalab.gouv.fr/v1/search").mock(
+        return_value=httpx.Response(
+            status.HTTP_200_OK,
+            json={
+                "data": [
+                    {
+                        "method": "semantic",
+                        "chunk": {
+                            "id": 1,
+                            "content": "snippet from beta",
+                            "metadata": {"document_name": "beta.pdf"},
+                        },
+                        "score": 0.9,
+                    }
+                ],
+                "usage": {"prompt_tokens": 10, "completion_tokens": 5},
+            },
+        )
+    )
+
+    async def agent_model(messages: list[ModelMessage], _info: AgentInfo):
+        if len(messages) == 1:
+            # First call: parse the system instructions, find the doc named
+            # "beta.pdf" by title, and emit a tool call targeting it.
+            # (Title-based lookup avoids dependence on listing order, which is
+            # tie-broken by UUID when created_at is frozen by @freeze_time.)
+            instructions = messages[0].instructions or ""
+            _, _, listing_json = instructions.partition(
+                "List of documents attached to this conversation:\n"
+            )
+            listing = json.loads(listing_json)
+            target_document_id = next(
+                (doc["document_id"] for doc in listing["documents"] if doc["title"] == "beta.pdf"),
+                None,
+            )
+            assert target_document_id is not None
+            yield {
+                0: DeltaToolCall(
+                    name="document_search_rag",
+                    json_args=json.dumps(
+                        {"query": "what is in the document?", "document_id": target_document_id}
+                    ),
+                )
+            }
+        else:
+            yield "It says beta content."
+
+    user_message = UIMessage(
+        id="1",
+        role="user",
+        content="What does the document say?",
+        parts=[TextUIPart(text="What does the document say?", type="text")],
+    )
+
+    with mock_ai_agent_service(FunctionModel(stream_function=agent_model)):
+        response = api_client.post(
+            f"/api/v1.0/chats/{chat_conversation.pk}/conversation/",
+            data={"messages": [user_message.model_dump(mode="json")]},
+            format="json",
+        )
+
+    assert response.status_code == status.HTTP_200_OK
+    # Drain the stream so side effects complete.
+    _ = b"".join(response.streaming_content)  # NOSONAR
+
+    # The Albert search endpoint was called exactly once, with metadata_filters
+    # carrying the targeted document's name (beta = newest = listing[0]).
+    assert albert_search_route.call_count == 1
+    payload = json.loads(albert_search_route.calls[0].request.content)
+    assert payload["metadata_filters"] == {
+        "key": "document_name",
+        "value": "beta.pdf",  # ".md" suffix stripped because alpha/beta are converted
+        "type": "eq",
+    }
+    assert payload["prompt"] == "what is in the document?"

--- a/src/backend/chat/tests/views/chat/conversations/test_conversation_search_with_document_id_retry.py
+++ b/src/backend/chat/tests/views/chat/conversations/test_conversation_search_with_document_id_retry.py
@@ -1,0 +1,211 @@
+"""
+Test the user-visible behavior of the silent-fallback removal:
+
+1. Model calls documet_search_rag(document_id=X) on a doc that has no matches.
+2. Albert returns empty data.
+3. The tool raises ModelRetry with a broaden/disclaim message.
+4. pydantic-ai re-run the model with the retry feedback
+5. the model retries without document_id (broadens the search).
+6. Albert returns results this time
+7. the model produces a final answer using those results
+
+"""
+
+import json
+from unittest import mock
+
+from django.contrib.sessions.backends.cache import SessionStore
+from django.core.files.base import ContentFile
+from django.core.files.storage import default_storage
+
+import httpx
+import pytest
+import respx
+from freezegun import freeze_time
+from pydantic_ai.messages import ModelMessage
+from pydantic_ai.models.function import AgentInfo, DeltaToolCall, FunctionModel
+from rest_framework import status
+
+from chat.ai_sdk_types import TextUIPart, UIMessage
+from chat.factories import ChatConversationAttachmentFactory, ChatConversationFactory
+
+pytestmark = pytest.mark.django_db(transaction=True)
+
+
+@pytest.fixture(autouse=True)
+def ai_settings(settings):
+    """Configure AI service URLs and the Albert backend."""
+    settings.RAG_DOCUMENT_SEARCH_BACKEND = (
+        "chat.agent_rag.document_rag_backends.albert_rag_backend.AlbertRagBackend"
+    )
+    settings.AI_BASE_URL = "https://www.external-ai-service.com/"
+    settings.AI_API_KEY = "test-api-key"
+    settings.AI_MODEL = "test-model"
+    settings.AI_AGENT_INSTRUCTIONS = "You are a helpful test assistant :)"
+    settings.ALBERT_API_URL = "https://albert.api.etalab.gouv.fr"
+    settings.ALBERT_API_KEY = "albert-api-key"
+    return settings
+
+
+@pytest.fixture(autouse=True)
+def mock_refresh_access_token():
+    """Bypass token refresh during the request."""
+    with mock.patch("utils.oidc.refresh_access_token") as mocked:
+        session = SessionStore()
+        session["oidc_access_token"] = "mocked-access-function"
+        mocked.return_value = session
+        yield mocked
+
+
+@respx.mock
+@freeze_time()
+def test_post_conversation_filtered_empty_triggers_model_retry_then_unfiltered(
+    api_client,
+    mock_ai_agent_service,
+):
+    """
+    The Albert search returns empty when filtered by document_name;  tool
+    raises ModelRetry;  model re-run and retries without the filter,
+    receives real results the 2nd time
+    """
+    chat_conversation = ChatConversationFactory(owner__language="en-us", collection_id="123")
+    api_client.force_authenticate(user=chat_conversation.owner)
+
+    # Create `other` first (becomes oldest), then `target` (becomes newest).
+    # The listing is rendered newest-first, so listing[0] is `target`.
+    other = ChatConversationAttachmentFactory(
+        conversation=chat_conversation,
+        uploaded_by=chat_conversation.owner,
+        file_name="other.pdf.md",
+        content_type="text/markdown",
+        conversion_from="123/attachments/other.pdf",
+    )
+    target = ChatConversationAttachmentFactory(
+        conversation=chat_conversation,
+        uploaded_by=chat_conversation.owner,
+        file_name="targeted.pdf.md",
+        content_type="text/markdown",
+        conversion_from="123/attachments/targeted.pdf",
+    )
+    default_storage.save(other.key, ContentFile(b"other content"))
+    default_storage.save(target.key, ContentFile(b"targeted content"))
+
+    # Albert handler: empty for filtered queries, results for unfiltered.
+    def search_handler(request):
+        body = json.loads(request.content)
+        if "metadata_filters" in body:
+            return httpx.Response(
+                status.HTTP_200_OK,
+                json={
+                    "data": [],
+                    "usage": {"prompt_tokens": 1, "completion_tokens": 0},
+                },
+            )
+        return httpx.Response(
+            status.HTTP_200_OK,
+            json={
+                "data": [
+                    {
+                        "method": "semantic",
+                        "chunk": {
+                            "id": 7,
+                            "content": "fallback snippet from collection",
+                            "metadata": {"document_name": "other.pdf"},
+                        },
+                        "score": 0.8,
+                    }
+                ],
+                "usage": {"prompt_tokens": 5, "completion_tokens": 3},
+            },
+        )
+
+    albert_search_route = respx.post("https://albert.api.etalab.gouv.fr/v1/search").mock(
+        side_effect=search_handler
+    )
+
+    # The model is called three times:
+    #   1. Initial: emit a tool call with document_id (filter -> empty -> ModelRetry).
+    #   2. After ModelRetry: emit the same query without document_id (broaden).
+    #   3. After unfiltered results land: emit the final user-facing text.
+    call_count = {"n": 0}
+
+    async def agent_model(messages: list[ModelMessage], _info: AgentInfo):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            # Find the targeted doc by title rather than listing position;
+            # @freeze_time makes the secondary UUID sort key non-deterministic.
+            instructions = messages[0].instructions or ""
+            _, _, listing_json = instructions.partition(
+                "List of documents attached to this conversation:\n"
+            )
+            listing = json.loads(listing_json)
+            target_document_id = next(
+                (
+                    doc["document_id"]
+                    for doc in listing["documents"]
+                    if doc["title"] == "targeted.pdf"
+                ),
+                None,
+            )
+            assert target_document_id is not None
+            yield {
+                0: DeltaToolCall(
+                    name="document_search_rag",
+                    json_args=json.dumps(
+                        {"query": "what is the deadline?", "document_id": target_document_id}
+                    ),
+                )
+            }
+        elif call_count["n"] == 2:
+            yield {
+                0: DeltaToolCall(
+                    name="document_search_rag",
+                    json_args=json.dumps({"query": "what is the deadline?"}),
+                )
+            }
+        else:
+            # Compliant with the ModelRetry instruction: when broadening, the
+            # model must disclose that the targeted document had no matches and
+            # that the search was broadened.
+            yield (
+                "The targeted document did not contain the requested information, "
+                "so I broadened the search to the full collection. "
+                "The deadline is mentioned in other.pdf."
+            )
+
+    user_message = UIMessage(
+        id="1",
+        role="user",
+        content="What is the deadline?",
+        parts=[TextUIPart(text="What is the deadline?", type="text")],
+    )
+
+    with mock_ai_agent_service(FunctionModel(stream_function=agent_model)):
+        response = api_client.post(
+            f"/api/v1.0/chats/{chat_conversation.pk}/conversation/",
+            data={"messages": [user_message.model_dump(mode="json")]},
+            format="json",
+        )
+
+    assert response.status_code == status.HTTP_200_OK
+    streamed = b"".join(response.streaming_content).decode("utf-8")
+
+    # The model was driven through all three iterations.
+    assert call_count["n"] == 3
+
+    # Two HTTP calls to Albert: first filtered, second unfiltered.
+    assert albert_search_route.call_count == 2
+
+    first_payload = json.loads(albert_search_route.calls[0].request.content)
+    second_payload = json.loads(albert_search_route.calls[1].request.content)
+    assert first_payload["metadata_filters"]["value"] == "targeted.pdf"
+    assert "metadata_filters" not in second_payload
+
+    # The user-facing stream contains the final answer (sourced from the unfiltered
+    # results) - not an empty/confusing response from the filtered miss.
+    streamed_lower = streamed.lower()
+    assert "the deadline is mentioned in other.pdf" in streamed_lower
+    # The model complies with the ModelRetry instruction: it discloses that the
+    # targeted document had no matches and that the search was broadened.
+    assert "did not contain" in streamed_lower
+    assert "broadened" in streamed_lower

--- a/src/backend/chat/tests/views/chat/conversations/test_conversation_with_document_upload.py
+++ b/src/backend/chat/tests/views/chat/conversations/test_conversation_with_document_upload.py
@@ -34,6 +34,7 @@ from chat.ai_sdk_types import (
     ToolInvocationUIPart,
     UIMessage,
 )
+from chat.constants import ACCESS_TOOL_CALL_ONLY
 from chat.factories import ChatConversationFactory
 from chat.tests.utils import replace_uuids_with_placeholder
 
@@ -66,7 +67,7 @@ def _assert_document_instructions(
     doc = payload["documents"][0]
     assert doc["document_id"]
     assert doc["title"] == expected_title
-    assert doc["access"] == "tool_call_only"
+    assert doc["access"] == ACCESS_TOOL_CALL_ONLY
     assert doc["content"] is None
     assert doc["info"] == expected_info
 
@@ -179,24 +180,32 @@ def fixture_mock_document_api():
         status=status.HTTP_201_CREATED,
     )
 
-    # Mock document search
+    # Mock document search.
+    # Two clients use this endpoint:
+    # - AlbertRagBackend.asearch via httpx -> intercepted by respx
+    # - FindRagBackend (sync search via base-class fallback) via requests
+    #   -> intercepted by responses
+    search_response_body = {
+        "data": [
+            {
+                "method": search_method,
+                "chunk": {
+                    "id": 123,
+                    "content": document_content,
+                    "metadata": {"document_name": document_name},
+                },
+                "score": search_score,
+            }
+        ],
+        "usage": {"prompt_tokens": prompt_tokens, "completion_tokens": completion_tokens},
+    }
     responses.post(
         "https://albert.api.etalab.gouv.fr/v1/search",
-        json={
-            "data": [
-                {
-                    "method": search_method,
-                    "chunk": {
-                        "id": 123,
-                        "content": document_content,
-                        "metadata": {"document_name": document_name},
-                    },
-                    "score": search_score,
-                }
-            ],
-            "usage": {"prompt_tokens": prompt_tokens, "completion_tokens": completion_tokens},
-        },
+        json=search_response_body,
         status=status.HTTP_200_OK,
+    )
+    respx.post("https://albert.api.etalab.gouv.fr/v1/search").mock(
+        return_value=httpx.Response(status.HTTP_200_OK, json=search_response_body)
     )
 
     # Mock document indexing (Find API)
@@ -262,24 +271,28 @@ def fixture_mock_odt_document_api():
         status=status.HTTP_201_CREATED,
     )
 
-    # Mock document search
+    # Mock document search (sync via responses, async via respx).
+    search_response_body = {
+        "data": [
+            {
+                "method": search_method,
+                "chunk": {
+                    "id": 123,
+                    "content": document_content,
+                    "metadata": {"document_name": document_name},
+                },
+                "score": search_score,
+            }
+        ],
+        "usage": {"prompt_tokens": prompt_tokens, "completion_tokens": completion_tokens},
+    }
     responses.post(
         "https://albert.api.etalab.gouv.fr/v1/search",
-        json={
-            "data": [
-                {
-                    "method": search_method,
-                    "chunk": {
-                        "id": 123,
-                        "content": document_content,
-                        "metadata": {"document_name": document_name},
-                    },
-                    "score": search_score,
-                }
-            ],
-            "usage": {"prompt_tokens": prompt_tokens, "completion_tokens": completion_tokens},
-        },
+        json=search_response_body,
         status=status.HTTP_200_OK,
+    )
+    respx.post("https://albert.api.etalab.gouv.fr/v1/search").mock(
+        return_value=httpx.Response(status.HTTP_200_OK, json=search_response_body)
     )
 
     # Mock document indexing (Find API)

--- a/src/backend/chat/tests/views/chat/conversations/test_conversation_with_document_upload.py
+++ b/src/backend/chat/tests/views/chat/conversations/test_conversation_with_document_upload.py
@@ -36,11 +36,6 @@ from chat.ai_sdk_types import (
 )
 from chat.factories import ChatConversationFactory
 from chat.tests.utils import replace_uuids_with_placeholder
-from chat.tools.descriptions import (
-    DOCUMENT_SEARCH_RAG_SYSTEM_PROMPT,
-    DOCUMENT_SUMMARIZE_SYSTEM_PROMPT,
-    SELF_DOCUMENTATION_TOOL_DESCRIPTION,
-)
 
 # enable database transactions for tests:
 # transaction=True ensures that the data are available in the database
@@ -48,19 +43,32 @@ from chat.tools.descriptions import (
 pytestmark = pytest.mark.django_db(transaction=True)
 
 
-def _expected_document_instructions(today_prompt_date: str) -> str:
-    """Return expected concatenated system instructions for document conversations."""
-    return (
-        "You are a helpful test assistant :)\n\n"
-        f"{today_prompt_date}\n\n"
-        "Answer in english.\n\n"
-        f"{SELF_DOCUMENTATION_TOOL_DESCRIPTION}\n\n"
-        f"{DOCUMENT_SEARCH_RAG_SYSTEM_PROMPT}\n\n"
-        f"{DOCUMENT_SUMMARIZE_SYSTEM_PROMPT}\n\n"
-        "[Internal context] User documents are attached to this conversation. "
-        "Do not request re-upload of documents; consider them already "
-        "available via the internal store."
+def _assert_document_instructions(
+    instructions: str,
+    today_prompt_date: str,
+    expected_title: str,
+    *,
+    expected_info: str | None = None,
+) -> None:
+    """Assert document instruction format and payload fields."""
+    assert f"{today_prompt_date}\n\nAnswer in english." in instructions
+    assert "User documents are attached to this conversation." in instructions
+    assert "consider them already available" in instructions
+    assert "List of documents attached to this conversation:\n" in instructions
+
+    _, _, payload_text = instructions.partition(
+        "List of documents attached to this conversation:\n"
     )
+    payload = json.loads(payload_text)
+    assert payload["documents_order"] == "newest_to_oldest"
+    assert len(payload["documents"]) == 1
+
+    doc = payload["documents"][0]
+    assert doc["document_id"]
+    assert doc["title"] == expected_title
+    assert doc["access"] == "tool_call_only"
+    assert doc["content"] is None
+    assert doc["info"] == expected_info
 
 
 @pytest.fixture(
@@ -518,9 +526,11 @@ def test_post_conversation_with_document_upload(
     assert len(chat_conversation.pydantic_messages) == 4
 
     _run_id = chat_conversation.pydantic_messages[0]["run_id"]
+    instruction_0 = chat_conversation.pydantic_messages[0]["instructions"]
+    _assert_document_instructions(instruction_0, today_prompt_date, "sample.pdf.md")
 
     assert chat_conversation.pydantic_messages[0] == {
-        "instructions": _expected_document_instructions(today_prompt_date),
+        "instructions": instruction_0,
         "kind": "request",
         "metadata": None,
         "parts": [
@@ -566,8 +576,10 @@ def test_post_conversation_with_document_upload(
         },
         "run_id": _run_id,
     }
+    instruction_2 = chat_conversation.pydantic_messages[2]["instructions"]
+    _assert_document_instructions(instruction_2, today_prompt_date, "sample.pdf.md")
     assert chat_conversation.pydantic_messages[2] == {
-        "instructions": _expected_document_instructions(today_prompt_date),
+        "instructions": instruction_2,
         "kind": "request",
         "metadata": None,
         "parts": [
@@ -833,8 +845,10 @@ def test_post_conversation_with_document_upload_summarize(  # pylint: disable=to
     assert len(chat_conversation.pydantic_messages) == 4
 
     _run_id = chat_conversation.pydantic_messages[0]["run_id"]
+    instruction_0 = chat_conversation.pydantic_messages[0]["instructions"]
+    _assert_document_instructions(instruction_0, today_prompt_date, "sample.pdf.md")
     assert chat_conversation.pydantic_messages[0] == {
-        "instructions": _expected_document_instructions(today_prompt_date),
+        "instructions": instruction_0,
         "kind": "request",
         "metadata": None,
         "parts": [
@@ -880,8 +894,10 @@ def test_post_conversation_with_document_upload_summarize(  # pylint: disable=to
         },
         "run_id": _run_id,
     }
+    instruction_2 = chat_conversation.pydantic_messages[2]["instructions"]
+    _assert_document_instructions(instruction_2, today_prompt_date, "sample.pdf.md")
     assert chat_conversation.pydantic_messages[2] == {
-        "instructions": _expected_document_instructions(today_prompt_date),
+        "instructions": instruction_2,
         "kind": "request",
         "metadata": None,
         "parts": [
@@ -1074,9 +1090,11 @@ def test_post_conversation_with_odt_document_upload(
     assert len(chat_conversation.pydantic_messages) == 4
 
     _run_id = chat_conversation.pydantic_messages[0]["run_id"]
+    instruction_0 = chat_conversation.pydantic_messages[0]["instructions"]
+    _assert_document_instructions(instruction_0, today_prompt_date, "sample.odt.md")
 
     assert chat_conversation.pydantic_messages[0] == {
-        "instructions": _expected_document_instructions(today_prompt_date),
+        "instructions": instruction_0,
         "kind": "request",
         "metadata": None,
         "parts": [
@@ -1122,8 +1140,10 @@ def test_post_conversation_with_odt_document_upload(
         },
         "run_id": _run_id,
     }
+    instruction_2 = chat_conversation.pydantic_messages[2]["instructions"]
+    _assert_document_instructions(instruction_2, today_prompt_date, "sample.odt.md")
     assert chat_conversation.pydantic_messages[2] == {
-        "instructions": _expected_document_instructions(today_prompt_date),
+        "instructions": instruction_2,
         "kind": "request",
         "metadata": None,
         "parts": [

--- a/src/backend/chat/tests/views/chat/conversations/test_conversation_with_document_url.py
+++ b/src/backend/chat/tests/views/chat/conversations/test_conversation_with_document_url.py
@@ -1,5 +1,6 @@
 """Unit tests for chat conversation actions with document URL."""
 
+import json
 import uuid
 
 # pylint: disable=too-many-lines
@@ -42,9 +43,16 @@ from chat.tools.descriptions import (
 pytestmark = pytest.mark.django_db(transaction=True)
 
 
-def _expected_document_instructions(today_prompt_date: str) -> str:
+def _expected_document_instructions(
+    today_prompt_date: str,
+    document_id: str | None = None,
+    document_title: str | None = None,
+    *,
+    is_converted: bool = False,
+    info: str | None = None,
+) -> str:
     """Return expected concatenated system instructions for document conversations."""
-    return (
+    base = (
         "You are a helpful test assistant :)\n\n"
         f"{today_prompt_date}\n\n"
         "Answer in english.\n\n"
@@ -53,8 +61,58 @@ def _expected_document_instructions(today_prompt_date: str) -> str:
         f"{DOCUMENT_SUMMARIZE_SYSTEM_PROMPT}\n\n"
         "[Internal context] User documents are attached to this conversation. "
         "Do not request re-upload of documents; consider them already available "
-        "via the internal store."
+        "either here in context or via the internal store."
     )
+    if not document_title or not document_id:
+        return base
+    normalized_title = document_title.removesuffix(".md") if is_converted else document_title
+    # Payload for hybrid document context
+    payload = {
+        "documents_order": "newest_to_oldest",
+        "documents": [
+            {
+                "document_id": document_id,
+                "title": normalized_title,
+                "access": "tool_call_only",
+                "content": None,
+                "info": info,
+            }
+        ],
+        "note": (
+            "Documents marked 'tool_call_only' are accessible through "
+            "tools like RAG search or summary. "
+        ),
+    }
+    return (
+        f"{base}\n\nList of documents attached to this conversation:\n"
+        f"{json.dumps(payload, ensure_ascii=False, indent=2)}"
+    )
+
+
+def _assert_document_instructions(
+    instructions: str,
+    today_prompt_date: str,
+    expected_title: str,
+    *,
+    expected_info: str | None = None,
+) -> None:
+    """Assert the document instruction payload shape without hardcoding document_id."""
+    assert f"{today_prompt_date}\n\nAnswer in english." in instructions
+    assert "User documents are attached to this conversation." in instructions
+    assert "consider them already available" in instructions
+
+    _, _, payload_text = instructions.partition(
+        "List of documents attached to this conversation:\n"
+    )
+    payload = json.loads(payload_text)
+    assert payload["documents_order"] == "newest_to_oldest"
+    assert len(payload["documents"]) == 1
+    document = payload["documents"][0]
+    assert document["document_id"]
+    assert document["title"] == expected_title
+    assert document["access"] == "tool_call_only"
+    assert document["content"] is None
+    assert document["info"] == expected_info
 
 
 @pytest.fixture(
@@ -154,16 +212,14 @@ def test_post_conversation_with_local_pdf_document_url(
     )
 
     async def agent_model(messages: list[ModelMessage], _info: AgentInfo):
-        assert messages == [
-            ModelRequest(
-                parts=[
-                    UserPromptPart(content=["What is in this document?"], timestamp=timezone.now())
-                ],
-                instructions=_expected_document_instructions(today_prompt_date),
-                run_id=messages[0].run_id,
-                timestamp=timezone.now(),
-            )
-        ]
+        assert len(messages) == 1
+        assert messages[0] == ModelRequest(
+            parts=[UserPromptPart(content=["What is in this document?"], timestamp=timezone.now())],
+            instructions=messages[0].instructions,
+            run_id=messages[0].run_id,
+            timestamp=timezone.now(),
+        )
+        _assert_document_instructions(messages[0].instructions, today_prompt_date, "sample.pdf")
         yield "This is a document about a single pixel."
 
     # Use the fixture with FunctionModel
@@ -233,9 +289,11 @@ def test_post_conversation_with_local_pdf_document_url(
     _formatted_date = formats.date_format(timezone.now(), "l d/m/Y", use_l10n=False)
 
     _run_id = chat_conversation.pydantic_messages[0]["run_id"]
+    instruction_0 = chat_conversation.pydantic_messages[0]["instructions"]
+    _assert_document_instructions(instruction_0, today_prompt_date, "sample.pdf")
     assert chat_conversation.pydantic_messages == [
         {
-            "instructions": _expected_document_instructions(today_prompt_date),
+            "instructions": instruction_0,
             "kind": "request",
             "metadata": None,
             "parts": [
@@ -792,8 +850,8 @@ def test_post_conversation_with_local_document_url_in_history(  # pylint: disabl
 def test_post_conversation_with_local_not_pdf_document_url(
     # pylint: disable=too-many-arguments,too-many-positional-arguments
     api_client,
-    today_prompt_date,
     mock_ai_agent_service,
+    today_prompt_date,
     file_name,
     content_type,
 ):
@@ -856,22 +914,22 @@ def test_post_conversation_with_local_not_pdf_document_url(
     async def agent_model(messages: list[ModelMessage], _info: AgentInfo):
         timestamp_now = timezone.now()
 
-        assert messages == [
-            ModelRequest(
-                parts=[
-                    UserPromptPart(
-                        content=[
-                            "What is in this document?",
-                            # No presigned URL for non-PDF documents (not supporter by LLM)
-                        ],
-                        timestamp=timestamp_now,
-                    ),
-                ],
-                timestamp=timestamp_now,
-                instructions=_expected_document_instructions(today_prompt_date),
-                run_id=messages[0].run_id,
-            )
-        ]
+        assert len(messages) == 1
+        assert messages[0] == ModelRequest(
+            parts=[
+                UserPromptPart(
+                    content=[
+                        "What is in this document?",
+                        # No presigned URL for non-PDF documents (not supporter by LLM)
+                    ],
+                    timestamp=timestamp_now,
+                ),
+            ],
+            timestamp=timestamp_now,
+            instructions=messages[0].instructions,
+            run_id=messages[0].run_id,
+        )
+        _assert_document_instructions(messages[0].instructions, today_prompt_date, file_name)
         yield "This is a document about you."
 
     # Use the fixture with FunctionModel
@@ -941,9 +999,11 @@ def test_post_conversation_with_local_not_pdf_document_url(
     _formatted_date = formats.date_format(timezone.now(), "l d/m/Y", use_l10n=False)
 
     _run_id = chat_conversation.pydantic_messages[0]["run_id"]
+    instruction_0 = chat_conversation.pydantic_messages[0]["instructions"]
+    _assert_document_instructions(instruction_0, today_prompt_date, file_name)
     assert chat_conversation.pydantic_messages == [
         {
-            "instructions": (_expected_document_instructions(today_prompt_date)),
+            "instructions": instruction_0,
             "kind": "request",
             "metadata": None,
             "parts": [

--- a/src/backend/chat/tests/views/chat/conversations/test_conversation_with_document_url.py
+++ b/src/backend/chat/tests/views/chat/conversations/test_conversation_with_document_url.py
@@ -29,6 +29,7 @@ from chat.ai_sdk_types import (
     TextUIPart,
     UIMessage,
 )
+from chat.constants import ACCESS_TOOL_CALL_ONLY
 from chat.factories import ChatConversationAttachmentFactory, ChatConversationFactory
 from chat.tests.utils import replace_uuids_with_placeholder
 from chat.tools.descriptions import (
@@ -73,13 +74,13 @@ def _expected_document_instructions(
             {
                 "document_id": document_id,
                 "title": normalized_title,
-                "access": "tool_call_only",
+                "access": ACCESS_TOOL_CALL_ONLY,
                 "content": None,
                 "info": info,
             }
         ],
         "note": (
-            "Documents marked 'tool_call_only' are accessible through "
+            f"Documents marked '{ACCESS_TOOL_CALL_ONLY}' are accessible through "
             "tools like RAG search or summary. "
         ),
     }
@@ -110,7 +111,7 @@ def _assert_document_instructions(
     document = payload["documents"][0]
     assert document["document_id"]
     assert document["title"] == expected_title
-    assert document["access"] == "tool_call_only"
+    assert document["access"] == ACCESS_TOOL_CALL_ONLY
     assert document["content"] is None
     assert document["info"] == expected_info
 

--- a/src/backend/chat/tools/descriptions.py
+++ b/src/backend/chat/tools/descriptions.py
@@ -16,6 +16,13 @@ Must be used whenever the user asks for specific information while having docume
 Do NOT use this tool for up-to-date information or current events.
 
 The query must contain all information to find accurate results.
+
+When `document_id` is provided, search is filtered to a single
+text attachment by UUID from the context documents list.
+Example:
+user : "Based on the X, answer the question"
+query : "question"
+document_id : id_from_context
 """
 
 DOCUMENT_SUMMARIZE_SYSTEM_PROMPT = """
@@ -36,8 +43,9 @@ Instructions are optional but should reflect the user's request.
 
 Examples:
 "Summarize this doc in 2 paragraphs" -> instructions = "summary in 2 paragraphs"
-"Summarize this doc in English" -> instructions = "In English"
-"Summarize this doc" -> instructions = "" (default)
+"Summarize this doc in English" -> instructions = "In English", document_id=None
+"Summarize this doc" -> instructions = "" (default), document_id=None
+"Summarize this specific doc" -> instructions = "", document_id=id_from_context
 """
 
 WEB_SEARCH_TOOL_DESCRIPTION = """

--- a/src/backend/chat/tools/descriptions.py
+++ b/src/backend/chat/tools/descriptions.py
@@ -20,8 +20,8 @@ The query must contain all information to find accurate results.
 When `document_id` is provided, search is filtered to a single
 text attachment by UUID from the context documents list.
 Example:
-user : "Based on the X, answer the question"
-query : "question"
+user : "Based on the report, what is the deadline?"
+query : "what is the deadline?"
 document_id : id_from_context
 """
 

--- a/src/backend/chat/tools/document_search_rag.py
+++ b/src/backend/chat/tools/document_search_rag.py
@@ -1,9 +1,12 @@
 """Tool to perform a document search using Albert RAG API."""
 
+import uuid
+
 from django.conf import settings
 from django.utils.module_loading import import_string
 
 from pydantic_ai import Agent, RunContext, RunUsage
+from pydantic_ai.exceptions import ModelRetry
 from pydantic_ai.messages import ToolReturn
 
 from chat.tools.descriptions import (
@@ -16,7 +19,12 @@ def add_document_rag_search_tool(agent: Agent) -> None:
     """Add the document RAG tool to an existing agent."""
 
     @agent.tool(description=DOCUMENT_SEARCH_RAG_TOOL_DESCRIPTION)
-    def document_search_rag(ctx: RunContext, query: str) -> ToolReturn:
+    def document_search_rag(
+        ctx: RunContext,
+        query: str,
+        document_id: str | None = None,
+    ) -> ToolReturn:
+        # pylint: disable=line-too-long
         """
         Search indexed conversation documents using the configured RAG backend.
 
@@ -24,22 +32,58 @@ def add_document_rag_search_tool(agent: Agent) -> None:
         ``ctx.deps.conversation.collection_id`` and returns retrieved chunks.
         The query should be self-contained to maximize retrieval quality.
 
-        Side effects:
-            - Updates ``ctx.usage`` with token usage reported by the backend.
-
-        Returns:
-            ToolReturn: Retrieved passages in ``return_value`` and source URLs in
-            ``metadata["sources"]``.
+        When ``document_id`` is provided, search is filtered to a single
+        text attachment by UUID.
 
         Args:
             ctx (RunContext): The run context containing the conversation.
             query (str): The query to search the documents for.
+            document_id (str | None): Optional document filter, attachment UUID from context.
+
+        Examples:
+        user : "Based on the X, answer the question"
+        query : "question"
+        document_id : id_from_context
         """
+        # pylint: enable=line-too-long
         document_store_backend = import_string(settings.RAG_DOCUMENT_SEARCH_BACKEND)
 
         document_store = document_store_backend(ctx.deps.conversation.collection_id)
+        document_name = None
+        if document_id is not None:
+            text_attachments = list(
+                ctx.deps.conversation.attachments.filter(content_type__startswith="text/").order_by(
+                    "created_at", "id"
+                )
+            )
+            try:
+                parsed_document_id = uuid.UUID(document_id)
+            except ValueError as exc:
+                raise ModelRetry("Invalid document_id. Expected a valid UUID.") from exc
+            selected_attachment = next(
+                (
+                    attachment
+                    for attachment in text_attachments
+                    if getattr(attachment, "id", None) == parsed_document_id
+                    or str(getattr(attachment, "id", "")) == document_id
+                ),
+                None,
+            )
+            if selected_attachment is None:
+                raise ModelRetry("document_id was not found among attached text documents.")
 
-        rag_results = document_store.search(query, session=ctx.deps.session)
+            # Converted attachments are stored as markdown blobs (e.g. "report.pdf.md")
+            # while RAG metadata keeps the original file name (e.g. "report.pdf").
+            if getattr(selected_attachment, "conversion_from", None):
+                document_name = selected_attachment.file_name.removesuffix(".md")
+            else:
+                document_name = selected_attachment.file_name
+
+        rag_results = document_store.search(
+            query,
+            session=ctx.deps.session,
+            document_name=document_name,
+        )
 
         ctx.usage += RunUsage(
             input_tokens=rag_results.usage.prompt_tokens,

--- a/src/backend/chat/tools/document_search_rag.py
+++ b/src/backend/chat/tools/document_search_rag.py
@@ -1,25 +1,26 @@
 """Tool to perform a document search using Albert RAG API."""
 
-import uuid
-
 from django.conf import settings
 from django.utils.module_loading import import_string
 
+from asgiref.sync import sync_to_async
 from pydantic_ai import Agent, RunContext, RunUsage
 from pydantic_ai.exceptions import ModelRetry
 from pydantic_ai.messages import ToolReturn
 
+from chat.constants import TEXT_MIME_PREFIX
 from chat.tools.descriptions import (
     DOCUMENT_SEARCH_RAG_SYSTEM_PROMPT,
     DOCUMENT_SEARCH_RAG_TOOL_DESCRIPTION,
 )
+from chat.tools.utils import resolve_attachment_by_id
 
 
 def add_document_rag_search_tool(agent: Agent) -> None:
     """Add the document RAG tool to an existing agent."""
 
     @agent.tool(description=DOCUMENT_SEARCH_RAG_TOOL_DESCRIPTION)
-    def document_search_rag(
+    async def document_search_rag(
         ctx: RunContext,
         query: str,
         document_id: str | None = None,
@@ -41,8 +42,8 @@ def add_document_rag_search_tool(agent: Agent) -> None:
             document_id (str | None): Optional document filter, attachment UUID from context.
 
         Examples:
-        user : "Based on the X, answer the question"
-        query : "question"
+        user : "Based on the report, what is the deadline?"
+        query : "what is the deadline?"
         document_id : id_from_context
         """
         # pylint: enable=line-too-long
@@ -51,26 +52,12 @@ def add_document_rag_search_tool(agent: Agent) -> None:
         document_store = document_store_backend(ctx.deps.conversation.collection_id)
         document_name = None
         if document_id is not None:
-            text_attachments = list(
-                ctx.deps.conversation.attachments.filter(content_type__startswith="text/").order_by(
-                    "created_at", "id"
-                )
+            text_attachments = await sync_to_async(list)(
+                ctx.deps.conversation.attachments.filter(
+                    content_type__startswith=TEXT_MIME_PREFIX
+                ).order_by("created_at", "id")
             )
-            try:
-                parsed_document_id = uuid.UUID(document_id)
-            except ValueError as exc:
-                raise ModelRetry("Invalid document_id. Expected a valid UUID.") from exc
-            selected_attachment = next(
-                (
-                    attachment
-                    for attachment in text_attachments
-                    if getattr(attachment, "id", None) == parsed_document_id
-                    or str(getattr(attachment, "id", "")) == document_id
-                ),
-                None,
-            )
-            if selected_attachment is None:
-                raise ModelRetry("document_id was not found among attached text documents.")
+            selected_attachment = resolve_attachment_by_id(text_attachments, document_id)
 
             # Converted attachments are stored as markdown blobs (e.g. "report.pdf.md")
             # while RAG metadata keeps the original file name (e.g. "report.pdf").
@@ -79,7 +66,7 @@ def add_document_rag_search_tool(agent: Agent) -> None:
             else:
                 document_name = selected_attachment.file_name
 
-        rag_results = document_store.search(
+        rag_results = await document_store.asearch(
             query,
             session=ctx.deps.session,
             document_name=document_name,
@@ -89,6 +76,20 @@ def add_document_rag_search_tool(agent: Agent) -> None:
             input_tokens=rag_results.usage.prompt_tokens,
             output_tokens=rag_results.usage.completion_tokens,
         )
+
+        if document_name is not None and not rag_results.data:
+            raise ModelRetry(
+                f"No results found in document filtered by document_id={document_id!r}. "
+                "If the user's question was not specific to this document, retry "
+                "document_search_rag with the same query but WITHOUT document_id to "
+                "search across the full collection. In that case, your final answer "
+                "to the user MUST explicitly state that the targeted document did "
+                "not contain the requested information and that you broadened the "
+                "search to the full collection. "
+                "If the question was specific to this document, do not retry - "
+                "inform the user that this document does not contain the requested "
+                "information."
+            )
 
         return ToolReturn(
             return_value=rag_results.data,

--- a/src/backend/chat/tools/document_summarize.py
+++ b/src/backend/chat/tools/document_summarize.py
@@ -2,7 +2,6 @@
 
 import asyncio
 import logging
-import uuid
 
 from django.conf import settings
 from django.core.files.storage import default_storage
@@ -14,8 +13,9 @@ from pydantic_ai.exceptions import ModelRetry
 from pydantic_ai.messages import ToolReturn
 
 from chat.agents.summarize import SummarizationAgent
+from chat.constants import TEXT_MIME_PREFIX
 from chat.tools.exceptions import ModelCannotRetry
-from chat.tools.utils import last_model_retry_soft_fail
+from chat.tools.utils import last_model_retry_soft_fail, resolve_attachment_by_id
 
 logger = logging.getLogger(__name__)
 
@@ -25,6 +25,72 @@ def read_document_content(doc):
     """Read document content asynchronously."""
     with default_storage.open(doc.key) as f:
         return doc.file_name, f.read().decode("utf-8")
+
+
+async def _read_documents_safely(text_attachment, document_id):
+    """
+    Read each attachment from object storage individually so that one
+    unreadable file (missing key, transient S3 error, decoding failure)
+    does not abort the whole summarization. Behavior depends on whether
+    the user targeted a specific document:
+      - document_id set  -> the failure is fatal for THIS request: surface a
+        doc-specific ModelCannotRetry instead of letting the outer except wrap
+        it into a generic "unexpected error" message.
+      - document_id None -> degrade gracefully: log the failure and skip the
+        bad doc; keep summarizing the others.
+    """
+    documents = []
+    for doc in text_attachment:
+        try:
+            documents.append(await read_document_content(doc))
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            logger.warning(
+                "Failed to read attachment %s (%s): %s",
+                doc.id,
+                doc.file_name,
+                exc,
+                exc_info=True,
+            )
+            if document_id is not None:
+                # Targeted summarization: there is no other document to fall
+                # back to, so report this specific failure clearly.
+                raise ModelCannotRetry(
+                    f"Could not read the requested document '{doc.file_name}'. "
+                    "You must explain this to the user and ask them to retry "
+                    "or provide the document again."
+                ) from exc
+            # All-docs summarization: skip this one and keep going.
+    return documents
+
+
+async def _summarize_documents_chunks(documents_chunks, summarization_agent, ctx):
+    """
+    Run chunk summarization for every document concurrently (bounded by a
+    semaphore) and return per-document lists of chunk summaries.
+    """
+    semaphore = asyncio.Semaphore(settings.SUMMARIZATION_CONCURRENT_REQUESTS)
+
+    async def summarize_chunk_with_semaphore(idx, chunk, total_chunks):
+        """Summarize a chunk with semaphore-controlled concurrency."""
+        async with semaphore:
+            return await summarize_chunk(idx, chunk, total_chunks, summarization_agent, ctx)
+
+    doc_chunk_summaries = []
+    try:
+        for doc_chunks in documents_chunks:
+            summarization_tasks = [
+                summarize_chunk_with_semaphore(idx, chunk, len(doc_chunks))
+                for idx, chunk in enumerate(doc_chunks, start=1)
+            ]
+            chunk_summaries = await asyncio.gather(*summarization_tasks)
+            doc_chunk_summaries.append(chunk_summaries)
+    except ModelRetry as exc:
+        logger.warning("Retryable error during chunk summarization: %s", exc, exc_info=True)
+        raise
+    except Exception as exc:
+        logger.warning("Error during chunk summarization: %s", exc, exc_info=True)
+        raise ModelRetry("An error occurred while processing document chunks.") from exc
+    return doc_chunk_summaries
 
 
 async def summarize_chunk(idx, chunk, total_chunks, summarization_agent, ctx):
@@ -52,7 +118,7 @@ async def summarize_chunk(idx, chunk, total_chunks, summarization_agent, ctx):
 
 
 @last_model_retry_soft_fail
-async def document_summarize(  # pylint: disable=too-many-locals, too-many-statements  # noqa: PLR0915
+async def document_summarize(
     ctx: RunContext,
     *,
     instructions: str | None = None,
@@ -87,7 +153,7 @@ async def document_summarize(  # pylint: disable=too-many-locals, too-many-state
 
         # Collect documents content
         text_attachment_qs = ctx.deps.conversation.attachments.filter(
-            content_type__startswith="text/"
+            content_type__startswith=TEXT_MIME_PREFIX
         ).order_by("created_at", "id")
         text_attachment = await sync_to_async(list)(text_attachment_qs)
 
@@ -98,25 +164,19 @@ async def document_summarize(  # pylint: disable=too-many-locals, too-many-state
             )
 
         if document_id is not None:
-            try:
-                parsed_document_id = uuid.UUID(document_id)
-            except ValueError as exc:
-                raise ModelRetry("Invalid document_id. Expected a valid UUID.") from exc
+            text_attachment = [resolve_attachment_by_id(text_attachment, document_id)]
 
-            selected_attachment = next(
-                (
-                    attachment
-                    for attachment in text_attachment
-                    if getattr(attachment, "id", None) == parsed_document_id
-                    or str(getattr(attachment, "id", "")) == document_id
-                ),
-                None,
+        documents = await _read_documents_safely(text_attachment, document_id)
+
+        # If every attachment failed to read we have nothing to summarize.
+        # Stop here with a clear message rather than feeding an empty list to
+        # the chunker &  merge prompt downstream.
+        if not documents:
+            raise ModelCannotRetry(
+                "None of the attached documents could be read. "
+                "You must explain this to the user and ask them to retry "
+                "or provide the documents again."
             )
-            if selected_attachment is None:
-                raise ModelRetry("document_id was not found among attached text documents.")
-            text_attachment = [selected_attachment]
-
-        documents = [await read_document_content(doc) for doc in text_attachment]
 
         # Chunk documents and summarize each chunk
         chunk_size = settings.SUMMARIZATION_CHUNK_SIZE
@@ -136,30 +196,12 @@ async def document_summarize(  # pylint: disable=too-many-locals, too-many-state
             instructions_hint,
         )
 
-        # Parallelize the chunk summarization with a semaphore to limit concurrent tasks
-        # because it can be very resource intensive on the LLM backend
-        semaphore = asyncio.Semaphore(settings.SUMMARIZATION_CONCURRENT_REQUESTS)
-
-        async def summarize_chunk_with_semaphore(idx, chunk, total_chunks):
-            """Summarize a chunk with semaphore-controlled concurrency."""
-            async with semaphore:
-                return await summarize_chunk(idx, chunk, total_chunks, summarization_agent, ctx)
-
-        doc_chunk_summaries = []
-        try:
-            for doc_chunks in documents_chunks:
-                summarization_tasks = [
-                    summarize_chunk_with_semaphore(idx, chunk, len(doc_chunks))
-                    for idx, chunk in enumerate(doc_chunks, start=1)
-                ]
-                chunk_summaries = await asyncio.gather(*summarization_tasks)
-                doc_chunk_summaries.append(chunk_summaries)
-        except ModelRetry as exc:
-            logger.warning("Retryable error during chunk summarization: %s", exc, exc_info=True)
-            raise
-        except Exception as exc:
-            logger.warning("Error during chunk summarization: %s", exc, exc_info=True)
-            raise ModelRetry("An error occurred while processing document chunks.") from exc
+        # Parallelize the chunk summarization with a semaphore (inside the
+        # helper) to limit concurrent tasks - it can be very resource intensive
+        # on the LLM backend.
+        doc_chunk_summaries = await _summarize_documents_chunks(
+            documents_chunks, summarization_agent, ctx
+        )
 
         context = "\n\n".join(
             doc_name + "\n\n" + "\n\n".join(summaries)

--- a/src/backend/chat/tools/document_summarize.py
+++ b/src/backend/chat/tools/document_summarize.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import logging
+import uuid
 
 from django.conf import settings
 from django.core.files.storage import default_storage
@@ -51,8 +52,11 @@ async def summarize_chunk(idx, chunk, total_chunks, summarization_agent, ctx):
 
 
 @last_model_retry_soft_fail
-async def document_summarize(  # pylint: disable=too-many-locals
-    ctx: RunContext, *, instructions: str | None = None
+async def document_summarize(  # pylint: disable=too-many-locals, too-many-statements  # noqa: PLR0915
+    ctx: RunContext,
+    *,
+    instructions: str | None = None,
+    document_id: str | None = None,
 ) -> ToolReturn:
     """
     Generate a complete, ready-to-use summary of the documents in context
@@ -66,11 +70,14 @@ async def document_summarize(  # pylint: disable=too-many-locals
 
     Examples:
     "Summarize this doc in 2 paragraphs" -> instructions = "summary in 2 paragraphs"
-    "Summarize this doc in English" -> instructions = "In English"
-    "Summarize this doc" -> instructions = "" (default)
+    "Summarize this doc in English" -> instructions = "In English", document_id=None
+    "Summarize this doc" -> instructions = "" (default), document_id=None
+    "Summarize this specific doc" -> instructions = "", document_id=id_from_context
 
     Args:
         instructions (str | None): The instructions the user gave to use for the summarization
+        document_id (str | None): Document UUID from context JSON.
+        If document_id is None, summarize all docs.
     """
     try:
         instructions_hint = (
@@ -79,17 +86,35 @@ async def document_summarize(  # pylint: disable=too-many-locals
         summarization_agent = SummarizationAgent()
 
         # Collect documents content
-        text_attachment = await sync_to_async(list)(
-            ctx.deps.conversation.attachments.filter(
-                content_type__startswith="text/",
-            )
-        )
+        text_attachment_qs = ctx.deps.conversation.attachments.filter(
+            content_type__startswith="text/"
+        ).order_by("created_at", "id")
+        text_attachment = await sync_to_async(list)(text_attachment_qs)
 
         if not text_attachment:
             raise ModelCannotRetry(
                 "No text documents found in the conversation. "
                 "You must explain this to the user and ask them to provide documents."
             )
+
+        if document_id is not None:
+            try:
+                parsed_document_id = uuid.UUID(document_id)
+            except ValueError as exc:
+                raise ModelRetry("Invalid document_id. Expected a valid UUID.") from exc
+
+            selected_attachment = next(
+                (
+                    attachment
+                    for attachment in text_attachment
+                    if getattr(attachment, "id", None) == parsed_document_id
+                    or str(getattr(attachment, "id", "")) == document_id
+                ),
+                None,
+            )
+            if selected_attachment is None:
+                raise ModelRetry("document_id was not found among attached text documents.")
+            text_attachment = [selected_attachment]
 
         documents = [await read_document_content(doc) for doc in text_attachment]
 

--- a/src/backend/chat/tools/utils.py
+++ b/src/backend/chat/tools/utils.py
@@ -2,13 +2,37 @@
 
 import functools
 import logging
-from typing import Any, Callable
+import uuid
+from typing import Any, Callable, Iterable
 
 from pydantic_ai import ModelRetry, RunContext
 
+from chat import models
 from chat.tools.exceptions import ModelCannotRetry
 
 logger = logging.getLogger(__name__)
+
+
+def resolve_attachment_by_id(
+    attachments: Iterable[models.ChatConversationAttachment],
+    document_id: str,
+) -> models.ChatConversationAttachment:
+    """
+    Resolve a model-supplied ``document_id`` string to one of the listed attachments.
+
+    Raises ``ModelRetry`` on invalid UUID or missing attachment so the model can
+    correct itself within the tool-retry budget.
+    """
+    try:
+        parsed_document_id = uuid.UUID(document_id)
+    except ValueError as exc:
+        raise ModelRetry("Invalid document_id. Expected a valid UUID.") from exc
+
+    for attachment in attachments:
+        if attachment.id == parsed_document_id:
+            return attachment
+
+    raise ModelRetry("document_id was not found among attached text documents.")
 
 
 def last_model_retry_soft_fail(

--- a/src/backend/conversations/settings.py
+++ b/src/backend/conversations/settings.py
@@ -894,6 +894,9 @@ USER QUESTION:
         environ_name="SUMMARIZATION_CONCURRENT_REQUESTS",
         environ_prefix=None,
     )
+    # Token estimation uses cl100k_base (GPT-4 tokenizer); non-OpenAI models
+    # (Mistral, Llama, Anthropic) may tokenize 5-15% higher for the same text.
+    # The security buffer below absorbs that drift.
     DOCUMENT_CONTEXT_BUDGET_RATIO = values.FloatValue(
         default=0.5,
         environ_name="DOCUMENT_CONTEXT_BUDGET_RATIO",
@@ -1185,6 +1188,14 @@ USER QUESTION:
             raise ValueError(
                 f"{cls.RAG_DOCUMENT_SEARCH_BACKEND} requires FIND_API_KEY, FIND_API_URL, "
                 "OIDC_STORE_ACCESS_TOKEN and OIDC_STORE_REFRESH_TOKEN to be set."
+            )
+
+        # Document context budget ratio must be a fraction (0 disables full inlining,
+        # 1 dedicates the entire model context to documents).
+        if not 0 <= cls.DOCUMENT_CONTEXT_BUDGET_RATIO <= 1:
+            raise ValueError(
+                "DOCUMENT_CONTEXT_BUDGET_RATIO must be between 0 and 1, "
+                f"got {cls.DOCUMENT_CONTEXT_BUDGET_RATIO}."
             )
 
         # OCR configuration validation

--- a/src/backend/conversations/settings.py
+++ b/src/backend/conversations/settings.py
@@ -894,6 +894,16 @@ USER QUESTION:
         environ_name="SUMMARIZATION_CONCURRENT_REQUESTS",
         environ_prefix=None,
     )
+    DOCUMENT_CONTEXT_BUDGET_RATIO = values.FloatValue(
+        default=0.5,
+        environ_name="DOCUMENT_CONTEXT_BUDGET_RATIO",
+        environ_prefix=None,
+    )
+    DOCUMENT_CONTEXT_SECURITY_BUFFER_TOKENS = values.PositiveIntegerValue(
+        default=1000,
+        environ_name="DOCUMENT_CONTEXT_SECURITY_BUFFER_TOKENS",
+        environ_prefix=None,
+    )
 
     # Tavily API
     TAVILY_API_KEY = values.Value(

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -70,6 +70,7 @@ dependencies = [
     "pypdf==6.10.2",
     "odfdo==3.22.1",
     "django-solo==2.5.1",
+    "tiktoken>=0.12.0",
 ]
 
 [project.urls]

--- a/src/backend/uv.lock
+++ b/src/backend/uv.lock
@@ -1,6 +1,6 @@
 version = 1
-revision = 3
-requires-python = "==3.13.*"
+revision = 2
+requires-python = ">=3.13.0, <3.14"
 resolution-markers = [
     "sys_platform == 'win32'",
     "sys_platform != 'win32'",
@@ -450,6 +450,7 @@ dependencies = [
     { name = "requests" },
     { name = "semchunk" },
     { name = "sentry-sdk" },
+    { name = "tiktoken" },
     { name = "trafilatura" },
     { name = "uvicorn" },
     { name = "whitenoise" },
@@ -546,6 +547,7 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = "==0.14.5" },
     { name = "semchunk", specifier = "==3.2.5" },
     { name = "sentry-sdk", specifier = "==2.44.0" },
+    { name = "tiktoken", specifier = ">=0.12.0" },
     { name = "trafilatura", specifier = "==2.0.0" },
     { name = "types-requests", marker = "extra == 'dev'", specifier = "==2.32.4.20250913" },
     { name = "uvicorn", specifier = "==0.38.0" },


### PR DESCRIPTION
Keep oversized documents tool-call-only, add FIFO context inlining, and align tools/tests with new document payload

## Summary

This PR introduces a hybrid document-context strategy for chat requests.  
Each attached document is represented in the instructions payload and can be either:

- `full-context` (inlined in prompt context), or
- `tool_call_only` (accessible through tools, not inlined).

Inlining is controlled by a token budget with FIFO eviction, so newer documents can be inlined while older ones are downgraded to tool access when needed.

## What Changed

- Added a dedicated document context builder in `chat/document_context_builder.py`:
  - Builds a structured payload with `documents_order` + per-document metadata.
  - Uses `document_id` (UUID) instead of positional `index`.
  - Applies title normalization only for converted files (via `conversion_from`).
  - Supports `full-context` vs `tool_call_only` access modes.
  - Applies FIFO eviction for inlined docs when budget is exceeded.
- Hardened failure behavior in `_load_document`:
  - If `read_attachment_content` fails, document stays `tool_call_only`.
  - Sets a sentinel `token_count` (`sys.maxsize`) to prevent accidental later promotion to `full-context`.
- Integrated context-window controls through configuration/model metadata:
  - `DOCUMENT_CONTEXT_BUDGET_RATIO`
  - `DOCUMENT_CONTEXT_SECURITY_BUFFER_TOKENS`
  - model `max_token_context` support.
- Updated tool behavior:
  - `document_summarize` now supports targeting a single attachment via `document_id`.
  - RAG search path supports document-level filtering (optional metadata filter / fallback behavior).
- Updated prompt/tool descriptions and changelog to reflect the new document-context behavior.
- Added/updated dependency/config surface needed by backend runtime (including `django-solo` in backend deps/settings).

## Why

- Keeps prompt size predictable while preserving access to all attached documents.
- Prevents oversized or unreadable attachments from bloating/poisoning prompt context.
- Improves determinism by using a structured payload (`document_id`, explicit access mode).
- Aligns summarize/search flows with explicit document scoping.

## Test Coverage

- Added/updated context-window tests for:
  - oversized docs remaining `tool_call_only`,
  - FIFO inlining behavior,
  - configurable budget ratio.
- Updated summarize tests for `document_id` selection and queryset-like attachment handling.
- Updated conversation upload/url tests to validate the new instructions payload shape:
  - `document_id` field,
  - converted filename behavior (`*.md`),
  - `info` behavior (`None` vs labeled cases),
  - robust JSON-field assertions instead of brittle full-string reconstruction.

### About Tiktokken
I benchmarked the tiktoken tokenizer against Mistral’s tokenizer on a sample of 10 documents (PDF and Markdown). On average, tiktoken reports about 7% more tokens than Mistral. This overestimation is acceptable for now, and even preferable in our context, since we want to err on the safe side when budgeting document context.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Target individual attachments via document_id for search and summarize; async search supported. Per-turn document-context listing with token-aware inlining and optional per-model max token context.

* **Behavior**
  * Deterministic newest→oldest ordering, FIFO eviction when budget exceeded, and tool-only marking for oversized/unreadable docs. Document-scoped searches propagate filters, log filtered no-results, and surface retry guidance for empty or invalid IDs.

* **Documentation**
  * Updated docs and tool examples for hybrid context, inlining budget, caching, and document-scoped tools.

* **Tests**
  * Expanded unit/integration tests covering selection, budgeting, caching, retry, and I/O edge cases.

* **Chores**
  * Added runtime token-counting dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->