### PR TITLE
🐛(fix) implement thinking part stripping for models without support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to
 - 💄(ui) little fix margin top
 - 💄(ui) review ui for part of the project
 - 🐛(fix) Fix streaming crash with OpenAI-compatible APIs
+- 🐛(fix) strip thinking part for models without reasoning support
 
 ## [0.0.15] - 2026-03-31
 

--- a/src/backend/chat/clients/pydantic_ai.py
+++ b/src/backend/chat/clients/pydantic_ai.py
@@ -121,6 +121,7 @@ from pydantic_ai.messages import (
     ToolReturnPart,
     UserPromptPart,
 )
+from pydantic_ai.models import Model, infer_model_profile
 
 from core.feature_flags.helpers import is_feature_enabled
 
@@ -213,6 +214,38 @@ def get_model_configuration(model_hrid: str):
         return settings.LLM_CONFIGURATIONS[model_hrid]
     except KeyError as exc:
         raise ImproperlyConfigured(f"LLM model configuration '{model_hrid}' not found.") from exc
+
+
+def _strip_thinking_parts(history: list[ModelMessage]) -> list[ModelMessage]:
+    """Remove ThinkingPart from ModelResponse history for models that don't support it.
+
+    Some models (e.g. mistral-medium) reject requests when previous assistant
+    messages contain ThinkingPart. This strips those parts before the history
+    is passed to the agent.
+
+    Only called when the current model's pydantic-ai ModelProfile.supports_thinking is False.
+    (no thinking_tags and no openai_supports_encrypted_reasoning_content).
+    """
+    has_thinking = any(
+        isinstance(p, ThinkingPart)
+        for msg in history
+        if isinstance(msg, ModelResponse)
+        for p in msg.parts
+    )
+    if not has_thinking:
+        return history
+
+    result = []
+    for original_message in history:
+        message = original_message
+        if isinstance(message, ModelResponse) and any(
+            isinstance(p, ThinkingPart) for p in message.parts
+        ):
+            message = dataclasses.replace(
+                message, parts=[p for p in message.parts if not isinstance(p, ThinkingPart)]
+            )
+        result.append(message)
+    return result
 
 
 def _extract_co2_from_usage(usage: RunUsage) -> float:
@@ -398,10 +431,11 @@ class AIAgentService:  # pylint: disable=too-many-instance-attributes
         This method handles the setup phase before the agent iteration loop:
         1. Loads and validates conversation history from pydantic_messages
         2. Pre-signs URLs for any local images in history (S3 signed URLs)
-        3. Extracts user prompt, images, and documents from the last message
-        4. Pre-signs URLs for input images
-        5. Updates Langfuse trace with input (if analytics enabled)
-        6. Checks if conversation already has documents in the vector store
+        3. Infers whether the model supports thinking and strips ThinkingPart if not
+        4. Extracts user prompt, images, and documents from the last message
+        5. Pre-signs URLs for input images
+        6. Updates Langfuse trace with input (if analytics enabled)
+        7. Checks if conversation already has documents in the vector store
 
         Returns:
             Tuple containing:
@@ -417,6 +451,14 @@ class AIAgentService:  # pylint: disable=too-many-instance-attributes
         history = update_history_local_urls(
             self.conversation, history
         )  # presign URLs for local images
+
+        model = self.conversation_agent.model
+        if isinstance(model, Model):
+            model_supports_thinking = model.profile.supports_thinking
+        else:
+            model_supports_thinking = infer_model_profile(model).supports_thinking
+        if not model_supports_thinking:
+            history = _strip_thinking_parts(history)
 
         user_prompt, input_images, input_documents = self._prepare_prompt(messages[-1])
 

