### PR TITLE
🐛(settings) change default for allow_smart_web_search to False

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to
 - ✨(tools): update descriptions
 - ✨(auth) add silent OIDC login
 - ⬆️(back) upgrade lxml and pypdf
+- ✨(back) set allow_smart_web_search to False for all users
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to
 - ✨(auth) add silent OIDC login
 - ⬆️(back) upgrade lxml and pypdf
 - ✨(back) set allow_smart_web_search to False for all users
+- ✨(back) make allow_conversation_analytics user setting readonly in admin
 
 ### Fixed
 

--- a/src/backend/conversations/settings.py
+++ b/src/backend/conversations/settings.py
@@ -679,7 +679,7 @@ class Base(BraveSettings, Configuration):
         environ_prefix=None,
     )
     DEFAULT_ALLOW_SMART_WEB_SEARCH = values.BooleanValue(
-        default=True,
+        default=False,
         environ_name="DEFAULT_ALLOW_SMART_WEB_SEARCH",
         environ_prefix=None,
     )

--- a/src/backend/core/admin.py
+++ b/src/backend/core/admin.py
@@ -34,6 +34,7 @@ class UserAdmin(auth_admin.UserAdmin):
                     "short_name",
                     "language",
                     "timezone",
+                    "allow_smart_web_search",
                     "allow_conversation_analytics",
                 )
             },
@@ -69,6 +70,7 @@ class UserAdmin(auth_admin.UserAdmin):
         "admin_email",
         "email",
         "is_active",
+        "allow_smart_web_search",
         "allow_conversation_analytics",
         "is_staff",
         "is_superuser",
@@ -81,6 +83,7 @@ class UserAdmin(auth_admin.UserAdmin):
         "is_superuser",
         "is_device",
         "is_active",
+        "allow_smart_web_search",
         "allow_conversation_analytics",
     )
     ordering = (
@@ -99,6 +102,8 @@ class UserAdmin(auth_admin.UserAdmin):
         "short_name",
         "created_at",
         "updated_at",
+        "allow_smart_web_search",
+        "allow_conversation_analytics",
     )
     search_fields = (
         "id",
@@ -106,9 +111,7 @@ class UserAdmin(auth_admin.UserAdmin):
         "admin_email",
         "email",
         "full_name",
-        "allow_conversation_analytics",
     )
-    list_editable = ("allow_conversation_analytics",)
 
 
 @admin.register(models.SiteConfiguration)

--- a/src/backend/core/migrations/0006_user_allow_smart_web_search_default_false.py
+++ b/src/backend/core/migrations/0006_user_allow_smart_web_search_default_false.py
@@ -1,0 +1,28 @@
+from django.db import migrations, models
+
+
+def reset_smart_web_search_to_false(apps, schema_editor):
+    User = apps.get_model("core", "User")
+    User.objects.filter(allow_smart_web_search=True).update(allow_smart_web_search=False)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("core", "0005_siteconfiguration"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            reset_smart_web_search_to_false,
+            reverse_code=migrations.RunPython.noop,
+        ),
+        migrations.AlterField(
+            model_name="user",
+            name="allow_smart_web_search",
+            field=models.BooleanField(
+                default=False,
+                help_text="Whether the user allows to use smart web search features.",
+                verbose_name="allow smart web search",
+            ),
+        ),
+    ]

--- a/src/backend/core/models.py
+++ b/src/backend/core/models.py
@@ -169,7 +169,7 @@ class User(AbstractBaseUser, BaseModel, auth_models.PermissionsMixin):
 
     allow_smart_web_search = models.BooleanField(
         _("allow smart web search"),
-        default=True,
+        default=False,
         help_text=_("Whether the user allows to use smart web search features."),
     )
 


### PR DESCRIPTION
Migration set default to false for all existing users

## Purpose

- Setting `smart_web_search` was set to True by default. It should by activated by user only, in order to enforce our privacy promise.
- Setting `allow_conversation_analytics` must be set to False in environment variable : https://github.com/numerique-gouv/lasuite-deploiement/pull/505
- Setting `allow_conversation_analytics` READONLY in Django admin

<img width="838" height="626" alt="Capture d’écran 2026-05-05 à 12 13 03" src="https://github.com/user-attachments/assets/a6bf12df-59b7-4705-9e67-a1fccf9e2b8e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Smart web search is disabled by default for all users (existing accounts updated).
  * Admin UI now exposes a per-user Smart Web Search setting and makes Conversation Analytics read-only inline.

* **Documentation**
  * Changelog updated to reflect the default change and admin UI editability update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->