### PR TITLE
✨(tools): update descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to
 - ✨(back) add debug mode setup for local development
 - ⬆️(dependencies) update pydanticai and related dependencies
 - ⚙️(back) get carbon data from albert api provider
+- ✨(tools): update descriptions
 
 ### Fixed
 

--- a/src/backend/chat/clients/pydantic_ai.py
+++ b/src/backend/chat/clients/pydantic_ai.py
@@ -141,6 +141,11 @@ from chat.clients.pydantic_ui_message_converter import (
     ui_message_to_user_content,
 )
 from chat.mcp_servers import get_mcp_servers
+from chat.tools.descriptions import (
+    DOCUMENT_SUMMARIZE_SYSTEM_PROMPT,
+    DOCUMENT_SUMMARIZE_TOOL_DESCRIPTION,
+    WEB_SEARCH_TOOL_DESCRIPTION,
+)
 from chat.tools.document_generic_search_rag import add_document_rag_search_tool_from_setting
 from chat.tools.document_search_rag import add_document_rag_search_tool
 from chat.tools.document_summarize import document_summarize
@@ -684,16 +689,7 @@ class AIAgentService:  # pylint: disable=too-many-instance-attributes
 
         @self.conversation_agent.instructions
         def summarization_system_prompt() -> str:
-            return (
-                "When you receive a result from the summarization tool, you MUST return it "
-                "directly to the user without any modification, paraphrasing, or additional "
-                "summarization."
-                "The tool already produces optimized summaries that should be presented "
-                "verbatim."
-                "You may translate the summary if required, but you MUST preserve all the "
-                "information from the original summary."
-                "You may add a follow-up question after the summary if needed."
-            )
+            return DOCUMENT_SUMMARIZE_SYSTEM_PROMPT
 
         # Inform the model (system-level) that documents are attached and available
         @self.conversation_agent.instructions
@@ -704,7 +700,11 @@ class AIAgentService:  # pylint: disable=too-many-instance-attributes
                 "via the internal store."
             )
 
-        @self.conversation_agent.tool(name="summarize", retries=2)
+        @self.conversation_agent.tool(
+            name="summarize",
+            retries=2,
+            description=DOCUMENT_SUMMARIZE_TOOL_DESCRIPTION,
+        )
         @functools.wraps(document_summarize)
         async def summarize(ctx: RunContext, *args, **kwargs) -> ToolReturn:
             """Wrap the document_summarize tool to provide context and add the tool."""
@@ -728,7 +728,7 @@ class AIAgentService:  # pylint: disable=too-many-instance-attributes
             name="web_search",
             retries=1,
             prepare=only_if_web_search_enabled,
-            description="Search the web for up-to-date information",
+            description=WEB_SEARCH_TOOL_DESCRIPTION,
         )
         @functools.wraps(web_search_impl)
         async def web_search(ctx: RunContext, *args, **kwargs) -> ToolReturn:

--- a/src/backend/chat/tests/views/chat/conversations/test_conversation_with_document_upload.py
+++ b/src/backend/chat/tests/views/chat/conversations/test_conversation_with_document_upload.py
@@ -36,11 +36,29 @@ from chat.ai_sdk_types import (
 )
 from chat.factories import ChatConversationFactory
 from chat.tests.utils import replace_uuids_with_placeholder
+from chat.tools.descriptions import (
+    DOCUMENT_SEARCH_RAG_SYSTEM_PROMPT,
+    DOCUMENT_SUMMARIZE_SYSTEM_PROMPT,
+)
 
 # enable database transactions for tests:
 # transaction=True ensures that the data are available in the database
 # in other threads
 pytestmark = pytest.mark.django_db(transaction=True)
