### PR TITLE
(back) handle Albert models issues 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to
 - 🐛(fix) new conversation in project button max size
 - 💄(ui) little fix margin top
 - 💄(ui) review ui for part of the project
+- 🐛(fix) Fix streaming crash with OpenAI-compatible APIs
 
 ## [0.0.15] - 2026-03-31
 

--- a/src/backend/chat/agents/base.py
+++ b/src/backend/chat/agents/base.py
@@ -17,6 +17,106 @@ from chat.tools import get_pydantic_tools_by_name
 logger = logging.getLogger(__name__)
 
 
+def _patch_mistral_streaming_map_content():
+    """Monkey-patch pydantic_ai.models.mistral._map_content to handle citations.
+
+    The original _map_content raises exceptions when responses contain
+    citation/reference data, which happens anytime we use web search or
+    other RAG tools (https://docs.mistral.ai/capabilities/citations/).
+    We replace it with a safe version that extracts text and thinking
+    chunks while ignoring unsupported data types.
+
+    ⚠ WARNING: this is a monkey patch and may break if the original function
+    changes in future versions of pydantic_ai. Current version: v1.0.18
+    """
+    # pylint: disable=import-outside-toplevel,protected-access
+    import pydantic_ai.models.mistral as mistral_models  # noqa: PLC0415
+    from mistralai.client.models import TextChunk as MistralTextChunk  # noqa: PLC0415
+    from mistralai.client.models import ThinkChunk as MistralThinkChunk  # noqa: PLC0415
+    from mistralai.client.types.basemodel import Unset as MistralUnset  # noqa: PLC0415
+
+    if getattr(mistral_models, "__safe_map_patched__", False):
+        return
+
+    def _safe_map_content(content):
+        text: str | None = None
+        thinking: list[str] = []
+
+        if isinstance(content, MistralUnset) or not content:
+            return None, []
+
+        if isinstance(content, list):
+            for chunk in content:
+                if isinstance(chunk, MistralTextChunk):
+                    text = (text or "") + chunk.text
+                elif isinstance(chunk, MistralThinkChunk):
+                    for thought in chunk.thinking:
+                        if thought.type == "text":  # pragma: no branch
+                            thinking.append(thought.text)
+                else:
+                    logger.info(  # pragma: no cover
+                        "Other data types like (Image, Reference) are not yet supported,  got %s",
+                        type(chunk),
+                    )
+        elif isinstance(content, str):
+            text = content
+
+        # Note: Check len to handle potential mismatch between function calls and
+        # responses from the API.
+        # (`msg: not the same number of function class and responses`)
+        if text == "":  # pragma: no cover
+            text = None
+
+        return text, thinking
+
+    mistral_models._map_content = _safe_map_content  # noqa: SLF001
+    mistral_models.__safe_map_patched__ = True
+
+
+def _patch_openai_streaming_list_content():
+    """Monkey-patch OpenAIStreamedResponse._map_text_delta to normalize list content.
+
+    Some OpenAI-compatible APIs (e.g. Albert API serving Mistral models)
+    return choice.delta.content as a list of content parts instead of a
+    plain string during streaming, particularly when the response includes
+    citation/reference data from web search. pydantic-ai expects a str and
+    crashes with:
+        TypeError: can only concatenate str (not "list") to str
+    We normalize list content to str before delegating to the original method.
+
+    ⚠ WARNING: this is a monkey patch and may break if the original function
+    changes in future versions of pydantic_ai. Current version: v1.77.0
+    """
+    # pylint: disable=import-outside-toplevel,protected-access
+    import pydantic_ai.models.openai as openai_models  # noqa: PLC0415
+    from pydantic_ai.models.openai import OpenAIStreamedResponse  # noqa: PLC0415
+
+    if getattr(openai_models, "__safe_text_delta_patched__", False):
+        return
+
+    _original_map_text_delta = OpenAIStreamedResponse._map_text_delta  # noqa: SLF001
+
+    def _safe_map_text_delta(self, choice):
+        content = choice.delta.content
+        if isinstance(content, list):
+            text_parts = []
+            for item in content:
+                if isinstance(item, str):
+                    text_parts.append(item)
+                elif isinstance(item, dict):
+                    text_parts.append(item.get("text") or "")
+                else:
+                    logger.info(
+                        "Unexpected content part type in streaming delta: %s",
+                        type(item),
+                    )
+            choice.delta.content = "".join(text_parts) or None
+        yield from _original_map_text_delta(self, choice)
+
+    OpenAIStreamedResponse._map_text_delta = _safe_map_text_delta  # noqa: SLF001
+    openai_models.__safe_text_delta_patched__ = True
+
+
 def prepare_custom_model(configuration: "chat.llm_configuration.LLModel"):
     """
     Prepare a custom model instance based on the provided configuration.
@@ -30,70 +130,9 @@ def prepare_custom_model(configuration: "chat.llm_configuration.LLModel"):
     match configuration.provider.kind:
         case "mistral":
             import pydantic_ai.models.mistral as mistral_models  # noqa: PLC0415
-            from mistralai.client.models import TextChunk as MistralTextChunk  # noqa: PLC0415
-            from mistralai.client.models import ThinkChunk as MistralThinkChunk  # noqa: PLC0415
-            from mistralai.client.types.basemodel import Unset as MistralUnset  # noqa: PLC0415
             from pydantic_ai.providers.mistral import MistralProvider  # noqa: PLC0415
 
-            # --- Monkey patch for pydantic_ai.models.mistral._map_content ---
-            # pylint: disable=protected-access
-
-            # ⚠ WARNING ⚠ WARNING ⚠ WARNING ⚠ WARNING ⚠ WARNING ⚠ WARNING ⚠ WARNING ⚠ WARNING ⚠
-            # |  This workaround is fragile and only works because we are in streaming mode.  |
-            # ⚠ WARNING ⚠ WARNING ⚠ WARNING ⚠ WARNING ⚠ WARNING ⚠ WARNING ⚠ WARNING ⚠ WARNING ⚠
-
-            # The original _map_content raises exceptions for some when responses
-            # contains citation/reference data, which is the case anytime we use
-            # web search or other RAG tool (https://docs.mistral.ai/capabilities/citations/).
-            # We make the patch idempotent using a sentinel attribute so repeated calls
-            # to prepare_custom_model do not re-wrap and do not cause recursive calls.
-            if not getattr(mistral_models, "__safe_map_patched__", False):
-                _original_map_content = mistral_models._map_content  # noqa: SLF001
-
-                def _safe_map_content(content):
-                    """
-                    A safe version of _map_content that ignores unsupported data types.
-
-                    WARNING: this is a monkey patch and may break if the original
-                    function changes in future versions of pydantic_ai.
-                    Current version: pydantic_ai v1.0.18
-                    """
-                    text: str | None = None
-                    thinking: list[str] = []
-
-                    if isinstance(content, MistralUnset) or not content:
-                        return None, []
-
-                    if isinstance(content, list):
-                        for chunk in content:
-                            if isinstance(chunk, MistralTextChunk):
-                                text = (text or "") + chunk.text
-                            elif isinstance(chunk, MistralThinkChunk):
-                                for thought in chunk.thinking:
-                                    if thought.type == "text":  # pragma: no branch
-                                        thinking.append(thought.text)
-                            else:
-                                logger.info(  # pragma: no cover
-                                    "Other data types like (Image, Reference) are not yet "
-                                    "supported,  got %s",
-                                    type(chunk),
-                                )
-                    elif isinstance(content, str):
-                        text = content
-
-                    # Note: Check len to handle potential mismatch between function calls and
-                    # responses from the API.
-                    # (`msg: not the same number of function class and responses`)
-                    if text == "":  # pragma: no cover
-                        text = None
-
-                    return text, thinking
-
-                # Replace the original module-level function
-                mistral_models._map_content = _safe_map_content  # noqa: SLF001
-                mistral_models.__safe_map_patched__ = True
-            # pylint: enable=protected-access
-            # --- End monkey patch ---
+            _patch_mistral_streaming_map_content()
 
             return mistral_models.MistralModel(
                 model_name=configuration.model_name,
@@ -121,6 +160,8 @@ def prepare_custom_model(configuration: "chat.llm_configuration.LLModel"):
                 AlbertOpenAIChatModel,
                 AlbertOpenAIProvider,
             )
+
+            _patch_openai_streaming_list_content()
 
             if configuration.profile and (
                 _config_profile := configuration.profile.dict(exclude_unset=True)

--- a/src/backend/chat/tests/agents/test_base_agent.py
+++ b/src/backend/chat/tests/agents/test_base_agent.py
@@ -1,10 +1,13 @@
 """Tests for the BaseAgent class and its model initialization logic."""
 
 # pylint: disable=protected-access
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
 import pytest
 from pydantic_ai.capabilities import Hooks
 from pydantic_ai.models.mistral import MistralModel
-from pydantic_ai.models.openai import OpenAIChatModel
+from pydantic_ai.models.openai import OpenAIChatModel, OpenAIStreamedResponse
 
 from chat.agents.base import BaseAgent
 from chat.llm_configuration import LLModel, LLMProfile, LLMProvider
@@ -176,3 +179,76 @@ def test_custom_model_albert(settings):
 
     assert isinstance(agent._model, AlbertOpenAIChatModel)
     assert isinstance(agent._model._provider, AlbertOpenAIProvider)
+
+
+def test_custom_model_openai_patches_text_delta(settings):
+    """Test that the OpenAI monkey patch for list content is applied."""
+    settings.LLM_CONFIGURATIONS = {
+        "openai-model": LLModel(
+            hrid="openai-model",
+            model_name="gpt-4",
+            human_readable_name="OpenAI Model",
+            provider=LLMProvider(
+                hrid="openai",
+                kind="openai",
+                base_url="https://test.vllm/v1",
+                api_key="testkey",
+            ),
+            is_active=True,
+            system_prompt="direct",
+            tools=[],
+        ),
+    }
+    BaseAgent(model_hrid="openai-model")
+
+    import pydantic_ai.models.openai as openai_models  # noqa: PLC0415 # pylint: disable=import-outside-toplevel
+
+    assert openai_models.__safe_text_delta_patched__ is True
+
+
+@pytest.mark.parametrize(
+    "content_input,expected",
+    [
+        (["hello", " world"], "hello world"),
+        ([{"type": "text", "text": "hello"}, {"type": "text", "text": " world"}], "hello world"),
+        (["hello", {"type": "text", "text": " world"}], "hello world"),
+        ([{"type": "text", "text": None}], None),
+        ([], None),
+        ("hello", "hello"),
+    ],
+    ids=[
+        "list-of-strings",
+        "list-of-dicts",
+        "mixed",
+        "dict-text-null",
+        "empty-list",
+        "plain-string-noop",
+    ],
+)
+def test_openai_text_delta_normalizes_list_content(settings, content_input, expected):
+    """Test that _map_text_delta normalizes list content to string."""
+    settings.LLM_CONFIGURATIONS = {
+        "openai-model": LLModel(
+            hrid="openai-model",
+            model_name="gpt-4",
+            human_readable_name="OpenAI Model",
+            provider=LLMProvider(
+                hrid="openai",
+                kind="openai",
+                base_url="https://test.vllm/v1",
+                api_key="testkey",
+            ),
+            is_active=True,
+            system_prompt="direct",
+            tools=[],
+        ),
+    }
+    BaseAgent(model_hrid="openai-model")
+
+    choice = SimpleNamespace(delta=SimpleNamespace(content=content_input))
+
+    mock_self = MagicMock()
+    mock_self._parts_manager.handle_text_delta.return_value = iter([])
+    list(OpenAIStreamedResponse._map_text_delta(mock_self, choice))
+
+    assert choice.delta.content == expected


### PR DESCRIPTION
## Purpose

- Some OpenAI-compatible APIs (Albert API serving Mistral models) returns  `choice.delta.content` as a list of content parts instead of a plain sting during streaming, causing pydantic-ai to crash with   "TypeError: can only concatenate str (not "list") to str"
- This only hapens when the model response includes citation/reference  data (triggered by web search tool results)
- The crash was oly visible on Sentry (staging, ASGI mode). The error is silently swallowed for the end user, resulting  in the conversation not being persisted and auto-rename not triggering


cf. https://github.com/orgs/suitenumerique/projects/13/views/3?pane=issue&itemId=171366500&issue=suitenumerique%7Cconversations%7C381


## Proposal

- Adds a monky-patch on `OpenAIStreamedResponse._map_text_delta` that  normalizes list content to string before delegation
- Extracts both Mistral and OpenAI monkey-patches into standalone  functions for consistency
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a streaming crash when using OpenAI-compatible APIs and improved streaming compatibility for Mistral-style responses.

* **Tests**
  * Added tests covering OpenAI streaming behavior and normalization of streamed content to prevent malformed payloads.

* **Changelog**
  * Appended an "Unreleased → Fixed" entry documenting the streaming crash fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->