### PR TITLE
⬆️(dependencies) update pydantic-ai-slim to v1.77.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to
 - ⬆️(dependencies) update back and front dependencies
 - 💄(ui) new header
 - ✨(back) add debug mode setup for local development
+- ⬆️(dependencies) update pydanticai and related dependencies
 
 ### Fixed
 

--- a/docs/llm-configuration.md
+++ b/docs/llm-configuration.md
@@ -141,7 +141,8 @@ Models define the LLMs available in your application.
       "is_active": true,
       "icon": null,
       "system_prompt": "You are a helpful assistant",
-      "tools": []
+      "tools": [],
+      "concatenate_instruction_messages": false
     }
   ]
 }
@@ -149,22 +150,25 @@ Models define the LLMs available in your application.
 
 **Model Fields:**
 
-| Field                 | Type         | Required | Description                                                                                         |
-|-----------------------|--------------|----------|-----------------------------------------------------------------------------------------------------|
-| `hrid`                | string       | Yes      | Unique identifier for the model                                                                     |
-| `model_name`          | string       | Yes      | Name of the model as recognized by the provider (can use `settings.` or `environ.` prefix)          |
-| `human_readable_name` | string       | Yes      | Display name shown to users                                                                         |
-| `provider_name`       | string       | No*      | Reference to a provider's `hrid`                                                                    |
-| `provider`            | object       | No*      | Inline provider definition (alternative to `provider_name`)                                         |
-| `profile`             | object       | No       | Model-specific capabilities and settings                                                            |
-| `settings`            | object       | No       | Model inference settings (temperature, max_tokens, etc.)                                            |
-| `is_active`           | boolean      | Yes      | Whether the model is available for use                                                              |
-| `icon`                | string/array | No       | Base64-encoded icon or array of icon parts                                                          |
-| `system_prompt`       | string       | Yes      | Default system prompt for the model (can use `settings.` or `environ.` prefix)                      |
-| `tools`               | array        | Yes      | List of enabled tools for this model (can use `settings.` or `environ.` prefix for the whole array) |
-| `supports_streaming`  | boolean      | No       | Whether the model supports streaming responses                                                      |
+| Field                                | Type         | Required | Description                                                                                         |
+|--------------------------------------|--------------|----------|-----------------------------------------------------------------------------------------------------|
+| `hrid`                               | string       | Yes      | Unique identifier for the model                                                                     |
+| `model_name`                         | string       | Yes      | Name of the model as recognized by the provider (can use `settings.` or `environ.` prefix)          |
+| `human_readable_name`                | string       | Yes      | Display name shown to users                                                                         |
+| `provider_name`                      | string       | No*      | Reference to a provider's `hrid`                                                                    |
+| `provider`                           | object       | No*      | Inline provider definition (alternative to `provider_name`)                                         |
+| `profile`                            | object       | No       | Model-specific capabilities and settings                                                            |
+| `settings`                           | object       | No       | Model inference settings (temperature, max_tokens, etc.)                                            |
+| `is_active`                          | boolean      | Yes      | Whether the model is available for use                                                              |
+| `icon`                               | string/array | No       | Base64-encoded icon or array of icon parts                                                          |
+| `system_prompt`                      | string       | Yes      | Default system prompt for the model (can use `settings.` or `environ.` prefix)                      |
+| `tools`                              | array        | Yes      | List of enabled tools for this model (can use `settings.` or `environ.` prefix for the whole array) |
+| `supports_streaming`                 | boolean      | No       | Whether the model supports streaming responses                                                      |
+| `concatenate_instruction_messages`  | boolean      | No       | Whether the model must concatenate instructions messages before calling the Model                          |
 
 \* Either `provider_name` or `provider` must be set, unless `model_name` is in the format `<provider>:<model>`.
+
+\* `concatenate_instruction_messages` was added to make the app support Open Source models using vLLM for which Conversation must alternate user/assistant messages.
 
 ## Adding New Models
 

--- a/src/backend/chat/agents/base.py
+++ b/src/backend/chat/agents/base.py
@@ -29,9 +29,9 @@ def prepare_custom_model(configuration: "chat.llm_configuration.LLModel"):
     match configuration.provider.kind:
         case "mistral":
             import pydantic_ai.models.mistral as mistral_models  # noqa: PLC0415
-            from mistralai import TextChunk as MistralTextChunk  # noqa: PLC0415
-            from mistralai import ThinkChunk as MistralThinkChunk  # noqa: PLC0415
-            from mistralai.types.basemodel import Unset as MistralUnset  # noqa: PLC0415
+            from mistralai.client.models import TextChunk as MistralTextChunk  # noqa: PLC0415
+            from mistralai.client.models import ThinkChunk as MistralThinkChunk  # noqa: PLC0415
+            from mistralai.client.types.basemodel import Unset as MistralUnset  # noqa: PLC0415
             from pydantic_ai.providers.mistral import MistralProvider  # noqa: PLC0415
 
             # --- Monkey patch for pydantic_ai.models.mistral._map_content ---

--- a/src/backend/chat/agents/base.py
+++ b/src/backend/chat/agents/base.py
@@ -7,7 +7,8 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 
 import httpx
-from pydantic_ai import Agent
+from pydantic_ai import Agent, InstructionPart, ModelRequestContext, RunContext
+from pydantic_ai.capabilities import Hooks
 from pydantic_ai.models import get_user_agent
 from pydantic_ai.profiles import ModelProfile
 
@@ -177,7 +178,36 @@ class BaseAgent(Agent):
 
         _tools = self.get_tools()
 
-        super().__init__(model=_model_instance, instructions=_system_prompt, tools=_tools, **kwargs)
+        _capabilities = list(kwargs.pop("capabilities", []))
+        if self.configuration.concatenate_instruction_messages:
+            _hooks = Hooks()
+
+            @_hooks.on.before_model_request
+            async def _concatenate_instructions(
+                ctx: RunContext,  # pylint: disable=unused-argument
+                request_context: ModelRequestContext,
+            ) -> ModelRequestContext:
+                """We enable to concatenate_instructions so that
+                we support open source models running with vLLM"""
+                instruction_parts = request_context.model_request_parameters.instruction_parts
+                # Instead of merging SystemPromptPart in messages,
+                # merge InstructionPart in model_request_parameters
+                merged_content = "\n\n".join(p.content for p in instruction_parts)
+                merged_parts = [InstructionPart(content=merged_content)]
+                new_params = dataclasses.replace(
+                    request_context.model_request_parameters, instruction_parts=merged_parts
+                )
+                return dataclasses.replace(request_context, model_request_parameters=new_params)
+
+            _capabilities.append(_hooks)
+
+        super().__init__(
+            model=_model_instance,
+            instructions=_system_prompt,
+            tools=_tools,
+            capabilities=_capabilities,
+            **kwargs,
+        )
 
     def get_system_prompt(self) -> str | None:
         """Override this method to customize the system prompt."""

--- a/src/backend/chat/llm_configuration.py
+++ b/src/backend/chat/llm_configuration.py
@@ -142,6 +142,7 @@ class LLModel(BaseModel):
     system_prompt: SettingEnvValue
     tools: list[str]
     web_search: SettingEnvValue | None = None
+    concatenate_instruction_messages: bool | None = None
 
     @field_validator("tools", mode="before")
     @classmethod

--- a/src/backend/chat/tests/agents/test_base_agent.py
+++ b/src/backend/chat/tests/agents/test_base_agent.py
@@ -1,11 +1,45 @@
 """Tests for the BaseAgent class and its model initialization logic."""
-# pylint: disable=protected-access
 
+# pylint: disable=protected-access
+import pytest
+from pydantic_ai.capabilities import Hooks
 from pydantic_ai.models.mistral import MistralModel
 from pydantic_ai.models.openai import OpenAIChatModel
 
 from chat.agents.base import BaseAgent
 from chat.llm_configuration import LLModel, LLMProfile, LLMProvider
+
+# ---------------------------------------------------------------------------
+# _concatenate_instructions hook — registration tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(name="llmodel_with_concatenate_instructions")
+def llmodel_with_concatenate_instructions_fixture():
+    """Return a basic OpenAI-compatible LLModel."""
+    return LLModel(
+        hrid="test-model",
+        model_name="gpt-4",
+        human_readable_name="Test Model",
+        provider=LLMProvider(
+            hrid="openai",
+            kind="openai",
+            base_url="https://test.vllm/v1",
+            api_key="testkey",
+        ),
+        is_active=True,
+        system_prompt="base system prompt",
+        tools=[],
+        concatenate_instruction_messages=True,
+    )
+
+
+def test_concatenate_instructions_enabled(settings, llmodel_with_concatenate_instructions):
+    """A Hooks capability is registered when concatenate_instruction_messages=True."""
+    settings.LLM_CONFIGURATIONS = {"test-model": llmodel_with_concatenate_instructions}
+    agent = BaseAgent(model_hrid="test-model")
+    capabilities = agent._root_capability.capabilities
+    assert any(isinstance(c, Hooks) for c in capabilities)
 
 
 def test_not_custom_model(monkeypatch, settings):
@@ -26,6 +60,9 @@ def test_not_custom_model(monkeypatch, settings):
 
     agent = BaseAgent(model_hrid="gpt-4")
     assert isinstance(agent._model, OpenAIChatModel)
+    # No Hooks capability when concatenate_instruction_messages is not set."""
+    capabilities = agent._root_capability.capabilities
+    assert not any(isinstance(c, Hooks) for c in capabilities)
 
 
 def test_custom_model_openai(settings):

--- a/src/backend/chat/tests/test_llm_configuration.py
+++ b/src/backend/chat/tests/test_llm_configuration.py
@@ -191,3 +191,36 @@ def test_llmodel_is_custom_property():
     )
     assert custom_model.is_custom is True
     assert non_custom_model.is_custom is False
+
+
+def test_llm_profile_concatenate_instruction_messages_from_json():
+    """LLMProfile parses concatenate_instruction_messages from JSON config."""
+    config_json = json.dumps(
+        {
+            "models": [
+                {
+                    "hrid": "vllm-model",
+                    "model_name": "my-model",
+                    "human_readable_name": "My Model",
+                    "concatenate_instruction_messages": True,
+                    "provider": {
+                        "hrid": "my-provider",
+                        "base_url": "https://vllm.example.com/v1",
+                        "api_key": "testkey",
+                    },
+                    "is_active": True,
+                    "system_prompt": "You are helpful.",
+                    "tools": [],
+                }
+            ],
+            "providers": [
+                {
+                    "hrid": "my-provider",
+                    "base_url": "https://vllm.example.com/v1",
+                    "api_key": "testkey",
+                }
+            ],
+        }
+    )
+    config = LLMConfiguration.model_validate_json(config_json)
+    assert config.models[0].concatenate_instruction_messages is True

--- a/src/backend/chat/tests/utils.py
+++ b/src/backend/chat/tests/utils.py
@@ -2,6 +2,27 @@
 
 import re
 
+from rest_framework import status
+
+ZERO_USAGE = {
+    "cache_audio_read_tokens": 0,
+    "cache_read_tokens": 0,
+    "cache_write_tokens": 0,
+    "details": {},
+    "input_audio_tokens": 0,
+    "input_tokens": 0,
+    "output_audio_tokens": 0,
+    "output_tokens": 0,
+}
+
+
+def assert_data_stream_response(response):
+    """Assert a response is a valid Vercel AI SDK data-stream SSE response."""
+    assert response.status_code == status.HTTP_200_OK
+    assert response.get("Content-Type") == "text/event-stream"
+    assert response.get("x-vercel-ai-data-stream") == "v1"
+    assert response.streaming
+
 
 def replace_uuids_with_placeholder(text):
     """Replace all UUIDs in the given text with a placeholder."""

--- a/src/backend/chat/tests/views/chat/conversations/conftest.py
+++ b/src/backend/chat/tests/views/chat/conversations/conftest.py
@@ -482,3 +482,21 @@ def fixture_mock_openai_stream_tool():
     )
 
     return route