--- a/src/backend/chat/tests/clients/pydantic_ai/test_thinking_history_stripping.py
+++ b/src/backend/chat/tests/clients/pydantic_ai/test_thinking_history_stripping.py
@@ -1,0 +1,152 @@
+"""Tests for ThinkingPart stripping based on model profile in AIAgentService."""
+
+# pylint: disable=protected-access
+import json
+from unittest.mock import MagicMock, PropertyMock, patch
+
+import pytest
+from asgiref.sync import sync_to_async
+from pydantic_ai.messages import (
+    ModelMessagesTypeAdapter,
+    ModelRequest,
+    ModelResponse,
+    TextPart,
+    ThinkingPart,
+    UserPromptPart,
+)
+
+from chat.ai_sdk_types import TextUIPart, UIMessage
+from chat.clients.pydantic_ai import AIAgentService, _strip_thinking_parts
+from chat.factories import ChatConversationFactory
+
+pytestmark = pytest.mark.django_db()
+
+
+def _response(*parts):
+    """Helper to build a ModelResponse with given parts."""
+    return ModelResponse(parts=list(parts))
+
+
+def _request(*parts):
+    """Helper to build a ModelRequest with given parts."""
+    return ModelRequest(parts=list(parts))
+
+
+@pytest.mark.parametrize(
+    ("parts_in", "expected_parts"),
+    [
+        # strips ThinkingPart from a mixed response
+        (
+            [ThinkingPart(content="thinking..."), TextPart(content="answer")],
+            [TextPart(content="answer")],
+        ),
+        # leaves response untouched when no ThinkingPart present
+        (
+            [TextPart(content="answer")],
+            [TextPart(content="answer")],
+        ),
+        # strips ThinkingPart-only response, leaving empty parts list
+        (
+            [ThinkingPart(content="thinking...")],
+            [],
+        ),
+    ],
+    ids=["mixed_thinking_and_text", "text_only_unchanged", "thinking_only_emptied"],
+)
+def test_strip_thinking_parts(parts_in, expected_parts):
+    """ThinkingPart is removed from ModelResponse; non-thinking parts are preserved."""
+    result = _strip_thinking_parts([_response(*parts_in)])
+    assert list(result[0].parts) == expected_parts
+
+
+def test_strip_thinking_parts_mixed_history():
+    """Only ModelResponse messages with ThinkingPart are modified; others are untouched."""
+    request = _request(UserPromptPart(content="hello"))
+    response_with_thinking = _response(
+        ThinkingPart(content="thinking..."), TextPart(content="answer")
+    )
+    response_without_thinking = _response(TextPart(content="follow-up"))
+
+    result = _strip_thinking_parts([request, response_with_thinking, response_without_thinking])
+
+    assert result[0] is request
+    assert list(result[1].parts) == [TextPart(content="answer")]
+    assert result[2] is response_without_thinking
+
+
+@pytest.fixture(autouse=True, name="base_settings")
+def base_settings_fixture(settings):
+    """Configure minimal LLM settings."""
+    settings.AI_BASE_URL = "https://api.llm.com/v1/"
+    settings.AI_API_KEY = "test-key"
+    settings.AI_MODEL = "model-123"
+    settings.AI_AGENT_INSTRUCTIONS = "You are a helpful assistant"
+    settings.AI_AGENT_TOOLS = []
+
+
+def _pydantic_messages_with_thinking():
+    """Return pydantic_messages JSON with a ModelResponse containing a ThinkingPart."""
+    messages = [
+        ModelResponse(parts=[ThinkingPart(content="let me think"), TextPart(content="answer")])
+    ]
+    return json.loads(ModelMessagesTypeAdapter.dump_json(messages).decode())
+
+
+def _mock_infer_model_profile(supports_thinking: bool):
+    mock_model_profile = MagicMock()
+    mock_model_profile.supports_thinking = supports_thinking
+    return mock_model_profile
+
+
+@pytest.mark.asyncio
+async def test_thinking_parts_stripped_when_model_does_not_support_thinking():
+    """When model profile.supports_thinking is False, ThinkingPart is removed from history."""
+    conversation = await sync_to_async(ChatConversationFactory)(
+        pydantic_messages=_pydantic_messages_with_thinking()
+    )
+    service = AIAgentService(conversation, user=conversation.owner)
+    ui_message = UIMessage(
+        id="msg-1", role="user", content="Hello", parts=[TextUIPart(type="text", text="Hello")]
+    )
+
+    with (
+        patch(
+            "chat.clients.pydantic_ai.infer_model_profile",
+            return_value=_mock_infer_model_profile(supports_thinking=False),
+        ),
+        patch("chat.clients.pydantic_ai.update_history_local_urls", side_effect=lambda _conv, h: h),
+    ):
+        _, _, _, _, _, history, _ = await service._prepare_agent_run([ui_message])
+
+    assert len(history) == 1
+    assert isinstance(history[0], ModelResponse)
+    assert not any(isinstance(p, ThinkingPart) for p in history[0].parts)
+    assert any(isinstance(p, TextPart) for p in history[0].parts)
+
+
+@pytest.mark.asyncio
+async def test_thinking_parts_kept_when_model_supports_thinking():
+    """When model profile.supports_thinking is True, ThinkingPart is preserved in history."""
+    conversation = await sync_to_async(ChatConversationFactory)(
+        pydantic_messages=_pydantic_messages_with_thinking()
+    )
+    service = AIAgentService(conversation, user=conversation.owner)
+    ui_message = UIMessage(
+        id="msg-1", role="user", content="Hello", parts=[TextUIPart(type="text", text="Hello")]
+    )
+
+    model_class = type(service.conversation_agent.model)
+    with (
+        patch.object(
+            model_class,
+            "profile",
+            new_callable=PropertyMock,
+            return_value=MagicMock(supports_thinking=True),
+        ),
+        patch("chat.clients.pydantic_ai.update_history_local_urls", side_effect=lambda _conv, h: h),
+    ):
+        _, _, _, _, _, history, _ = await service._prepare_agent_run([ui_message])
+
+    assert len(history) == 1
+    assert isinstance(history[0], ModelResponse)
+    assert any(isinstance(p, ThinkingPart) for p in history[0].parts)


### PR DESCRIPTION

## Purpose
Switching from a reasoning-enabled model (e.g. Albert) to a Mistral model mid-conversation causes a 500 error. The conversation history contains
ThinkingPart objects generated by the previous model, which Mistral rejects with: "Reasoning input is not enabled for this model".

## Solution
We remove all thinking parts from history when model has support_thinking=False 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chat now strips model "thinking" segments from conversation history when the chosen model does not support them, while preserving all other message content.

* **Tests**
  * Added tests validating history filtering: thinking segments are removed for unsupported models, preserved for supported models, and non-thinking content remains unchanged.

* **Documentation**
  * Changelog updated to note stripping of thinking parts for models without reasoning support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->