+
+
+def _expected_document_instructions(today_prompt_date: str) -> str:
+    """Return expected concatenated system instructions for document conversations."""
+    return (
+        "You are a helpful test assistant :)\n\n"
+        f"{today_prompt_date}\n\n"
+        "Answer in english.\n\n"
+        f"{DOCUMENT_SEARCH_RAG_SYSTEM_PROMPT}\n\n"
+        f"{DOCUMENT_SUMMARIZE_SYSTEM_PROMPT}\n\n"
+        "[Internal context] User documents are attached to this conversation. "
+        "Do not request re-upload of documents; consider them already "
+        "available via the internal store."
+    )
 
 
 @pytest.fixture(
@@ -500,21 +518,7 @@ def test_post_conversation_with_document_upload(
     _run_id = chat_conversation.pydantic_messages[0]["run_id"]
 
     assert chat_conversation.pydantic_messages[0] == {
-        "instructions": "You are a helpful test assistant :)\n\n"
-        f"{today_prompt_date}\n\n"
-        "Answer in english.\n\n"
-        "Use document_search_rag ONLY to retrieve specific passages from "
-        "attached documents. Do NOT use it to summarize; for summaries, "
-        "call the summarize tool instead.\n\nWhen you receive a result from the "
-        "summarization tool, you MUST return it directly to the user without "
-        "any modification, paraphrasing, or additional summarization."
-        "The tool already produces optimized summaries that should be "
-        "presented verbatim.You may translate the summary if required, "
-        "but you MUST preserve all the information from the original summary."
-        "You may add a follow-up question after the summary if needed.\n\n"
-        "[Internal context] User documents are attached to this conversation. "
-        "Do not request re-upload of documents; consider them already "
-        "available via the internal store.",
+        "instructions": _expected_document_instructions(today_prompt_date),
         "kind": "request",
         "metadata": None,
         "parts": [
@@ -561,23 +565,7 @@ def test_post_conversation_with_document_upload(
         "run_id": _run_id,
     }
     assert chat_conversation.pydantic_messages[2] == {
-        "instructions": (
-            "You are a helpful test assistant :)\n\n"
-            f"{today_prompt_date}\n\n"
-            "Answer in english.\n\n"
-            "Use document_search_rag ONLY to retrieve specific passages from "
-            "attached documents. Do NOT use it to summarize; for summaries, "
-            "call the summarize tool instead.\n\nWhen you receive a result from the "
-            "summarization tool, you MUST return it directly to the user without "
-            "any modification, paraphrasing, or additional summarization."
-            "The tool already produces optimized summaries that should be "
-            "presented verbatim.You may translate the summary if required, "
-            "but you MUST preserve all the information from the original summary."
-            "You may add a follow-up question after the summary if needed.\n\n"
-            "[Internal context] User documents are attached to this conversation. "
-            "Do not request re-upload of documents; consider them already "
-            "available via the internal store."
-        ),
+        "instructions": _expected_document_instructions(today_prompt_date),
         "kind": "request",
         "metadata": None,
         "parts": [
@@ -844,23 +832,7 @@ def test_post_conversation_with_document_upload_summarize(  # pylint: disable=to
 
     _run_id = chat_conversation.pydantic_messages[0]["run_id"]
     assert chat_conversation.pydantic_messages[0] == {
-        "instructions": (
-            "You are a helpful test assistant :)\n\n"
-            f"{today_prompt_date}\n\n"
-            "Answer in english.\n\n"
-            "Use document_search_rag ONLY to retrieve specific passages from "
-            "attached documents. Do NOT use it to summarize; for summaries, "
-            "call the summarize tool instead.\n\nWhen you receive a result from the "
-            "summarization tool, you MUST return it directly to the user without "
-            "any modification, paraphrasing, or additional summarization."
-            "The tool already produces optimized summaries that should be "
-            "presented verbatim.You may translate the summary if required, "
-            "but you MUST preserve all the information from the original summary."
-            "You may add a follow-up question after the summary if needed.\n\n"
-            "[Internal context] User documents are attached to this conversation. "
-            "Do not request re-upload of documents; consider them already "
-            "available via the internal store."
-        ),
+        "instructions": _expected_document_instructions(today_prompt_date),
         "kind": "request",
         "metadata": None,
         "parts": [
@@ -907,23 +879,7 @@ def test_post_conversation_with_document_upload_summarize(  # pylint: disable=to
         "run_id": _run_id,
     }
     assert chat_conversation.pydantic_messages[2] == {
-        "instructions": (
-            "You are a helpful test assistant :)\n\n"
-            f"{today_prompt_date}\n\n"
-            "Answer in english.\n\n"
-            "Use document_search_rag ONLY to retrieve specific passages from "
-            "attached documents. Do NOT use it to summarize; for summaries, "
-            "call the summarize tool instead.\n\nWhen you receive a result from the "
-            "summarization tool, you MUST return it directly to the user without "
-            "any modification, paraphrasing, or additional summarization."
-            "The tool already produces optimized summaries that should be "
-            "presented verbatim.You may translate the summary if required, "
-            "but you MUST preserve all the information from the original summary."
-            "You may add a follow-up question after the summary if needed.\n\n"
-            "[Internal context] User documents are attached to this conversation. "
-            "Do not request re-upload of documents; consider them already "
-            "available via the internal store."
-        ),
+        "instructions": _expected_document_instructions(today_prompt_date),
         "kind": "request",
         "metadata": None,
         "parts": [
@@ -1118,21 +1074,7 @@ def test_post_conversation_with_odt_document_upload(
     _run_id = chat_conversation.pydantic_messages[0]["run_id"]
 
     assert chat_conversation.pydantic_messages[0] == {
-        "instructions": "You are a helpful test assistant :)\n\n"
-        f"{today_prompt_date}\n\n"
-        "Answer in english.\n\n"
-        "Use document_search_rag ONLY to retrieve specific passages from "
-        "attached documents. Do NOT use it to summarize; for summaries, "
-        "call the summarize tool instead.\n\nWhen you receive a result from the "
-        "summarization tool, you MUST return it directly to the user without "
-        "any modification, paraphrasing, or additional summarization."
-        "The tool already produces optimized summaries that should be "
-        "presented verbatim.You may translate the summary if required, "
-        "but you MUST preserve all the information from the original summary."
-        "You may add a follow-up question after the summary if needed.\n\n"
-        "[Internal context] User documents are attached to this conversation. "
-        "Do not request re-upload of documents; consider them already "
-        "available via the internal store.",
+        "instructions": _expected_document_instructions(today_prompt_date),
         "kind": "request",
         "metadata": None,
         "parts": [
@@ -1179,23 +1121,7 @@ def test_post_conversation_with_odt_document_upload(
         "run_id": _run_id,
     }
     assert chat_conversation.pydantic_messages[2] == {
-        "instructions": (
-            "You are a helpful test assistant :)\n\n"
-            f"{today_prompt_date}\n\n"
-            "Answer in english.\n\n"
-            "Use document_search_rag ONLY to retrieve specific passages from "
-            "attached documents. Do NOT use it to summarize; for summaries, "
-            "call the summarize tool instead.\n\nWhen you receive a result from the "
-            "summarization tool, you MUST return it directly to the user without "
-            "any modification, paraphrasing, or additional summarization."
-            "The tool already produces optimized summaries that should be "
-            "presented verbatim.You may translate the summary if required, "
-            "but you MUST preserve all the information from the original summary."
-            "You may add a follow-up question after the summary if needed.\n\n"
-            "[Internal context] User documents are attached to this conversation. "
-            "Do not request re-upload of documents; consider them already "
-            "available via the internal store."
-        ),
+        "instructions": _expected_document_instructions(today_prompt_date),
         "kind": "request",
         "metadata": None,
         "parts": [

--- a/src/backend/chat/tests/views/chat/conversations/test_conversation_with_document_url.py
+++ b/src/backend/chat/tests/views/chat/conversations/test_conversation_with_document_url.py
@@ -30,11 +30,29 @@ from chat.ai_sdk_types import (
 )
 from chat.factories import ChatConversationAttachmentFactory, ChatConversationFactory
 from chat.tests.utils import replace_uuids_with_placeholder
+from chat.tools.descriptions import (
+    DOCUMENT_SEARCH_RAG_SYSTEM_PROMPT,
+    DOCUMENT_SUMMARIZE_SYSTEM_PROMPT,
+)
 
 # enable database transactions for tests:
 # transaction=True ensures that the data are available in the database
 # in other threads
 pytestmark = pytest.mark.django_db(transaction=True)
+
+
+def _expected_document_instructions(today_prompt_date: str) -> str:
+    """Return expected concatenated system instructions for document conversations."""
+    return (
+        "You are a helpful test assistant :)\n\n"
+        f"{today_prompt_date}\n\n"
+        "Answer in english.\n\n"
+        f"{DOCUMENT_SEARCH_RAG_SYSTEM_PROMPT}\n\n"
+        f"{DOCUMENT_SUMMARIZE_SYSTEM_PROMPT}\n\n"
+        "[Internal context] User documents are attached to this conversation. "
+        "Do not request re-upload of documents; consider them already available "
+        "via the internal store."
+    )
 
 
 @pytest.fixture(
@@ -139,23 +157,7 @@ def test_post_conversation_with_local_pdf_document_url(
                 parts=[
                     UserPromptPart(content=["What is in this document?"], timestamp=timezone.now())
                 ],
-                instructions=(
-                    "You are a helpful test assistant :)\n\n"
-                    f"{today_prompt_date}\n\n"
-                    "Answer in english.\n\n"
-                    "Use document_search_rag ONLY to retrieve specific passages from attached "
-                    "documents. Do NOT use it to summarize; for summaries, call the summarize "
-                    "tool instead.\n\nWhen you receive a result from the summarization tool, "
-                    "you MUST return it directly to the user without any modification, "
-                    "paraphrasing, or additional summarization.The tool already produces "
-                    "optimized summaries that should be presented verbatim.You may translate "
-                    "the summary if required, but you MUST preserve all the information from "
-                    "the original summary.You may add a follow-up question after the summary "
-                    "if needed.\n\n"
-                    "[Internal context] User documents are attached to this conversation. "
-                    "Do not request re-upload of documents; consider them already available "
-                    "via the internal store."
-                ),
+                instructions=_expected_document_instructions(today_prompt_date),
                 run_id=messages[0].run_id,
                 timestamp=timezone.now(),
             )
@@ -231,26 +233,7 @@ def test_post_conversation_with_local_pdf_document_url(
     _run_id = chat_conversation.pydantic_messages[0]["run_id"]
     assert chat_conversation.pydantic_messages == [
         {
-            "instructions": "You are a helpful test assistant :)\n\n"
-            f"{today_prompt_date}\n\n"
-            "Answer in english.\n"
-            "\n"
-            "Use document_search_rag ONLY to retrieve specific passages "
-            "from attached documents. Do NOT use it to summarize; for "
-            "summaries, call the summarize tool instead.\n"
-            "\n"
-            "When you receive a result from the summarization tool, you "
-            "MUST return it directly to the user without any "
-            "modification, paraphrasing, or additional summarization.The "
-            "tool already produces optimized summaries that should be "
-            "presented verbatim.You may translate the summary if "
-            "required, but you MUST preserve all the information from "
-            "the original summary.You may add a follow-up question after "
-            "the summary if needed.\n"
-            "\n"
-            "[Internal context] User documents are attached to this "
-            "conversation. Do not request re-upload of documents; "
-            "consider them already available via the internal store.",
+            "instructions": _expected_document_instructions(today_prompt_date),
             "kind": "request",
             "metadata": None,
             "parts": [
@@ -887,24 +870,7 @@ def test_post_conversation_with_local_not_pdf_document_url(
                     ),
                 ],
                 timestamp=timestamp_now,
-                instructions=(
-                    "You are a helpful test assistant :)\n\n"
-                    f"{today_prompt_date}\n\n"
-                    "Answer in english.\n\n"
-                    "Use document_search_rag ONLY to retrieve specific passages from "
-                    "attached documents. Do NOT use it to summarize; for summaries, "
-                    "call the summarize tool instead.\n\nWhen you receive a result "
-                    "from the summarization tool, you MUST return it directly to "
-                    "the user without any modification, paraphrasing, or additional "
-                    "summarization.The tool already produces optimized summaries "
-                    "that should be presented verbatim.You may translate the summary "
-                    "if required, but you MUST preserve all the information from the "
-                    "original summary.You may add a follow-up question after the "
-                    "summary if needed.\n\n"
-                    "[Internal context] User documents are attached to this conversation. "
-                    "Do not request re-upload of documents; "
-                    "consider them already available via the internal store."
-                ),
+                instructions=_expected_document_instructions(today_prompt_date),
                 run_id=messages[0].run_id,
             )
         ]
@@ -979,24 +945,7 @@ def test_post_conversation_with_local_not_pdf_document_url(
     _run_id = chat_conversation.pydantic_messages[0]["run_id"]
     assert chat_conversation.pydantic_messages == [
         {
-            "instructions": (
-                "You are a helpful test assistant :)\n\n"
-                f"{today_prompt_date}\n\n"
-                "Answer in english.\n\n"
-                "Use document_search_rag ONLY to retrieve specific passages from "
-                "attached documents. Do NOT use it to summarize; for summaries, "
-                "call the summarize tool instead.\n\nWhen you receive a result "
-                "from the summarization tool, you MUST return it directly to "
-                "the user without any modification, paraphrasing, or additional "
-                "summarization.The tool already produces optimized summaries "
-                "that should be presented verbatim.You may translate the summary "
-                "if required, but you MUST preserve all the information from the "
-                "original summary.You may add a follow-up question after the "
-                "summary if needed.\n\n"
-                "[Internal context] User documents are attached to this conversation. "
-                "Do not request re-upload of documents; "
-                "consider them already available via the internal store."
-            ),
+            "instructions": (_expected_document_instructions(today_prompt_date)),
             "kind": "request",
             "metadata": None,
             "parts": [

--- a/src/backend/chat/tools/descriptions.py
+++ b/src/backend/chat/tools/descriptions.py
@@ -1,0 +1,73 @@
+"""Shared descriptions for chat tools."""
+
+DOCUMENT_SEARCH_RAG_SYSTEM_PROMPT = """
+Use document_search_rag ONLY to retrieve specific passages from attached documents.
+Do NOT use it to summarize; for summaries, call the summarize tool instead.
+"""
+
+DOCUMENT_SEARCH_RAG_TOOL_DESCRIPTION = """
+Search for information within the documents provided by the user.
+
+Use this tool when the user asks about content from attached documents 
+(reports, contracts, PDFs, etc.). Prefer this tool over web_search when 
+the answer might be in the documents.
+
+Must be used whenever the user asks for specific information while having documents attached.
+Do NOT use this tool for up-to-date information or current events.
+
+The query must contain all information to find accurate results.
+"""
+
+DOCUMENT_SUMMARIZE_SYSTEM_PROMPT = """
+When you receive a result from the summarization tool, you MUST return it 
+directly to the user without any modification, paraphrasing, or additional summarization.
+You may translate it if needed, but preserve all information / copy it verbatim.
+"""
+
+DOCUMENT_SUMMARIZE_TOOL_DESCRIPTION = """
+Generate a complete, ready-to-use summary of the documents already attached in context.
+Do not request the documents to the user, this tool can access them directly.
+Return this summary directly to the user WITHOUT any modification,
+or additional summarization.
+The summary is already optimized and MUST be presented as-is in the final response
+or translated preserving the information.
+
+Instructions are optional but should reflect the user's request.
+
+Examples:
+"Summarize this doc in 2 paragraphs" -> instructions = "summary in 2 paragraphs"
+"Summarize this doc in English" -> instructions = "In English"
+"Summarize this doc" -> instructions = "" (default)
+"""
+
+WEB_SEARCH_TOOL_DESCRIPTION = """
+Search the web for real-time and up-to-date information.
+
+Use this tool when the user asks about:
+- Recent news, current events or ongoing situations
+- Legal questions, laws, regulations or jurisprudence
+- Data that changes over time (prices, rates, statistics)
+- Complex technical topics requiring verifiable sources
+- Any topic where outdated information could mislead or harm the user
+- Any terms, acronyms, or specificities that sound foreign to you
+
+When in doubt, ALWAYS prefer calling this tool rather than relying 
+on your training data, which may be outdated.
+
+Do NOT use for general conversation or creative tasks without factual needs.
+
+Examples of queries that MUST trigger web_search tool:
+- "Quelles sont les dernières nouvelles sur X ?"
+- "Quel est le taux d'intérêt actuel ?"
+- "Est-ce que la loi X est toujours en vigueur ?"
+- "Quelle est la réglementation RGPD sur X ?"
+- "Quel est le prix actuel de X ?"
+- "Que signifie l'acronyme X ?"
+- "Qu'est-ce qui s'est passé récemment avec X ?"
+- "Quelles sont les sanctions prévues par la loi pour X ?"
+
+Examples of queries that do NOT need web_search tool:
+- "Explique-moi comment fonctionne une boucle for"
+- "Écris-moi un poème sur l'automne"
+- "Résume ce texte"
+"""

--- a/src/backend/chat/tools/document_search_rag.py
+++ b/src/backend/chat/tools/document_search_rag.py
@@ -6,17 +6,30 @@ from django.utils.module_loading import import_string
 from pydantic_ai import Agent, RunContext, RunUsage
 from pydantic_ai.messages import ToolReturn
 
+from chat.tools.descriptions import (
+    DOCUMENT_SEARCH_RAG_SYSTEM_PROMPT,
+    DOCUMENT_SEARCH_RAG_TOOL_DESCRIPTION,
+)
+
 
 def add_document_rag_search_tool(agent: Agent) -> None:
     """Add the document RAG tool to an existing agent."""
 
-    @agent.tool
+    @agent.tool(description=DOCUMENT_SEARCH_RAG_TOOL_DESCRIPTION)
     def document_search_rag(ctx: RunContext, query: str) -> ToolReturn:
         """
-        Perform a search in the documents provided by the user.
-        Must be used whenever the user asks for information that
-        is not in the model's knowledge base and most of the time.
-        The query must contain all information to find accurate results.
+        Search indexed conversation documents using the configured RAG backend.
+
+        This function queries the conversation collection associated with
+        ``ctx.deps.conversation.collection_id`` and returns retrieved chunks.
+        The query should be self-contained to maximize retrieval quality.
+
+        Side effects:
+            - Updates ``ctx.usage`` with token usage reported by the backend.
+
+        Returns:
+            ToolReturn: Retrieved passages in ``return_value`` and source URLs in
+            ``metadata["sources"]``.
 
         Args:
             ctx (RunContext): The run context containing the conversation.
@@ -42,7 +55,4 @@ def add_document_rag_search_tool(agent: Agent) -> None:
     @agent.instructions
     def document_rag_instructions() -> str:
         """Dynamic system prompt function to add RAG instructions if any."""
-        return (
-            "Use document_search_rag ONLY to retrieve specific passages from attached documents. "
-            "Do NOT use it to summarize; for summaries, call the summarize tool instead."
-        )
+        return DOCUMENT_SEARCH_RAG_SYSTEM_PROMPT


### PR DESCRIPTION
## Summary

This PR centralizes tool descriptions into a dedicated module to keep the chat client and tool implementations cleaner and easier to maintain.

### Changes
- Added `chat/tools/descriptions.py` to store shared tool description constants.
- Moved web search tool description out of `pydantic_ai.py` and `web_search_brave.py` into the new descriptions module.
- Added and wired a shared description for the `summarize` tool.
- Added and wired a shared description for the `document_search_rag` tool.
- Updated web_search tool description to encourage the model to use it more (especially on legal and laws questions)

### Why
- Reduces noise in `pydantic_ai.py`.
- Keeps prompt-like tool metadata in one place.
- Makes future updates to tool guidance simpler and less error-prone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added shared guidance for document search, document summarization, and web search tools, including usage rules and example-trigger/non-trigger queries.
* **Chores**
  * Tool registrations and prompts now reference standardized descriptions instead of inline strings.
* **Minor**
  * Tests and user-facing instruction text updated to use the new shared prompts; summarization is specified to return content verbatim (or translated while preserving information).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->