+
+
+@pytest.fixture(name="hello_user_message")
+def hello_user_message_fixture():
+    """Common Hello user message dict for conversation request payloads."""
+    return {
+        "id": "yuPoOuBkKA4FnKvk",
+        "role": "user",
+        "parts": [{"text": "Hello", "type": "text"}],
+        "content": "Hello",
+        "createdAt": "2025-07-03T15:22:17.105Z",
+    }
+
+
+@pytest.fixture(name="hello_conversation_data")
+def hello_conversation_data_fixture(hello_user_message):
+    """Common request payload for a single Hello user message conversation."""
+    return {"messages": [hello_user_message]}

--- a/src/backend/chat/tests/views/chat/conversations/test_conversation.py
+++ b/src/backend/chat/tests/views/chat/conversations/test_conversation.py
@@ -134,13 +134,15 @@ def test_post_conversation_data_protocol(api_client, mock_openai_stream):
 
     # ensure instructions are merged as a system prompt
     last_request_payload = json.loads(respx.calls.last.request.content)
-    assert last_request_payload["messages"][0] == {
-        "content": (
-            "You are a helpful test assistant :)\n\nToday is Friday 25/07/2025.\n\n"
-            "Answer in english."
-        ),
-        "role": "system",
-    }
+
+    system_messages_content = [
+        message["content"]
+        for message in last_request_payload["messages"]
+        if message["role"] == "system"
+    ]
+    assert system_messages_content[0] == "You are a helpful test assistant :)"
+    assert system_messages_content[1] == "Today is Friday 25/07/2025."
+    assert system_messages_content[2] == "Answer in english."
 
     chat_conversation.refresh_from_db()
     assert chat_conversation.ui_messages == [
@@ -412,13 +414,15 @@ def test_post_conversation_text_protocol(api_client, mock_openai_stream):
     assert mock_openai_stream.called
     # ensure instructions are merged as a system prompt
     last_request_payload = json.loads(respx.calls.last.request.content)
-    assert last_request_payload["messages"][0] == {
-        "content": (
-            "You are a helpful test assistant :)\n\nToday is Friday 25/07/2025.\n\n"
-            "Answer in english."
-        ),
-        "role": "system",
-    }
+
+    system_messages_content = [
+        message["content"]
+        for message in last_request_payload["messages"]
+        if message["role"] == "system"
+    ]
+    assert system_messages_content[0] == "You are a helpful test assistant :)"
+    assert system_messages_content[1] == "Today is Friday 25/07/2025."
+    assert system_messages_content[2] == "Answer in english."
 
     chat_conversation.refresh_from_db()
     assert chat_conversation.ui_messages == [
@@ -574,10 +578,15 @@ def test_post_conversation_with_image(api_client, mock_openai_stream_image):
     # Check the exact structure expected by the AI service
     assert body["messages"] == [
         {
-            "content": (
-                "You are a helpful test assistant :)\n\nToday is Friday 25/07/2025."
-                "\n\nAnswer in english."
-            ),
+            "content": ("You are a helpful test assistant :)"),
+            "role": "system",
+        },
+        {
+            "content": ("Today is Friday 25/07/2025."),
+            "role": "system",
+        },
+        {
+            "content": ("Answer in english."),
             "role": "system",
         },
         {
@@ -782,10 +791,15 @@ def test_post_conversation_tool_call(api_client, mock_openai_stream_tool, settin
 
     assert body["messages"] == [
         {
-            "content": (
-                "You are a helpful test assistant :)\n\n"
-                "Today is Friday 25/07/2025.\n\nAnswer in english."
-            ),
+            "content": "You are a helpful test assistant :)",
+            "role": "system",
+        },
+        {
+            "content": "Today is Friday 25/07/2025.",
+            "role": "system",
+        },
+        {
+            "content": "Answer in english.",
             "role": "system",
         },
         {"content": [{"text": "Weather in Paris?", "type": "text"}], "role": "user"},
@@ -908,6 +922,7 @@ def test_post_conversation_tool_call(api_client, mock_openai_stream_tool, settin
                 {
                     "content": {"location": "Paris", "temperature": 22, "unit": "celsius"},
                     "metadata": None,
+                    "outcome": "success",
                     "part_kind": "tool-return",
                     "timestamp": "2025-07-25T10:36:35.297675Z",
                     "tool_call_id": "xLDcIljdsDrz0idal7tATWSMm2jhMj47",
@@ -1006,10 +1021,15 @@ def test_post_conversation_tool_call_fails(api_client, mock_openai_stream_tool, 
 
     assert body["messages"] == [
         {
-            "content": (
-                "You are a helpful test assistant :)\n\n"
-                "Today is Friday 25/07/2025.\n\nAnswer in french."
-            ),
+            "content": "You are a helpful test assistant :)",
+            "role": "system",
+        },
+        {
+            "content": "Today is Friday 25/07/2025.",
+            "role": "system",
+        },
+        {
+            "content": "Answer in french.",
             "role": "system",
         },
         {"content": [{"text": "Weather in Paris?", "type": "text"}], "role": "user"},
@@ -1838,14 +1858,14 @@ def test_post_conversation_oidc_refresh_enabled(  # pylint: disable=unused-argum
 
     # ensure instructions are merged as a system prompt
     last_request_payload = json.loads(respx.calls.last.request.content)
-    assert last_request_payload["messages"][0] == {
-        "content": (
-            "You are a helpful test assistant :)\n\nToday is Friday 25/07/2025.\n\n"
-            "Answer in english."
-        ),
-        "role": "system",
-    }
-
+    system_messages_content = [
+        message["content"]
+        for message in last_request_payload["messages"]
+        if message["role"] == "system"
+    ]
+    assert system_messages_content[0] == "You are a helpful test assistant :)"
+    assert system_messages_content[1] == "Today is Friday 25/07/2025."
+    assert system_messages_content[2] == "Answer in english."
     chat_conversation.refresh_from_db()
     assert chat_conversation.ui_messages == [
         {

--- a/src/backend/chat/tests/views/chat/conversations/test_conversation.py
+++ b/src/backend/chat/tests/views/chat/conversations/test_conversation.py
@@ -26,12 +26,116 @@ from chat.ai_sdk_types import (
 )
 from chat.factories import ChatConversationFactory
 from chat.llm_configuration import LLModel, LLMProvider
-from chat.tests.utils import replace_uuids_with_placeholder
+from chat.tests.utils import (
+    ZERO_USAGE,
+    assert_data_stream_response,
+    replace_uuids_with_placeholder,
+)
 
 # enable database transactions for tests:
 # transaction=True ensures that the data are available in the database
 # in other threads
 pytestmark = pytest.mark.django_db(transaction=True)
+
+FROZEN_TIMESTAMP = "2025-07-25T10:36:35.297675Z"
+ENGLISH_INSTRUCTIONS = (
+    "You are a helpful test assistant :)\n\nToday is Friday 25/07/2025.\n\nAnswer in english."
+)
+
+
+def _assert_hello_ui_messages(chat_conversation):
+    assert chat_conversation.ui_messages == [
+        {
+            "content": "Hello",
+            "createdAt": "2025-07-03T15:22:17.105Z",
+            "id": "yuPoOuBkKA4FnKvk",
+            "parts": [{"text": "Hello", "type": "text"}],
+            "role": "user",
+        }
+    ]
+
+
+def _assert_hello_messages(chat_conversation, frozen_now):
+    assert len(chat_conversation.messages) == 2
+    assert chat_conversation.messages[0].id == IsUUID(4)
+    assert chat_conversation.messages[0] == UIMessage(
+        id=chat_conversation.messages[0].id,
+        createdAt=frozen_now,
+        content="Hello",
+        reasoning=None,
+        experimental_attachments=None,
+        role="user",
+        annotations=None,
+        toolInvocations=None,
+        parts=[TextUIPart(type="text", text="Hello")],
+    )
+    assert chat_conversation.messages[1].id == IsUUID(4)
+    assert chat_conversation.messages[1] == UIMessage(
+        id=chat_conversation.messages[1].id,
+        createdAt=frozen_now,
+        content="Hello there",
+        reasoning=None,
+        experimental_attachments=None,
+        role="assistant",
+        annotations=None,
+        toolInvocations=None,
+        parts=[TextUIPart(type="text", text="Hello there")],
+    )
+
+
+def _make_pydantic_request(run_id, instructions, content, timestamp=FROZEN_TIMESTAMP):
+    return {
+        "instructions": instructions,
+        "kind": "request",
+        "metadata": None,
+        "parts": [{"content": content, "part_kind": "user-prompt", "timestamp": timestamp}],
+        "run_id": run_id,
+        "timestamp": timestamp,
+    }
+
+
+def _make_pydantic_text_response(  # pylint: disable=too-many-arguments,too-many-positional-arguments  # noqa: PLR0913
+    run_id,
+    content,
+    timestamp=FROZEN_TIMESTAMP,
+    model_name="test-model",
+    provider_response_id="chatcmpl-1234567890",
+    provider_url="https://www.external-ai-service.com/",
+    usage=None,
+):
+    return {
+        "finish_reason": "stop",
+        "kind": "response",
+        "metadata": None,
+        "model_name": model_name,
+        "parts": [
+            {
+                "content": content,
+                "id": None,
+                "part_kind": "text",
+                "provider_details": None,
+                "provider_name": None,
+            }
+        ],
+        "provider_details": {"finish_reason": "stop", "timestamp": timestamp},
+        "provider_name": "openai",
+        "provider_response_id": provider_response_id,
+        "provider_url": provider_url,
+        "timestamp": timestamp,
+        "usage": usage if usage is not None else ZERO_USAGE,
+        "run_id": run_id,
+    }
+
+
+def _assert_english_system_prompts(last_request_payload):
+    system_messages = [
+        m["content"] for m in last_request_payload["messages"] if m["role"] == "system"
+    ]
+    assert system_messages == [
+        "You are a helpful test assistant :)",
+        "Today is Friday 25/07/2025.",
+        "Answer in english.",
+    ]
 
 
 @pytest.fixture(autouse=True)
@@ -92,36 +196,20 @@ def test_post_conversation_invalid_protocol(api_client):
 
 @freeze_time("2025-07-25T10:36:35.297675Z")
 @respx.mock
-def test_post_conversation_data_protocol(api_client, mock_openai_stream):
+def test_post_conversation_data_protocol(api_client, mock_openai_stream, hello_conversation_data):
     """Test posting messages to a conversation using the 'data' protocol."""
     chat_conversation = ChatConversationFactory(owner__language="en-us")
 
     url = f"/api/v1.0/chats/{chat_conversation.pk}/conversation/?protocol=data"
-    data = {
-        "messages": [
-            {
-                "id": "yuPoOuBkKA4FnKvk",
-                "role": "user",
-                "parts": [{"text": "Hello", "type": "text"}],
-                "content": "Hello",
-                "createdAt": "2025-07-03T15:22:17.105Z",
-            }
-        ]
-    }
     api_client.force_login(chat_conversation.owner)
 
-    response = api_client.post(url, data, format="json")
+    response = api_client.post(url, hello_conversation_data, format="json")
 
-    assert response.status_code == status.HTTP_200_OK
-    assert response.get("Content-Type") == "text/event-stream"
-    assert response.get("x-vercel-ai-data-stream") == "v1"
-    assert response.streaming
+    assert_data_stream_response(response)
 
-    # Wait for the streaming content to be fully received
-    response_content = b"".join(response.streaming_content).decode("utf-8")
-
-    # Replace UUIDs with placeholders for assertion
-    response_content = replace_uuids_with_placeholder(response_content)
+    response_content = replace_uuids_with_placeholder(
+        b"".join(response.streaming_content).decode("utf-8")
+    )
 
     assert response_content == (
         '0:"Hello"\n'
@@ -132,111 +220,16 @@ def test_post_conversation_data_protocol(api_client, mock_openai_stream):
 
     assert mock_openai_stream.called
 
-    # ensure instructions are merged as a system prompt
-    last_request_payload = json.loads(respx.calls.last.request.content)
-
-    system_messages_content = [
-        message["content"]
-        for message in last_request_payload["messages"]
-        if message["role"] == "system"
-    ]
-    assert system_messages_content[0] == "You are a helpful test assistant :)"
-    assert system_messages_content[1] == "Today is Friday 25/07/2025."
-    assert system_messages_content[2] == "Answer in english."
+    _assert_english_system_prompts(json.loads(respx.calls.last.request.content))
 
     chat_conversation.refresh_from_db()
-    assert chat_conversation.ui_messages == [
-        {
-            "content": "Hello",
-            "createdAt": "2025-07-03T15:22:17.105Z",
-            "id": "yuPoOuBkKA4FnKvk",
-            "parts": [{"text": "Hello", "type": "text"}],
-            "role": "user",
-        }
-    ]
-
-    assert len(chat_conversation.messages) == 2
-
-    assert chat_conversation.messages[0].id == IsUUID(4)
-    assert chat_conversation.messages[0] == UIMessage(
-        id=chat_conversation.messages[0].id,  # don't test the message ID here
-        createdAt=timezone.now(),  # Mocked timestamp
-        content="Hello",
-        reasoning=None,
-        experimental_attachments=None,
-        role="user",
-        annotations=None,
-        toolInvocations=None,
-        parts=[TextUIPart(type="text", text="Hello")],
-    )
-
-    assert chat_conversation.messages[1].id == IsUUID(4)
-    assert chat_conversation.messages[1] == UIMessage(
-        id=chat_conversation.messages[1].id,  # don't test the message ID here
-        createdAt=timezone.now(),  # Mocked timestamp
-        content="Hello there",
-        reasoning=None,
-        experimental_attachments=None,
-        role="assistant",
-        annotations=None,
-        toolInvocations=None,
-        parts=[TextUIPart(type="text", text="Hello there")],
-    )
+    _assert_hello_ui_messages(chat_conversation)
+    _assert_hello_messages(chat_conversation, timezone.now())
 
     _run_id = chat_conversation.pydantic_messages[0]["run_id"]
-
     assert chat_conversation.pydantic_messages == [
-        {
-            "instructions": (
-                "You are a helpful test assistant :)\n\n"
-                "Today is Friday 25/07/2025.\n\nAnswer in english."
-            ),
-            "kind": "request",
-            "metadata": None,
-            "parts": [
-                {
-                    "content": ["Hello"],
-                    "part_kind": "user-prompt",
-                    "timestamp": "2025-07-25T10:36:35.297675Z",
-                },
-            ],
-            "run_id": _run_id,
-            "timestamp": "2025-07-25T10:36:35.297675Z",
-        },
-        {
-            "finish_reason": "stop",
-            "kind": "response",
-            "metadata": None,
-            "model_name": "test-model",
-            "parts": [
-                {
-                    "content": "Hello there",
-                    "id": None,
-                    "part_kind": "text",
-                    "provider_details": None,
-                    "provider_name": None,
-                }
-            ],
-            "provider_details": {
-                "finish_reason": "stop",
-                "timestamp": "2025-07-25T10:36:35.297675Z",
-            },
-            "provider_name": "openai",
-            "provider_response_id": "chatcmpl-1234567890",
-            "provider_url": "https://www.external-ai-service.com/",
-            "timestamp": "2025-07-25T10:36:35.297675Z",
-            "usage": {
-                "cache_audio_read_tokens": 0,
-                "cache_read_tokens": 0,
-                "cache_write_tokens": 0,
-                "details": {},
-                "input_audio_tokens": 0,
-                "input_tokens": 0,
-                "output_audio_tokens": 0,
-                "output_tokens": 0,
-            },
-            "run_id": _run_id,
-        },
+        _make_pydantic_request(_run_id, ENGLISH_INSTRUCTIONS, ["Hello"]),
+        _make_pydantic_text_response(_run_id, "Hello there"),
     ]
 
 
@@ -244,37 +237,21 @@ def test_post_conversation_data_protocol(api_client, mock_openai_stream):
 @respx.mock
 @patch("chat.keepalive.get_current_time")
 def test_post_conversation_data_protocol_triggers_keepalives(
-    mock_time, api_client, mock_openai_stream
+    mock_time, api_client, mock_openai_stream, hello_conversation_data
 ):
     """Test streaming response contains keepalive messages"""
     chat_conversation = ChatConversationFactory(owner__language="en-us")
     mock_time.side_effect = [float(i * 60) for i in range(10)]
     url = f"/api/v1.0/chats/{chat_conversation.pk}/conversation/?protocol=data"
-    data = {
-        "messages": [
-            {
-                "id": "yuPoOuBkKA4FnKvk",
-                "role": "user",
-                "parts": [{"text": "Hello", "type": "text"}],
-                "content": "Hello",
-                "createdAt": "2025-07-03T15:22:17.105Z",
-            }
-        ]
-    }
     api_client.force_login(chat_conversation.owner)
 
-    response = api_client.post(url, data, format="json")
+    response = api_client.post(url, hello_conversation_data, format="json")
 
-    assert response.status_code == status.HTTP_200_OK
-    assert response.get("Content-Type") == "text/event-stream"
-    assert response.get("x-vercel-ai-data-stream") == "v1"
-    assert response.streaming
+    assert_data_stream_response(response)
 
-    # Wait for the streaming content to be fully received
-    response_content = b"".join(response.streaming_content).decode("utf-8")
-
-    # Replace UUIDs with placeholders for assertion
-    response_content = replace_uuids_with_placeholder(response_content)
+    response_content = replace_uuids_with_placeholder(
+        b"".join(response.streaming_content).decode("utf-8")
+    )
 
     assert response_content == (
         '0:"Hello"\n'
@@ -287,122 +264,26 @@ def test_post_conversation_data_protocol_triggers_keepalives(
     assert mock_openai_stream.called
 
     chat_conversation.refresh_from_db()
-    assert chat_conversation.ui_messages == [
-        {
-            "content": "Hello",
-            "createdAt": "2025-07-03T15:22:17.105Z",
-            "id": "yuPoOuBkKA4FnKvk",
-            "parts": [{"text": "Hello", "type": "text"}],
-            "role": "user",
-        }
-    ]
-
-    assert len(chat_conversation.messages) == 2
-
-    assert chat_conversation.messages[0].id == IsUUID(4)
-    assert chat_conversation.messages[0] == UIMessage(
-        id=chat_conversation.messages[0].id,  # don't test the message ID here
-        createdAt=timezone.now(),  # Mocked timestamp
-        content="Hello",
-        reasoning=None,
-        experimental_attachments=None,
-        role="user",
-        annotations=None,
-        toolInvocations=None,
-        parts=[TextUIPart(type="text", text="Hello")],
-    )
-
-    assert chat_conversation.messages[1].id == IsUUID(4)
-    assert chat_conversation.messages[1] == UIMessage(
-        id=chat_conversation.messages[1].id,  # don't test the message ID here
-        createdAt=timezone.now(),  # Mocked timestamp
-        content="Hello there",
-        reasoning=None,
-        experimental_attachments=None,
-        role="assistant",
-        annotations=None,
-        toolInvocations=None,
-        parts=[TextUIPart(type="text", text="Hello there")],
-    )
+    _assert_hello_ui_messages(chat_conversation)
+    _assert_hello_messages(chat_conversation, timezone.now())
 
     _run_id = chat_conversation.pydantic_messages[0]["run_id"]
     assert chat_conversation.pydantic_messages == [
-        {
-            "instructions": (
-                "You are a helpful test assistant :)\n\n"
-                "Today is Friday 25/07/2025.\n\n"
-                "Answer in english."
-            ),
-            "kind": "request",
-            "metadata": None,
-            "parts": [
-                {
-                    "content": ["Hello"],
-                    "part_kind": "user-prompt",
-                    "timestamp": "2025-07-25T10:36:35.297675Z",
-                },
-            ],
-            "run_id": _run_id,
-            "timestamp": "2025-07-25T10:36:35.297675Z",
-        },
-        {
-            "finish_reason": "stop",
-            "kind": "response",
-            "metadata": None,
-            "model_name": "test-model",
-            "parts": [
-                {
-                    "content": "Hello there",
-                    "id": None,
-                    "part_kind": "text",
-                    "provider_details": None,
-                    "provider_name": None,
-                }
-            ],
-            "provider_details": {
-                "finish_reason": "stop",
-                "timestamp": "2025-07-25T10:36:35.297675Z",
-            },
-            "provider_name": "openai",
-            "provider_response_id": "chatcmpl-1234567890",
-            "provider_url": "https://www.external-ai-service.com/",
-            "timestamp": "2025-07-25T10:36:35.297675Z",
-            "usage": {
-                "cache_audio_read_tokens": 0,
-                "cache_read_tokens": 0,
-                "cache_write_tokens": 0,
-                "details": {},
-                "input_audio_tokens": 0,
-                "input_tokens": 0,
-                "output_audio_tokens": 0,
-                "output_tokens": 0,
-            },
-            "run_id": _run_id,
-        },
+        _make_pydantic_request(_run_id, ENGLISH_INSTRUCTIONS, ["Hello"]),
+        _make_pydantic_text_response(_run_id, "Hello there"),
     ]
 
 
 @freeze_time("2025-07-25T10:36:35.297675Z")
 @respx.mock
-def test_post_conversation_text_protocol(api_client, mock_openai_stream):
+def test_post_conversation_text_protocol(api_client, mock_openai_stream, hello_conversation_data):
     """Test posting messages to a conversation using the 'text' protocol."""
     chat_conversation = ChatConversationFactory(owner__language="en-us")
 
     url = f"/api/v1.0/chats/{chat_conversation.pk}/conversation/?protocol=text"
-    data = {
-        "messages": [
-            {
-                "id": "yuPoOuBkKA4FnKvk",
-                "role": "user",
-                "parts": [{"text": "Hello", "type": "text"}],
-                "content": "Hello",
-                "createdAt": "2025-07-03T15:22:17.105Z",
-            }
-        ]
-    }
     api_client.force_login(chat_conversation.owner)
 
-    response = api_client.post(url, data, format="json")
+    response = api_client.post(url, hello_conversation_data, format="json")
 
     assert response.status_code == status.HTTP_200_OK
     assert response.get("Content-Type") == "text/event-stream"
@@ -412,111 +293,16 @@ def test_post_conversation_text_protocol(api_client, mock_openai_stream):
     assert response_content == "Hello there"
 
     assert mock_openai_stream.called
-    # ensure instructions are merged as a system prompt
-    last_request_payload = json.loads(respx.calls.last.request.content)
-
-    system_messages_content = [
-        message["content"]
-        for message in last_request_payload["messages"]
-        if message["role"] == "system"
-    ]
-    assert system_messages_content[0] == "You are a helpful test assistant :)"
-    assert system_messages_content[1] == "Today is Friday 25/07/2025."
-    assert system_messages_content[2] == "Answer in english."
+    _assert_english_system_prompts(json.loads(respx.calls.last.request.content))
 
     chat_conversation.refresh_from_db()
-    assert chat_conversation.ui_messages == [
-        {
-            "content": "Hello",
-            "createdAt": "2025-07-03T15:22:17.105Z",
-            "id": "yuPoOuBkKA4FnKvk",
-            "parts": [{"text": "Hello", "type": "text"}],
-            "role": "user",
-        }
-    ]
-
-    assert len(chat_conversation.messages) == 2
-
-    assert chat_conversation.messages[0].id == IsUUID(4)
-    assert chat_conversation.messages[0] == UIMessage(
-        id=chat_conversation.messages[0].id,  # don't test the message ID here
-        createdAt=timezone.now(),  # Mocked timestamp
-        content="Hello",
-        reasoning=None,
-        experimental_attachments=None,
-        role="user",
-        annotations=None,
-        toolInvocations=None,
-        parts=[TextUIPart(type="text", text="Hello")],
-    )
-
-    assert chat_conversation.messages[1].id == IsUUID(4)
-    assert chat_conversation.messages[1] == UIMessage(
-        id=chat_conversation.messages[1].id,  # don't test the message ID here
-        createdAt=timezone.now(),  # Mocked timestamp
-        content="Hello there",
-        reasoning=None,
-        experimental_attachments=None,
-        role="assistant",
-        annotations=None,
-        toolInvocations=None,
-        parts=[TextUIPart(type="text", text="Hello there")],
-    )
+    _assert_hello_ui_messages(chat_conversation)
+    _assert_hello_messages(chat_conversation, timezone.now())
 
     _run_id = chat_conversation.pydantic_messages[0]["run_id"]
-
     assert chat_conversation.pydantic_messages == [
-        {
-            "instructions": (
-                "You are a helpful test assistant :)\n\n"
-                "Today is Friday 25/07/2025.\n\nAnswer in english."
-            ),
-            "kind": "request",
-            "metadata": None,
-            "parts": [
-                {
-                    "content": ["Hello"],
-                    "part_kind": "user-prompt",
-                    "timestamp": "2025-07-25T10:36:35.297675Z",
-                },
-            ],
-            "run_id": _run_id,
-            "timestamp": "2025-07-25T10:36:35.297675Z",
-        },
-        {
-            "finish_reason": "stop",
-            "kind": "response",
-            "metadata": None,
-            "model_name": "test-model",
-            "parts": [
-                {
-                    "content": "Hello there",
-                    "id": None,
-                    "part_kind": "text",
-                    "provider_details": None,
-                    "provider_name": None,
-                }
-            ],
-            "provider_details": {
-                "finish_reason": "stop",
-                "timestamp": "2025-07-25T10:36:35.297675Z",
-            },
-            "provider_name": "openai",
-            "provider_response_id": "chatcmpl-1234567890",
-            "provider_url": "https://www.external-ai-service.com/",
-            "timestamp": "2025-07-25T10:36:35.297675Z",
-            "usage": {
-                "cache_audio_read_tokens": 0,
-                "cache_read_tokens": 0,
-                "cache_write_tokens": 0,
-                "details": {},
-                "input_audio_tokens": 0,
-                "input_tokens": 0,
-                "output_audio_tokens": 0,
-                "output_tokens": 0,
-            },
-            "run_id": _run_id,
-        },
+        _make_pydantic_request(_run_id, ENGLISH_INSTRUCTIONS, ["Hello"]),
+        _make_pydantic_text_response(_run_id, "Hello there"),
     ]
 
 
@@ -553,16 +339,11 @@ def test_post_conversation_with_image(api_client, mock_openai_stream_image):
 
     response = api_client.post(url, data, format="json")
 
-    assert response.status_code == status.HTTP_200_OK
-    assert response.get("Content-Type") == "text/event-stream"
-    assert response.get("x-vercel-ai-data-stream") == "v1"
-    assert response.streaming
+    assert_data_stream_response(response)
 
-    # Wait for the streaming content to be fully received
-    response_content = b"".join(response.streaming_content).decode("utf-8")
-
-    # Replace UUIDs with placeholders for assertion
-    response_content = replace_uuids_with_placeholder(response_content)
+    response_content = replace_uuids_with_placeholder(
+        b"".join(response.streaming_content).decode("utf-8")
+    )
 
     assert response_content == (
         '0:"I see a cat"\n'
@@ -672,69 +453,24 @@ def test_post_conversation_with_image(api_client, mock_openai_stream_image):
 
     _run_id = chat_conversation.pydantic_messages[0]["run_id"]
     assert chat_conversation.pydantic_messages == [
-        {
-            "instructions": (
-                "You are a helpful test assistant :)\n\n"
-                "Today is Friday 25/07/2025.\n\nAnswer in english."
-            ),
-            "kind": "request",
-            "metadata": None,
-            "parts": [
+        _make_pydantic_request(
+            _run_id,
+            ENGLISH_INSTRUCTIONS,
+            [
+                "Hello, what do you see on this picture?",
                 {
-                    "content": [
-                        "Hello, what do you see on this picture?",
-                        {
-                            "data": (
-                                "iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD-wSzIAAAABlBMVEX___-_"
-                                "v7-jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD_aNpbtEAAAAASUVORK5CYII="
-                            ),
-                            "kind": "binary",
-                            "identifier": "FELV-cat.jpg",
-                            "media_type": "image/png",
-                            "vendor_metadata": None,
-                        },
-                    ],
-                    "part_kind": "user-prompt",
-                    "timestamp": "2025-07-25T10:36:35.297675Z",
+                    "data": (
+                        "iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD-wSzIAAAABlBMVEX___-_"
+                        "v7-jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD_aNpbtEAAAAASUVORK5CYII="
+                    ),
+                    "kind": "binary",
+                    "identifier": "FELV-cat.jpg",
+                    "media_type": "image/png",
+                    "vendor_metadata": None,
                 },
             ],
-            "run_id": _run_id,
-            "timestamp": "2025-07-25T10:36:35.297675Z",
-        },
-        {
-            "finish_reason": "stop",
-            "kind": "response",
-            "metadata": None,
-            "model_name": "test-model",
-            "parts": [
-                {
-                    "content": "I see a cat in the picture.",
-                    "id": None,
-                    "part_kind": "text",
-                    "provider_details": None,
-                    "provider_name": None,
-                }
-            ],
-            "provider_details": {
-                "finish_reason": "stop",
-                "timestamp": "2025-07-25T10:36:35.297675Z",
-            },
-            "provider_name": "openai",
-            "provider_response_id": "chatcmpl-1234567890",
-            "provider_url": "https://www.external-ai-service.com/",
-            "timestamp": "2025-07-25T10:36:35.297675Z",
-            "usage": {
-                "cache_audio_read_tokens": 0,
-                "cache_read_tokens": 0,
-                "cache_write_tokens": 0,
-                "details": {},
-                "input_audio_tokens": 0,
-                "input_tokens": 0,
-                "output_audio_tokens": 0,
-                "output_tokens": 0,
-            },
-            "run_id": _run_id,
-        },
+        ),
+        _make_pydantic_text_response(_run_id, "I see a cat in the picture."),
     ]
 
 
@@ -762,16 +498,11 @@ def test_post_conversation_tool_call(api_client, mock_openai_stream_tool, settin
 
     response = api_client.post(url, data, format="json")
 
-    assert response.status_code == status.HTTP_200_OK
-    assert response.get("Content-Type") == "text/event-stream"
-    assert response.get("x-vercel-ai-data-stream") == "v1"
-    assert response.streaming
+    assert_data_stream_response(response)
 
-    # Wait for the streaming content to be fully received
-    response_content = b"".join(response.streaming_content).decode("utf-8")
-
-    # Replace UUIDs with placeholders for assertion
-    response_content = replace_uuids_with_placeholder(response_content)
+    response_content = replace_uuids_with_placeholder(
+        b"".join(response.streaming_content).decode("utf-8")
+    )
 
     assert response_content == (
         'b:{"toolCallId":"xLDcIljdsDrz0idal7tATWSMm2jhMj47","toolName":'
@@ -858,23 +589,7 @@ def test_post_conversation_tool_call(api_client, mock_openai_stream_tool, settin
 
     _run_id = chat_conversation.pydantic_messages[0]["run_id"]
     assert chat_conversation.pydantic_messages == [
-        {
-            "instructions": (
-                "You are a helpful test assistant :)\n\n"
-                "Today is Friday 25/07/2025.\n\nAnswer in english."
-            ),
-            "kind": "request",
-            "metadata": None,
-            "parts": [
-                {
-                    "content": ["Weather in Paris?"],
-                    "part_kind": "user-prompt",
-                    "timestamp": "2025-07-25T10:36:35.297675Z",
-                },
-            ],
-            "run_id": _run_id,
-            "timestamp": "2025-07-25T10:36:35.297675Z",
-        },
+        _make_pydantic_request(_run_id, ENGLISH_INSTRUCTIONS, ["Weather in Paris?"]),
         {
             "finish_reason": "tool_call",
             "kind": "response",
@@ -893,29 +608,17 @@ def test_post_conversation_tool_call(api_client, mock_openai_stream_tool, settin
             ],
             "provider_details": {
                 "finish_reason": "tool_calls",
-                "timestamp": "2025-07-25T10:36:35.297675Z",
+                "timestamp": FROZEN_TIMESTAMP,
             },
             "provider_name": "openai",
             "provider_response_id": "chatcmpl-tool-call",
             "provider_url": "https://www.external-ai-service.com/",
-            "timestamp": "2025-07-25T10:36:35.297675Z",
-            "usage": {
-                "cache_audio_read_tokens": 0,
-                "cache_read_tokens": 0,
-                "cache_write_tokens": 0,
-                "details": {},
-                "input_audio_tokens": 0,
-                "input_tokens": 0,
-                "output_audio_tokens": 0,
-                "output_tokens": 0,
-            },
+            "timestamp": FROZEN_TIMESTAMP,
+            "usage": ZERO_USAGE,
             "run_id": _run_id,
         },
         {
-            "instructions": (
-                "You are a helpful test assistant :)\n\n"
-                "Today is Friday 25/07/2025.\n\nAnswer in english."
-            ),
+            "instructions": ENGLISH_INSTRUCTIONS,
             "kind": "request",
             "metadata": None,
             "parts": [
@@ -924,48 +627,19 @@ def test_post_conversation_tool_call(api_client, mock_openai_stream_tool, settin
                     "metadata": None,
                     "outcome": "success",
                     "part_kind": "tool-return",
-                    "timestamp": "2025-07-25T10:36:35.297675Z",
+                    "timestamp": FROZEN_TIMESTAMP,
                     "tool_call_id": "xLDcIljdsDrz0idal7tATWSMm2jhMj47",
                     "tool_name": "get_current_weather",
                 }
             ],
             "run_id": _run_id,
-            "timestamp": "2025-07-25T10:36:35.297675Z",
+            "timestamp": FROZEN_TIMESTAMP,
         },
-        {
-            "finish_reason": "stop",
-            "kind": "response",
-            "metadata": None,
-            "model_name": "test-model",
-            "parts": [
-                {
-                    "content": "The current weather in Paris is nice",
-                    "id": None,
-                    "part_kind": "text",
-                    "provider_details": None,
-                    "provider_name": None,
-                }
-            ],
-            "provider_details": {
-                "finish_reason": "stop",
-                "timestamp": "2025-07-25T10:36:35.297675Z",
-            },
-            "provider_name": "openai",
-            "provider_response_id": "chatcmpl-final",
-            "provider_url": "https://www.external-ai-service.com/",
-            "timestamp": "2025-07-25T10:36:35.297675Z",
-            "usage": {
-                "cache_audio_read_tokens": 0,
-                "cache_read_tokens": 0,
-                "cache_write_tokens": 0,
-                "details": {},
-                "input_audio_tokens": 0,
-                "input_tokens": 0,
-                "output_audio_tokens": 0,
-                "output_tokens": 0,
-            },
-            "run_id": _run_id,
-        },
+        _make_pydantic_text_response(
+            _run_id,
+            "The current weather in Paris is nice",
+            provider_response_id="chatcmpl-final",
+        ),
     ]
 
 
@@ -993,16 +667,11 @@ def test_post_conversation_tool_call_fails(api_client, mock_openai_stream_tool, 
 
     response = api_client.post(url, data, format="json")
 
-    assert response.status_code == status.HTTP_200_OK
-    assert response.get("Content-Type") == "text/event-stream"
-    assert response.get("x-vercel-ai-data-stream") == "v1"
-    assert response.streaming
+    assert_data_stream_response(response)
 
-    # Wait for the streaming content to be fully received
-    response_content = b"".join(response.streaming_content).decode("utf-8")
-
-    # Replace UUIDs with placeholders for assertion
-    response_content = replace_uuids_with_placeholder(response_content)
+    response_content = replace_uuids_with_placeholder(
+        b"".join(response.streaming_content).decode("utf-8")
+    )
 
     assert response_content == (
         'b:{"toolCallId":"xLDcIljdsDrz0idal7tATWSMm2jhMj47","toolName":"get_current_weather"}\n'
@@ -1086,25 +755,12 @@ def test_post_conversation_tool_call_fails(api_client, mock_openai_stream_tool, 
         ],
     )
 
+    french_instructions = (
+        "You are a helpful test assistant :)\n\nToday is Friday 25/07/2025.\n\nAnswer in french."
+    )
     _run_id = chat_conversation.pydantic_messages[0]["run_id"]
     assert chat_conversation.pydantic_messages == [
-        {
-            "instructions": (
-                "You are a helpful test assistant :)\n\n"
-                "Today is Friday 25/07/2025.\n\nAnswer in french."
-            ),
-            "kind": "request",
-            "metadata": None,
-            "parts": [
-                {
-                    "content": ["Weather in Paris?"],
-                    "part_kind": "user-prompt",
-                    "timestamp": "2025-07-25T10:36:35.297675Z",
-                },
-            ],
-            "run_id": _run_id,
-            "timestamp": "2025-07-25T10:36:35.297675Z",
-        },
+        _make_pydantic_request(_run_id, french_instructions, ["Weather in Paris?"]),
         {
             "finish_reason": "tool_call",
             "kind": "response",
@@ -1123,77 +779,36 @@ def test_post_conversation_tool_call_fails(api_client, mock_openai_stream_tool, 
             ],
             "provider_details": {
                 "finish_reason": "tool_calls",
-                "timestamp": "2025-07-25T10:36:35.297675Z",
+                "timestamp": FROZEN_TIMESTAMP,
             },
             "provider_name": "openai",
             "provider_response_id": "chatcmpl-tool-call",
             "provider_url": "https://www.external-ai-service.com/",
-            "timestamp": "2025-07-25T10:36:35.297675Z",
-            "usage": {
-                "cache_audio_read_tokens": 0,
-                "cache_read_tokens": 0,
-                "cache_write_tokens": 0,
-                "details": {},
-                "input_audio_tokens": 0,
-                "input_tokens": 0,
-                "output_audio_tokens": 0,
-                "output_tokens": 0,
-            },
+            "timestamp": FROZEN_TIMESTAMP,
+            "usage": ZERO_USAGE,
             "run_id": _run_id,
         },
         {
-            "instructions": (
-                "You are a helpful test assistant :)\n\n"
-                "Today is Friday 25/07/2025.\n\nAnswer in french."
-            ),
+            "instructions": french_instructions,
             "kind": "request",
             "metadata": None,
             "parts": [
                 {
                     "content": "Unknown tool name: 'get_current_weather'. No tools available.",
                     "part_kind": "retry-prompt",
-                    "timestamp": "2025-07-25T10:36:35.297675Z",
+                    "timestamp": FROZEN_TIMESTAMP,
                     "tool_call_id": "xLDcIljdsDrz0idal7tATWSMm2jhMj47",
                     "tool_name": "get_current_weather",
                 }
             ],
             "run_id": _run_id,
-            "timestamp": "2025-07-25T10:36:35.297675Z",
+            "timestamp": FROZEN_TIMESTAMP,
         },
-        {
-            "finish_reason": "stop",
-            "kind": "response",
-            "metadata": None,
-            "model_name": "test-model",
-            "parts": [
-                {
-                    "content": "I cannot give you an answer to that.",
-                    "id": None,
-                    "part_kind": "text",
-                    "provider_details": None,
-                    "provider_name": None,
-                }
-            ],
-            "provider_details": {
-                "finish_reason": "stop",
-                "timestamp": "2025-07-25T10:36:35.297675Z",
-            },
-            "provider_name": "openai",
-            "provider_response_id": "chatcmpl-final",
-            "provider_url": "https://www.external-ai-service.com/",
-            "timestamp": "2025-07-25T10:36:35.297675Z",
-            "usage": {
-                "cache_audio_read_tokens": 0,
-                "cache_read_tokens": 0,
-                "cache_write_tokens": 0,
-                "details": {},
-                "input_audio_tokens": 0,
-                "input_tokens": 0,
-                "output_audio_tokens": 0,
-                "output_tokens": 0,
-            },
-            "run_id": _run_id,
-        },
+        _make_pydantic_text_response(
+            _run_id,
+            "I cannot give you an answer to that.",
+            provider_response_id="chatcmpl-final",
+        ),
     ]
 
 
@@ -1225,6 +840,7 @@ def test_post_conversation_model_selection_invalid(api_client):
 def test_post_conversation_model_selection_new(
     api_client,
     mock_openai_stream,
+    hello_conversation_data,
     settings,
 ):
     """Test the user can select a different model."""
@@ -1247,31 +863,15 @@ def test_post_conversation_model_selection_new(
     chat_conversation = ChatConversationFactory()
 
     url = f"/api/v1.0/chats/{chat_conversation.pk}/conversation/?protocol=data&model_hrid=plop"
-    data = {
-        "messages": [
-            {
-                "id": "yuPoOuBkKA4FnKvk",
-                "role": "user",
-                "parts": [{"text": "Hello", "type": "text"}],
-                "content": "Hello",
-                "createdAt": "2025-07-03T15:22:17.105Z",
-            }
-        ]
-    }
     api_client.force_login(chat_conversation.owner)
 
-    response = api_client.post(url, data, format="json")
+    response = api_client.post(url, hello_conversation_data, format="json")
 
-    assert response.status_code == status.HTTP_200_OK
-    assert response.get("Content-Type") == "text/event-stream"
-    assert response.get("x-vercel-ai-data-stream") == "v1"
-    assert response.streaming
+    assert_data_stream_response(response)
 
-    # Wait for the streaming content to be fully received
-    response_content = b"".join(response.streaming_content).decode("utf-8")
-
-    # Replace UUIDs with placeholders for assertion
-    response_content = replace_uuids_with_placeholder(response_content)
+    response_content = replace_uuids_with_placeholder(
+        b"".join(response.streaming_content).decode("utf-8")
+    )
 
     assert response_content == (
         '0:"Hello"\n'
@@ -1333,16 +933,11 @@ def test_post_conversation_data_protocol_no_stream(
 
     response = api_client.post(url, data, format="json")
 
-    assert response.status_code == status.HTTP_200_OK
-    assert response.get("Content-Type") == "text/event-stream"
-    assert response.get("x-vercel-ai-data-stream") == "v1"
-    assert response.streaming
+    assert_data_stream_response(response)
 
-    # Wait for the content to be fully received
-    response_content = b"".join(response.streaming_content).decode("utf-8")
-
-    # Replace UUIDs with placeholders for assertion
-    response_content = replace_uuids_with_placeholder(response_content)
+    response_content = replace_uuids_with_placeholder(
+        b"".join(response.streaming_content).decode("utf-8")
+    )
 
     if stream_delay:
         assert response_content == (
@@ -1421,56 +1016,25 @@ def test_post_conversation_data_protocol_no_stream(
 
     _run_id = chat_conversation.pydantic_messages[0]["run_id"]
     assert chat_conversation.pydantic_messages == [
-        {
-            "instructions": (
-                "You are an amazing assistant.\n\nToday is Friday 25/07/2025.\n\nAnswer in english."
-            ),
-            "kind": "request",
-            "metadata": None,
-            "parts": [
-                {
-                    "content": ["Why the sky is blue?"],
-                    "part_kind": "user-prompt",
-                    "timestamp": "2025-07-25T10:36:35.297675Z",
-                },
-            ],
-            "run_id": _run_id,
-            "timestamp": "2025-07-25T10:36:35.297675Z",
-        },
-        {
-            "finish_reason": "stop",
-            "kind": "response",
-            "metadata": None,
-            "model_name": "mistralai/Mistral-Small-3.2-24B-Instruct-2506",
-            "parts": [
-                {
-                    "content": "The sky appears blue due to a phenomenon called "
-                    "Rayleigh scattering.",
-                    "id": None,
-                    "part_kind": "text",
-                    "provider_details": None,
-                    "provider_name": None,
-                }
-            ],
+        _make_pydantic_request(
+            _run_id,
+            "You are an amazing assistant.\n\nToday is Friday 25/07/2025.\n\nAnswer in english.",
+            ["Why the sky is blue?"],
+        ),
+        _make_pydantic_text_response(
+            _run_id,
+            "The sky appears blue due to a phenomenon called Rayleigh scattering.",
+            timestamp=FROZEN_TIMESTAMP,
+            model_name="mistralai/Mistral-Small-3.2-24B-Instruct-2506",
+            provider_response_id="chatcmpl-92c413bb5a45426299335d0621324654",
+            provider_url="https://www.external-ai-service.com",
+            usage={**ZERO_USAGE, "output_tokens": 135},
+        )
+        | {
             "provider_details": {
                 "finish_reason": "stop",
                 "timestamp": "2025-09-22T14:13:49Z",
             },
-            "provider_name": "openai",
-            "provider_response_id": "chatcmpl-92c413bb5a45426299335d0621324654",
-            "provider_url": "https://www.external-ai-service.com",
-            "timestamp": "2025-07-25T10:36:35.297675Z",
-            "usage": {
-                "cache_audio_read_tokens": 0,
-                "cache_read_tokens": 0,
-                "cache_write_tokens": 0,
-                "details": {},
-                "input_audio_tokens": 0,
-                "input_tokens": 0,
-                "output_audio_tokens": 0,
-                "output_tokens": 135,
-            },
-            "run_id": _run_id,
         },
     ]
 
@@ -1503,10 +1067,7 @@ async def test_post_conversation_async(api_client, mock_openai_stream, monkeypat
 
     response = await sync_to_async(api_client.post)(url, data, format="json")  # client is sync
 
-    assert response.status_code == status.HTTP_200_OK
-    assert response.get("Content-Type") == "text/event-stream"
-    assert response.get("x-vercel-ai-data-stream") == "v1"
-    assert response.streaming
+    assert_data_stream_response(response)
 
     assert "Using ASYNC streaming for chat conversation" in caplog.text
 
@@ -1516,7 +1077,6 @@ async def test_post_conversation_async(api_client, mock_openai_stream, monkeypat
         "utf-8"
     )
 
-    # Replace UUIDs with placeholders for assertion
     response_content = replace_uuids_with_placeholder(response_content)
 
     assert response_content == (
@@ -1529,15 +1089,7 @@ async def test_post_conversation_async(api_client, mock_openai_stream, monkeypat
     assert mock_openai_stream.called
 
     await chat_conversation.arefresh_from_db()
-    assert chat_conversation.ui_messages == [
-        {
-            "content": "Hello",
-            "createdAt": "2025-07-03T15:22:17.105Z",
-            "id": "yuPoOuBkKA4FnKvk",
-            "parts": [{"text": "Hello", "type": "text"}],
-            "role": "user",
-        }
-    ]
+    _assert_hello_ui_messages(chat_conversation)
 
     assert len(chat_conversation.messages) == 2
 
@@ -1569,57 +1121,8 @@ async def test_post_conversation_async(api_client, mock_openai_stream, monkeypat
 
     _run_id = chat_conversation.pydantic_messages[0]["run_id"]
     assert chat_conversation.pydantic_messages == [
-        {
-            "instructions": (
-                "You are a helpful test assistant :)\n\n"
-                "Today is Friday 25/07/2025.\n\nAnswer in english."
-            ),
-            "kind": "request",
-            "metadata": None,
-            "parts": [
-                {
-                    "content": ["Hello"],
-                    "part_kind": "user-prompt",
-                    "timestamp": "2025-07-25T10:36:35.297675Z",
-                },
-            ],
-            "run_id": _run_id,
-            "timestamp": "2025-07-25T10:36:35.297675Z",
-        },
-        {
-            "finish_reason": "stop",
-            "kind": "response",
-            "metadata": None,
-            "model_name": "test-model",
-            "parts": [
-                {
-                    "content": "Hello there",
-                    "id": None,
-                    "part_kind": "text",
-                    "provider_details": None,
-                    "provider_name": None,
-                }
-            ],
-            "provider_details": {
-                "finish_reason": "stop",
-                "timestamp": "2025-07-25T10:36:35.297675Z",
-            },
-            "provider_name": "openai",
-            "provider_response_id": "chatcmpl-1234567890",
-            "provider_url": "https://www.external-ai-service.com/",
-            "timestamp": "2025-07-25T10:36:35.297675Z",
-            "usage": {
-                "cache_audio_read_tokens": 0,
-                "cache_read_tokens": 0,
-                "cache_write_tokens": 0,
-                "details": {},
-                "input_audio_tokens": 0,
-                "input_tokens": 0,
-                "output_audio_tokens": 0,
-                "output_tokens": 0,
-            },
-            "run_id": _run_id,
-        },
+        _make_pydantic_request(_run_id, ENGLISH_INSTRUCTIONS, ["Hello"]),
+        _make_pydantic_text_response(_run_id, "Hello there"),
     ]
 
 
@@ -1655,10 +1158,7 @@ async def test_post_conversation_async_triggers_keepalive(
 
     response = await sync_to_async(api_client.post)(url, data, format="json")  # client is sync
 
-    assert response.status_code == status.HTTP_200_OK
-    assert response.get("Content-Type") == "text/event-stream"
-    assert response.get("x-vercel-ai-data-stream") == "v1"
-    assert response.streaming
+    assert_data_stream_response(response)
 
     assert "Using ASYNC streaming for chat conversation" in caplog.text
 
@@ -1668,7 +1168,6 @@ async def test_post_conversation_async_triggers_keepalive(
         "utf-8"
     )
 
-    # Replace UUIDs with placeholders for assertion
     response_content = replace_uuids_with_placeholder(response_content)
 
     assert response_content == (
@@ -1682,15 +1181,7 @@ async def test_post_conversation_async_triggers_keepalive(
     assert mock_openai_stream_slow.called
 
     await chat_conversation.arefresh_from_db()
-    assert chat_conversation.ui_messages == [
-        {
-            "content": "Hello",
-            "createdAt": "2025-07-03T15:22:17.105Z",
-            "id": "yuPoOuBkKA4FnKvk",
-            "parts": [{"text": "Hello", "type": "text"}],
-            "role": "user",
-        }
-    ]
+    _assert_hello_ui_messages(chat_conversation)
 
     assert len(chat_conversation.messages) == 2
 
@@ -1724,57 +1215,8 @@ async def test_post_conversation_async_triggers_keepalive(
 
     # using ANY because time is not frozen in this api mock
     assert chat_conversation.pydantic_messages == [
-        {
-            "instructions": (
-                "You are a helpful test assistant :)\n\n"
-                "Today is Friday 25/07/2025.\n\nAnswer in english."
-            ),
-            "kind": "request",
-            "metadata": None,
-            "parts": [
-                {
-                    "content": ["Hello"],
-                    "part_kind": "user-prompt",
-                    "timestamp": ANY,
-                },
-            ],
-            "run_id": _run_id,
-            "timestamp": ANY,
-        },
-        {
-            "finish_reason": "stop",
-            "kind": "response",
-            "metadata": None,
-            "model_name": "test-model",
-            "parts": [
-                {
-                    "content": "Hello there",
-                    "id": None,
-                    "part_kind": "text",
-                    "provider_details": None,
-                    "provider_name": None,
-                }
-            ],
-            "provider_details": {
-                "finish_reason": "stop",
-                "timestamp": ANY,
-            },
-            "provider_name": "openai",
-            "provider_response_id": "chatcmpl-1234567890",
-            "provider_url": "https://www.external-ai-service.com/",
-            "timestamp": ANY,
-            "usage": {
-                "cache_audio_read_tokens": 0,
-                "cache_read_tokens": 0,
-                "cache_write_tokens": 0,
-                "details": {},
-                "input_audio_tokens": 0,
-                "input_tokens": 0,
-                "output_audio_tokens": 0,
-                "output_tokens": 0,
-            },
-            "run_id": _run_id,
-        },
+        _make_pydantic_request(_run_id, ENGLISH_INSTRUCTIONS, ["Hello"], timestamp=ANY),
+        _make_pydantic_text_response(_run_id, "Hello there", timestamp=ANY),
     ]
 
 
@@ -1808,23 +1250,12 @@ def test_post_conversation_oidc_refresh_enabled_unrefreshed(  # pylint: disable=
 @freeze_time("2025-07-25T10:36:35.297675Z")
 @respx.mock
 def test_post_conversation_oidc_refresh_enabled(  # pylint: disable=unused-argument
-    api_client, mock_openai_stream, oidc_refresh_token_enabled
+    api_client, mock_openai_stream, oidc_refresh_token_enabled, hello_conversation_data
 ):
     """Test posting messages to a conversation using the 'data' protocol."""
     chat_conversation = ChatConversationFactory(owner__language="en-us")
 
     url = f"/api/v1.0/chats/{chat_conversation.pk}/conversation/?protocol=data"
-    data = {
-        "messages": [
-            {
-                "id": "yuPoOuBkKA4FnKvk",
-                "role": "user",
-                "parts": [{"text": "Hello", "type": "text"}],
-                "content": "Hello",
-                "createdAt": "2025-07-03T15:22:17.105Z",
-            }
-        ]
-    }
     api_client.force_login(
         chat_conversation.owner, backend="core.authentication.backends.OIDCAuthenticationBackend"
     )
@@ -1834,18 +1265,13 @@ def test_post_conversation_oidc_refresh_enabled(  # pylint: disable=unused-argum
     session["oidc_token_expiration"] = session["oidc_id_token_expiration"]  # ...
     session.save()
 
-    response = api_client.post(url, data, format="json")
+    response = api_client.post(url, hello_conversation_data, format="json")
 
-    assert response.status_code == status.HTTP_200_OK
-    assert response.get("Content-Type") == "text/event-stream"
-    assert response.get("x-vercel-ai-data-stream") == "v1"
-    assert response.streaming
+    assert_data_stream_response(response)
 
-    # Wait for the streaming content to be fully received
-    response_content = b"".join(response.streaming_content).decode("utf-8")
-
-    # Replace UUIDs with placeholders for assertion
-    response_content = replace_uuids_with_placeholder(response_content)
+    response_content = replace_uuids_with_placeholder(
+        b"".join(response.streaming_content).decode("utf-8")
+    )
 
     assert response_content == (
         '0:"Hello"\n'
@@ -1856,26 +1282,10 @@ def test_post_conversation_oidc_refresh_enabled(  # pylint: disable=unused-argum
 
     assert mock_openai_stream.called
 
-    # ensure instructions are merged as a system prompt
-    last_request_payload = json.loads(respx.calls.last.request.content)
-    system_messages_content = [
-        message["content"]
-        for message in last_request_payload["messages"]
-        if message["role"] == "system"
-    ]
-    assert system_messages_content[0] == "You are a helpful test assistant :)"
-    assert system_messages_content[1] == "Today is Friday 25/07/2025."
-    assert system_messages_content[2] == "Answer in english."
+    _assert_english_system_prompts(json.loads(respx.calls.last.request.content))
+
     chat_conversation.refresh_from_db()
-    assert chat_conversation.ui_messages == [
-        {
-            "content": "Hello",
-            "createdAt": "2025-07-03T15:22:17.105Z",
-            "id": "yuPoOuBkKA4FnKvk",
-            "parts": [{"text": "Hello", "type": "text"}],
-            "role": "user",
-        }
-    ]
+    _assert_hello_ui_messages(chat_conversation)
 
     assert len(chat_conversation.messages) == 2
     assert len(chat_conversation.pydantic_messages) == 2

--- a/src/backend/chat/tests/views/chat/conversations/test_conversation_concatenate_system_messages.py
+++ b/src/backend/chat/tests/views/chat/conversations/test_conversation_concatenate_system_messages.py
@@ -1,0 +1,85 @@
+"""Unit tests for chat conversation actions in the with instruction concatenation"""
+
+import json
+
+import pytest
+import respx
+from freezegun import freeze_time
+
+from chat.factories import ChatConversationFactory, ChatProjectFactory, UserFactory
+from chat.llm_configuration import LLModel, LLMProvider
+from chat.tests.utils import assert_data_stream_response
+
+# enable database transactions for tests:
+# transaction=True ensures that the data are available in the database
+# in other threads
+pytestmark = pytest.mark.django_db(transaction=True)
+
+
+@pytest.fixture(autouse=True)
+def settings_with_concatenation(settings):
+    """Fixture to set AI service URLs for testing."""
+    settings.LLM_CONFIGURATIONS = {
+        "default-model": LLModel(
+            hrid="test-model",
+            model_name="gpt-4",
+            human_readable_name="Test Model",
+            provider=LLMProvider(
+                hrid="openai",
+                kind="openai",
+                base_url="https://www.external-ai-service.com/",
+                api_key="testkey",
+            ),
+            is_active=True,
+            system_prompt="base system prompt",
+            tools=[],
+            concatenate_instruction_messages=True,
+        )
+    }
+    return settings
+
+
+@freeze_time("2025-07-25T10:36:35.297675Z")
+@pytest.mark.parametrize(
+    ("conversation_in_project", "expected_system_message"),
+    (
+        [False, "base system prompt\n\nToday is Friday 25/07/2025.\n\nAnswer in english."],
+        [
+            True,
+            (
+                "base system prompt\n\nToday is Friday 25/07/2025.\n\nAnswer in english.\n\n"
+                "Custom project instructions."
+            ),
+        ],
+    ),
+)
+@respx.mock
+def test_post_conversation_concatenate(
+    api_client,
+    hello_conversation_data,
+    mock_openai_stream,
+    conversation_in_project,
+    expected_system_message,
+):
+    """The hook merges multiple SystemPromptParts into one before the model receives them."""
+    if conversation_in_project:
+        project = ChatProjectFactory(
+            owner=UserFactory(language="en-us"), llm_instructions="Custom project instructions."
+        )
+        chat_conversation = ChatConversationFactory(owner=project.owner, project=project)
+    else:
+        chat_conversation = ChatConversationFactory(owner__language="en-us")
+
+    url = f"/api/v1.0/chats/{chat_conversation.pk}/conversation/?protocol=data"
+    api_client.force_login(chat_conversation.owner)
+
+    response = api_client.post(url, hello_conversation_data, format="json")
+
+    assert_data_stream_response(response)
+    assert b"".join(response.streaming_content) is not None
+    request_sent = mock_openai_stream.calls[0].request
+    body = json.loads(request_sent.content)
+
+    system_messages = [m for m in body["messages"] if m["role"] == "system"]
+    assert len(system_messages) == 1
+    assert system_messages[0]["content"] == expected_system_message

--- a/src/backend/chat/tests/views/chat/conversations/test_conversation_with_document_upload.py
+++ b/src/backend/chat/tests/views/chat/conversations/test_conversation_with_document_upload.py
@@ -1204,6 +1204,7 @@ def test_post_conversation_with_odt_document_upload(
                     }
                 ],
                 "metadata": {"sources": ["sample.odt"]},
+                "outcome": "success",
                 "part_kind": "tool-return",
                 "timestamp": timezone_now,
                 "tool_call_id": chat_conversation.pydantic_messages[2]["parts"][0]["tool_call_id"],

--- a/src/backend/chat/tests/views/chat/conversations/test_conversation_with_document_upload.py
+++ b/src/backend/chat/tests/views/chat/conversations/test_conversation_with_document_upload.py
@@ -589,6 +589,7 @@ def test_post_conversation_with_document_upload(
                     }
                 ],
                 "metadata": {"sources": ["sample.pdf"]},
+                "outcome": "success",
                 "part_kind": "tool-return",
                 "timestamp": timezone_now,
                 "tool_call_id": chat_conversation.pydantic_messages[2]["parts"][0]["tool_call_id"],
@@ -926,6 +927,7 @@ def test_post_conversation_with_document_upload_summarize(  # pylint: disable=to
             {
                 "content": "The document discusses various topics.",
                 "metadata": {"sources": ["sample.pdf.md"]},
+                "outcome": "success",
                 "part_kind": "tool-return",
                 "timestamp": timezone_now,
                 "tool_call_id": chat_conversation.pydantic_messages[2]["parts"][0]["tool_call_id"],

--- a/src/backend/chat/tests/views/chat/conversations/test_conversation_with_history.py
+++ b/src/backend/chat/tests/views/chat/conversations/test_conversation_with_history.py
@@ -1554,6 +1554,7 @@ def test_post_conversation_with_existing_tool_history(
             {
                 "content": {"location": "Paris", "temperature": 22, "unit": "celsius"},
                 "metadata": None,
+                "outcome": "success",
                 "part_kind": "tool-return",
                 "timestamp": "2025-07-25T10:36:35.297675Z",
                 "tool_call_id": "xLDcIljdsDrz0idal7tATWSMm2jhMj47",

--- a/src/backend/chat/tests/views/chat/conversations/test_conversation_with_project.py
+++ b/src/backend/chat/tests/views/chat/conversations/test_conversation_with_project.py
@@ -61,9 +61,12 @@ def test_post_conversation_includes_project_llm_instructions(api_client, mock_op
     )
 
     last_request_payload = json.loads(respx.calls.last.request.content)
-    system_message = last_request_payload["messages"][0]
-    assert system_message["role"] == "system"
-    assert "Always reply in bullet points." in system_message["content"]
+    system_messages_content = [
+        message["content"]
+        for message in last_request_payload["messages"]
+        if message["role"] == "system"
+    ]
+    assert "Always reply in bullet points." in system_messages_content
     assert mock_openai_stream.called
 
 
@@ -104,9 +107,15 @@ def test_post_conversation_without_project_has_no_project_instructions(
     )
 
     last_request_payload = json.loads(respx.calls.last.request.content)
-    system_message = last_request_payload["messages"][0]
-    assert system_message["role"] == "system"
-    assert system_message["content"] == (
-        "You are a helpful test assistant :)\n\nToday is Friday 25/07/2025.\n\nAnswer in english."
-    )
+
+    system_messages_content = [
+        message["content"]
+        for message in last_request_payload["messages"]
+        if message["role"] == "system"
+    ]
+    assert system_messages_content == [
+        "You are a helpful test assistant :)",
+        "Today is Friday 25/07/2025.",
+        "Answer in english.",
+    ]
     assert mock_openai_stream.called

--- a/src/backend/chat/tests/views/chat/conversations/test_conversation_with_project.py
+++ b/src/backend/chat/tests/views/chat/conversations/test_conversation_with_project.py
@@ -12,6 +12,18 @@ from chat.tests.utils import replace_uuids_with_placeholder
 
 pytestmark = pytest.mark.django_db(transaction=True)
 
+_HELLO_THERE_STREAM = (
+    '0:"Hello"\n'
+    '0:" there"\n'
+    'f:{"messageId":"<mocked_uuid>"}\n'
+    'd:{"finishReason":"stop","usage":{"promptTokens":0,"completionTokens":0}}\n'
+)
+
+
+def _get_system_messages(last_respx_call):
+    payload = json.loads(last_respx_call.request.content)
+    return [m["content"] for m in payload["messages"] if m["role"] == "system"]
+
 
 @pytest.fixture(autouse=True)
 def ai_settings(settings):
@@ -24,9 +36,27 @@ def ai_settings(settings):
     return settings
 
 
+@pytest.fixture(name="project_hello_data")
+def project_hello_data_fixture():
+    """Request payload with a simple Hello user message."""
+    return {
+        "messages": [
+            {
+                "id": "msg-1",
+                "role": "user",
+                "parts": [{"text": "Hello", "type": "text"}],
+                "content": "Hello",
+                "createdAt": "2025-07-03T15:22:17.105Z",
+            }
+        ]
+    }
+
+
 @freeze_time("2025-07-25T10:36:35.297675Z")
 @respx.mock
-def test_post_conversation_includes_project_llm_instructions(api_client, mock_openai_stream):
+def test_post_conversation_includes_project_llm_instructions(
+    api_client, mock_openai_stream, project_hello_data
+):
     """Test that project LLM instructions are sent to the LLM as part of the system prompt."""
     project = ChatProjectFactory(llm_instructions="Always reply in bullet points.")
     conversation = ChatConversationFactory(
@@ -34,86 +64,40 @@ def test_post_conversation_includes_project_llm_instructions(api_client, mock_op
     )
 
     url = f"/api/v1.0/chats/{conversation.pk}/conversation/?protocol=data"
-    data = {
-        "messages": [
-            {
-                "id": "msg-1",
-                "role": "user",
-                "parts": [{"text": "Hello", "type": "text"}],
-                "content": "Hello",
-                "createdAt": "2025-07-03T15:22:17.105Z",
-            }
-        ]
-    }
     api_client.force_login(conversation.owner)
-    response = api_client.post(url, data, format="json")
+    response = api_client.post(url, project_hello_data, format="json")
 
     assert response.status_code == status.HTTP_200_OK
 
-    # Wait for the streaming content to be fully received
-    response_content = b"".join(response.streaming_content).decode("utf-8")
-    response_content = replace_uuids_with_placeholder(response_content)
-    assert response_content == (
-        '0:"Hello"\n'
-        '0:" there"\n'
-        'f:{"messageId":"<mocked_uuid>"}\n'
-        'd:{"finishReason":"stop","usage":{"promptTokens":0,"completionTokens":0}}\n'
+    response_content = replace_uuids_with_placeholder(
+        b"".join(response.streaming_content).decode("utf-8")
     )
+    assert response_content == _HELLO_THERE_STREAM
 
-    last_request_payload = json.loads(respx.calls.last.request.content)
-    system_messages_content = [
-        message["content"]
-        for message in last_request_payload["messages"]
-        if message["role"] == "system"
-    ]
-    assert "Always reply in bullet points." in system_messages_content
+    assert "Always reply in bullet points." in _get_system_messages(respx.calls.last)
     assert mock_openai_stream.called
 
 
 @freeze_time("2025-07-25T10:36:35.297675Z")
 @respx.mock
 def test_post_conversation_without_project_has_no_project_instructions(
-    api_client, mock_openai_stream
+    api_client, mock_openai_stream, project_hello_data
 ):
     """Test that conversations without a project do not include project instructions."""
     conversation = ChatConversationFactory(owner__language="en-us")
 
     url = f"/api/v1.0/chats/{conversation.pk}/conversation/?protocol=data"
-    data = {
-        "messages": [
-            {
-                "id": "msg-1",
-                "role": "user",
-                "parts": [{"text": "Hello", "type": "text"}],
-                "content": "Hello",
-                "createdAt": "2025-07-03T15:22:17.105Z",
-            }
-        ]
-    }
     api_client.force_login(conversation.owner)
-    response = api_client.post(url, data, format="json")
+    response = api_client.post(url, project_hello_data, format="json")
 
     assert response.status_code == status.HTTP_200_OK
 
-    # Wait for the streaming content to be fully received
-    response_content = b"".join(response.streaming_content).decode("utf-8")
-    response_content = replace_uuids_with_placeholder(response_content)
-
-    assert response_content == (
-        '0:"Hello"\n'
-        '0:" there"\n'
-        'f:{"messageId":"<mocked_uuid>"}\n'
-        'd:{"finishReason":"stop","usage":{"promptTokens":0,"completionTokens":0}}\n'
+    response_content = replace_uuids_with_placeholder(
+        b"".join(response.streaming_content).decode("utf-8")
     )
+    assert response_content == _HELLO_THERE_STREAM
 
-    last_request_payload = json.loads(respx.calls.last.request.content)
-
-    system_messages_content = [
-        message["content"]
-        for message in last_request_payload["messages"]
-        if message["role"] == "system"
-    ]
-    assert system_messages_content == [
+    assert _get_system_messages(respx.calls.last) == [
         "You are a helpful test assistant :)",
         "Today is Friday 25/07/2025.",
         "Answer in english.",

--- a/src/backend/chat/tests/views/chat/conversations/test_conversation_with_project.py
+++ b/src/backend/chat/tests/views/chat/conversations/test_conversation_with_project.py
@@ -7,7 +7,7 @@ import respx
 from freezegun import freeze_time
 from rest_framework import status
 
-from chat.factories import ChatConversationFactory, ChatProjectFactory
+from chat.factories import ChatConversationFactory, ChatProjectFactory, UserFactory
 from chat.tests.utils import replace_uuids_with_placeholder
 
 pytestmark = pytest.mark.django_db(transaction=True)
@@ -53,15 +53,40 @@ def project_hello_data_fixture():
 
 
 @freeze_time("2025-07-25T10:36:35.297675Z")
+@pytest.mark.parametrize(
+    ("with_project", "expected_system_messages"),
+    (
+        [
+            True,
+            [
+                "You are a helpful test assistant :)",
+                "Today is Friday 25/07/2025.",
+                "Answer in english.",
+                "Always reply in bullet points.",
+            ],
+        ],
+        [
+            False,
+            [
+                "You are a helpful test assistant :)",
+                "Today is Friday 25/07/2025.",
+                "Answer in english.",
+            ],
+        ],
+    ),
+)
 @respx.mock
 def test_post_conversation_includes_project_llm_instructions(
-    api_client, mock_openai_stream, project_hello_data
+    api_client, mock_openai_stream, project_hello_data, with_project, expected_system_messages
 ):
     """Test that project LLM instructions are sent to the LLM as part of the system prompt."""
-    project = ChatProjectFactory(llm_instructions="Always reply in bullet points.")
-    conversation = ChatConversationFactory(
-        owner=project.owner, project=project, owner__language="en-us"
-    )
+    if with_project:
+        project = ChatProjectFactory(
+            owner=UserFactory(language="en-us"), llm_instructions="Always reply in bullet points."
+        )
+        conversation = ChatConversationFactory(owner=project.owner, project=project)
+    else:
+        conversation = ChatConversationFactory(owner__language="en-us")
 
     url = f"/api/v1.0/chats/{conversation.pk}/conversation/?protocol=data"
     api_client.force_login(conversation.owner)
@@ -74,32 +99,5 @@ def test_post_conversation_includes_project_llm_instructions(
     )
     assert response_content == _HELLO_THERE_STREAM
 
-    assert "Always reply in bullet points." in _get_system_messages(respx.calls.last)
-    assert mock_openai_stream.called
-
-
-@freeze_time("2025-07-25T10:36:35.297675Z")
-@respx.mock
-def test_post_conversation_without_project_has_no_project_instructions(
-    api_client, mock_openai_stream, project_hello_data
-):
-    """Test that conversations without a project do not include project instructions."""
-    conversation = ChatConversationFactory(owner__language="en-us")
-
-    url = f"/api/v1.0/chats/{conversation.pk}/conversation/?protocol=data"
-    api_client.force_login(conversation.owner)
-    response = api_client.post(url, project_hello_data, format="json")
-
-    assert response.status_code == status.HTTP_200_OK
-
-    response_content = replace_uuids_with_placeholder(
-        b"".join(response.streaming_content).decode("utf-8")
-    )
-    assert response_content == _HELLO_THERE_STREAM
-
-    assert _get_system_messages(respx.calls.last) == [
-        "You are a helpful test assistant :)",
-        "Today is Friday 25/07/2025.",
-        "Answer in english.",
-    ]
+    assert _get_system_messages(respx.calls.last) == expected_system_messages
     assert mock_openai_stream.called

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -56,7 +56,7 @@ dependencies = [
     "nested-multipart-parser==1.6.0",
     "posthog==7.0.0",
     "pydantic==2.12.4",
-    "pydantic-ai-slim[openai,mistral,mcp,evals,logfire]==1.62.0",
+    "pydantic-ai-slim[openai,mistral,mcp,evals,logfire]==1.77.0",
     "psycopg[binary]==3.2.12",
     "PyJWT==2.12.0",
     "python-magic==0.4.27",
@@ -111,6 +111,7 @@ zip-safe = true
 universal = true
 
 [tool.uv]
+exclude-newer = "7 days"
 required-environments = [
     "sys_platform == 'linux' and platform_machine == 'x86_64'",
     "sys_platform == 'darwin'",

--- a/src/backend/uv.lock
+++ b/src/backend/uv.lock
@@ -10,6 +10,10 @@ required-markers = [
     "sys_platform == 'darwin'",
 ]
 
+[options]
+exclude-newer = "2026-04-07T14:14:58.908812Z"
+exclude-newer-span = "P7D"
+
 [manifest]
 overrides = [
     { name = "cryptography", specifier = ">=46.0.5" },
@@ -519,7 +523,7 @@ requires-dist = [
     { name = "posthog", specifier = "==7.0.0" },
     { name = "psycopg", extras = ["binary"], specifier = "==3.2.12" },
     { name = "pydantic", specifier = "==2.12.4" },
-    { name = "pydantic-ai-slim", extras = ["openai", "mistral", "mcp", "evals", "logfire"], specifier = "==1.62.0" },
+    { name = "pydantic-ai-slim", extras = ["openai", "mistral", "mcp", "evals", "logfire"], specifier = "==1.77.0" },
     { name = "pyfakefs", marker = "extra == 'dev'", specifier = "==5.10.2" },
     { name = "pyjwt", specifier = "==2.12.0" },
     { name = "pylint", marker = "extra == 'dev'", specifier = "==3.3.9" },
@@ -1192,15 +1196,6 @@ wheels = [
 ]
 
 [[package]]
-name = "invoke"
-version = "2.2.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/de/bd/b461d3424a24c80490313fd77feeb666ca4f6a28c7e72713e3d9095719b4/invoke-2.2.1.tar.gz", hash = "sha256:515bf49b4a48932b79b024590348da22f39c4942dff991ad1fb8b8baea1be707", size = 304762, upload-time = "2025-10-11T00:36:35.172Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/32/4b/b99e37f88336009971405cbb7630610322ed6fbfa31e1d7ab3fbf3049a2d/invoke-2.2.1-py3-none-any.whl", hash = "sha256:2413bc441b376e5cd3f55bb5d364f973ad8bdd7bf87e53c79de3c11bf3feecc8", size = 160287, upload-time = "2025-10-11T00:36:33.703Z" },
-]
-
-[[package]]
 name = "ipdb"
 version = "0.13.13"
 source = { registry = "https://pypi.org/simple" }
@@ -1342,6 +1337,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ce/90/b8cc8635c4ce2e5e8104bf26ef147f6e599478f6329107283cdc53aae97f/joserfc-1.6.3.tar.gz", hash = "sha256:c00c2830db969b836cba197e830e738dd9dda0955f1794e55d3c636f17f5c9a6", size = 229090, upload-time = "2026-02-25T15:33:38.167Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/12/4f/124b3301067b752f44f292f0b9a74e837dd75ff863ee39500a082fc4c733/joserfc-1.6.3-py3-none-any.whl", hash = "sha256:6beab3635358cbc565cb94fb4c53d0557e6d10a15b933e2134939351590bda9a", size = 70465, upload-time = "2026-02-25T15:33:36.997Z" },
+]
+
+[[package]]
+name = "jsonpath-python"
+version = "1.1.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/db/2f4ecc24da35c6142b39c353d5b7c16eef955cc94b35a48d3fa47996d7c3/jsonpath_python-1.1.5.tar.gz", hash = "sha256:ceea2efd9e56add09330a2c9631ea3d55297b9619348c1055e5bfb9cb0b8c538", size = 87352, upload-time = "2026-03-17T06:16:40.597Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/28/50/1a313fb700526b134c71eb8a225d8b83be0385dbb0204337b4379c698cef/jsonpath_python-1.1.5-py3-none-any.whl", hash = "sha256:a60315404d70a65e76c9a782c84e50600480221d94a58af47b7b4d437351cb4b", size = 14090, upload-time = "2026-03-17T06:16:39.152Z" },
 ]
 
 [[package]]
@@ -1627,20 +1631,21 @@ wheels = [
 
 [[package]]
 name = "mistralai"
-version = "1.9.11"
+version = "2.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "eval-type-backport" },
     { name = "httpx" },
-    { name = "invoke" },
+    { name = "jsonpath-python" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
     { name = "pydantic" },
     { name = "python-dateutil" },
-    { name = "pyyaml" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5a/8d/d8b7af67a966b6f227024e1cb7287fc19901a434f87a5a391dcfe635d338/mistralai-1.9.11.tar.gz", hash = "sha256:3df9e403c31a756ec79e78df25ee73cea3eb15f86693773e16b16adaf59c9b8a", size = 208051, upload-time = "2025-10-02T15:53:40.473Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/d0/229ac07a67a9f4488d13f7a0080471d82f22dc1cdad7bf6b748d27a00d1a/mistralai-2.2.0.tar.gz", hash = "sha256:48abfa247ea5a888400ee294a5c1e090ae7e1445cc8cd008c120ae1e3b8eb9eb", size = 385567, upload-time = "2026-03-31T11:21:38.265Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fe/76/4ce12563aea5a76016f8643eff30ab731e6656c845e9e4d090ef10c7b925/mistralai-1.9.11-py3-none-any.whl", hash = "sha256:7a3dc2b8ef3fceaa3582220234261b5c4e3e03a972563b07afa150e44a25a6d3", size = 442796, upload-time = "2025-10-02T15:53:39.134Z" },
+    { url = "https://files.pythonhosted.org/packages/db/96/91c8225e1517b728543fcad7bc789391aa22452beb8d88edfaf4111cc9eb/mistralai-2.2.0-py3-none-any.whl", hash = "sha256:9e0cea19eb5281428010c9a220f186e5db0993cfe88f8855ef9d69291956f40b", size = 924713, upload-time = "2026-03-31T11:21:39.761Z" },
 ]
 
 [[package]]
@@ -1777,7 +1782,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "2.15.0"
+version = "2.30.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1789,9 +1794,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/94/f4/4690ecb5d70023ce6bfcfeabfe717020f654bde59a775058ec6ac4692463/openai-2.15.0.tar.gz", hash = "sha256:42eb8cbb407d84770633f31bf727d4ffb4138711c670565a41663d9439174fba", size = 627383, upload-time = "2026-01-09T22:10:08.603Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/15/52580c8fbc16d0675d516e8749806eda679b16de1e4434ea06fb6feaa610/openai-2.30.0.tar.gz", hash = "sha256:92f7661c990bda4b22a941806c83eabe4896c3094465030dd882a71abe80c885", size = 676084, upload-time = "2026-03-25T22:08:59.96Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b5/df/c306f7375d42bafb379934c2df4c2fa3964656c8c782bac75ee10c102818/openai-2.15.0-py3-none-any.whl", hash = "sha256:6ae23b932cd7230f7244e52954daa6602716d6b9bf235401a107af731baea6c3", size = 1067879, upload-time = "2026-01-09T22:10:06.446Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/9e/5bfa2270f902d5b92ab7d41ce0475b8630572e71e349b2a4996d14bdda93/openai-2.30.0-py3-none-any.whl", hash = "sha256:9a5ae616888eb2748ec5e0c5b955a51592e0b201a11f4262db920f2a78c5231d", size = 1146656, upload-time = "2026-03-25T22:08:58.2Z" },
 ]
 
 [[package]]
@@ -2198,7 +2203,7 @@ wheels = [
 
 [[package]]
 name = "pydantic-ai-slim"
-version = "1.62.0"
+version = "1.77.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "genai-prices" },
@@ -2209,9 +2214,9 @@ dependencies = [
     { name = "pydantic-graph" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/cc/8d/6350a49f2e4b636efbcfc233221420ab576e4ba4edba38254cb84ae4a1e6/pydantic_ai_slim-1.62.0.tar.gz", hash = "sha256:00d84f659107bbbd88823a3d3dbe7348385935a9870b9d7d4ba799256f6b6983", size = 422452, upload-time = "2026-02-19T05:07:10.292Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/79/a7/ad011e626bed1f275fbaf933181573a50b05c2b9a0be927583d46fb8ff13/pydantic_ai_slim-1.77.0.tar.gz", hash = "sha256:a6e7006a4b048193d45b6ba816d301271e3f5ef1cdc4f9fb340617f382c6ce0d", size = 518781, upload-time = "2026-04-03T02:16:54.524Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3d/67/21e9b3b0944568662e3790c936226bd48a9f27c6b5f27b5916f5857bc4d8/pydantic_ai_slim-1.62.0-py3-none-any.whl", hash = "sha256:5210073fadd46f65859a67da67845093c487f025fa430ed027151f22ec684ab2", size = 549296, upload-time = "2026-02-19T05:07:01.624Z" },
+    { url = "https://files.pythonhosted.org/packages/96/c5/5913cc4ae99047901c602f0d8208e3a75a7952b7e57d76169547307d7cea/pydantic_ai_slim-1.77.0-py3-none-any.whl", hash = "sha256:110c516935de384f1beddc36fda04e8df36cdf5bee3a5bfd0da562726182e52b", size = 664494, upload-time = "2026-04-03T02:16:46.668Z" },
 ]
 
 [package.optional-dependencies]
@@ -2259,7 +2264,7 @@ wheels = [
 
 [[package]]
 name = "pydantic-evals"
-version = "1.62.0"
+version = "1.77.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -2269,14 +2274,14 @@ dependencies = [
     { name = "pyyaml" },
     { name = "rich" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/23/90/080f6722412263395d1d6d066ee90fa8bc2722ce097844220c2d9c946877/pydantic_evals-1.62.0.tar.gz", hash = "sha256:198c4bee936718a4acf6f504056b113e60b34eb49021df8889a394e14c803693", size = 56434, upload-time = "2026-02-19T05:07:11.793Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/de/23/8da617d3803362325790e73e6219dec359559c2ef2350b35dbeb9e39c92f/pydantic_evals-1.77.0.tar.gz", hash = "sha256:64a12324c9a3f4fefa34b5a5eb4c2320c0976e425404372fa69f2872f585c3d0", size = 65811, upload-time = "2026-04-03T02:16:55.71Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d8/b9/dc8dba744ec02b16c6fd1abe3fd8ef1b00fd05c72feef5069851b811952f/pydantic_evals-1.62.0-py3-none-any.whl", hash = "sha256:0ca7e10037ed90393c54b6cff41370d6d4bac63f8c878715599c58863c303db1", size = 67341, upload-time = "2026-02-19T05:07:03.83Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/07/b9e6ba4afcce41f70a0f149cd7bc299a0babaf9c62a57d7cb291679a6cc7/pydantic_evals-1.77.0-py3-none-any.whl", hash = "sha256:2b536081e36d70826da216a3a6df8d84e3ac1982fc3b8078c123fd539ce6bfb6", size = 77740, upload-time = "2026-04-03T02:16:48.681Z" },
 ]
 
 [[package]]
 name = "pydantic-graph"
-version = "1.62.0"
+version = "1.77.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -2284,9 +2289,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3b/b6/0b084c847ecd99624f4fbc5c8ecd3f67a2388a282a32612b2a68c3b3595f/pydantic_graph-1.62.0.tar.gz", hash = "sha256:efe56bee3a8ca35b11a3be6a5f7352419fe182ef1e1323a3267ee12dec95f3c7", size = 58529, upload-time = "2026-02-19T05:07:12.947Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/60/40/a8b8e256bb90e4e284b35cc1c5e1a8e2724fa88ad89b7eac958fbf85852b/pydantic_graph-1.77.0.tar.gz", hash = "sha256:ba75dbdf221cd7e366e5c5d250f4d9f3138e05400ea52d3f36330772d989deee", size = 58689, upload-time = "2026-04-03T02:16:56.625Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f0/12/1a9cbcd59fd070ba72b0fe544caa6ca97758518643523ec2bf1162084e0d/pydantic_graph-1.62.0-py3-none-any.whl", hash = "sha256:abe0e7b356b4d3202b069ec020d8dd1f647f55e9a0e85cd272dab48250bde87d", size = 72350, upload-time = "2026-02-19T05:07:05.305Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/09/3c9c3aba8031adbd21d1833e8e4edd749697e50a88fa9bdab641874abe4f/pydantic_graph-1.77.0-py3-none-any.whl", hash = "sha256:063803e87aec901919c2073ccf3fdd6e4fff84e8b05dbfbe8a6c1af63dd12c05", size = 72503, upload-time = "2026-04-03T02:16:49.97Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Purpose

- Update pydantic-ai to benefit from new features (Capabilities)
- Update monkey patch
- Refactor tests make them DRY


## Manual End-to-End Test Plan
### All good 🟢 
> Tested with OpenAI and Mistral models.

### 1. Basic Chat

- [x] Send a message and receive a streamed response
- [x] Send a follow-up message in the same conversation (message history preserved)
- [x] Response renders Markdown correctly (bold, code blocks, lists)
- [x] Code blocks have syntax highlighting
- [x] Auto-scroll to bottom during streaming; scroll-down button appears when scrolled up

---

### 2. Instructions (key for this upgrade)

- [x] Response respects the configured system prompt (e.g., agent name, persona)
- [x] Response date in "Today is..." instruction matches the current date
- [x] Changing the UI language (FR → EN) changes the response language

---

### 3. Projects
- [x] A conversation inside a project appears under the project in the left panel, not in standalone chats
- [x] A standalone conversation does not receive project instructions

---

### 4. File Attachments & Document RAG

- [x] Upload a file (PDF, DOCX, PNG)
- [x] Ask question about a file

---

### 5. Web Search

- [x] Ask a question requiring fresh information → agent performs a search and cites sources
- [x] Source items are displayed below the AI response
- [x] "Force web search" parameter triggers web search even for non-fresh-info questions

---

### 6. Model Selector

- [x] Model selector displays all configured LLM profiles


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated changelog and upgraded pydantic-ai-slim and related packages to v1.77.0.

* **New Features**
  * Added an optional model configuration flag to control concatenation of instruction messages.

* **Tests**
  * Expanded conversation tests and fixtures for consistent timestamps, zeroed usage values, and streaming-response assertions.
  * Tests now expect tool-call results to include an "outcome": "success" field and validate system-prompt concatenation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->