### PR TITLE
🐛(fix) add prevent_url_hallucination instruction to ConversationAgent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to
 - ✨(back) add self-documentation tool
 - ✅(front) add tests for SourceItem component
 - ✨(documents) make document context hybrid
+- 🐛(fix) add prevent_url_hallucination instruction to ConversationAgent
 
 ### Changed
 

--- a/src/backend/chat/agents/conversation.py
+++ b/src/backend/chat/agents/conversation.py
@@ -16,6 +16,14 @@ from .base import BaseAgent
 
 logger = logging.getLogger(__name__)
 
+PREVENT_URL_HALLUCINATION_INSTRUCTION = (
+    "Never invent or guess URLs. "
+    "Only include URLs explicitly found in tool outputs (e.g., web search results) "
+    "or in provided documents when available. Do not introduce new URLs."
+    "If you need to reference a web page that was not returned by a tool, "
+    "use a descriptive placeholder such as [official link] instead of a URL."
+)
+
 MOCKED_RESPONSE = """
 # **Ode to the AI Assistant** 🤖✨
 
@@ -116,6 +124,11 @@ class ConversationAgent(BaseAgent):
         def enforce_response_language() -> str:
             """Dynamic instruction function to set the expected language to use."""
             return f"Answer in {get_language_name(language).lower()}." if language else ""
+
+        @self.instructions
+        def prevent_url_hallucination() -> str:
+            """Prevent the LLM from generating hallucinated URLs."""
+            return PREVENT_URL_HALLUCINATION_INSTRUCTION
 
     def is_web_search_configured(self) -> bool:
         """

--- a/src/backend/chat/tests/agents/test_build_conversation_agent.py
+++ b/src/backend/chat/tests/agents/test_build_conversation_agent.py
@@ -13,6 +13,19 @@ from chat.agents.conversation import ConversationAgent
 from chat.llm_configuration import LLModel, LLMProvider
 
 
+def assert_base_instructions(instructions, date_str=None, language_str=""):
+    """Assert the standard set of ConversationAgent instructions are registered."""
+    assert len(instructions) == 4
+    assert instructions[0] == "You are a helpful assistant"
+    assert instructions[1].__name__ == "add_the_date"
+    if date_str is not None:
+        assert instructions[1]() == date_str
+    assert instructions[2].__name__ == "enforce_response_language"
+    assert instructions[2]() == language_str
+    assert instructions[3].__name__ == "prevent_url_hallucination"
+    assert "Never invent or guess URLs" in instructions[3]()
+
+
 @pytest.fixture(autouse=True)
 def base_settings(settings):
     """Set up base settings for the tests."""
@@ -29,11 +42,7 @@ def test_build_pydantic_agent_success_no_tools():
     assert isinstance(agent, Agent)
     assert agent._system_prompts == ()
 
-    instructions = agent._instructions
-    assert len(instructions) == 3
-    assert instructions[0] == "You are a helpful assistant"
-    assert instructions[1].__name__ == "add_the_date"
-    assert instructions[2].__name__ == "enforce_response_language"
+    assert_base_instructions(agent._instructions)
 
     assert isinstance(agent.model, OpenAIChatModel)
     assert agent.model.model_name == "model-123"
@@ -50,13 +59,7 @@ def test_build_pydantic_agent_with_tools(settings):
     agent = ConversationAgent(model_hrid="default-model")
     assert isinstance(agent, Agent)
 
-    instructions = agent._instructions
-    assert len(instructions) == 3
-    assert instructions[0] == "You are a helpful assistant"
-    assert instructions[1].__name__ == "add_the_date"
-    assert instructions[1]() == "Today is Friday 25/07/2025."
-    assert instructions[2].__name__ == "enforce_response_language"
-    assert instructions[2]() == ""
+    assert_base_instructions(agent._instructions, date_str="Today is Friday 25/07/2025.")
 
     assert isinstance(agent.model, OpenAIChatModel)
     assert agent.model.model_name == "model-123"
@@ -75,13 +78,7 @@ def test_add_dynamic_system_prompt():
 
     assert len(agent._system_prompt_functions) == 0
 
-    instructions = agent._instructions
-    assert len(instructions) == 3
-    assert instructions[0] == "You are a helpful assistant"
-    assert instructions[1].__name__ == "add_the_date"
-    assert instructions[1]() == "Today is Friday 25/07/2025."
-    assert instructions[2].__name__ == "enforce_response_language"
-    assert instructions[2]() == ""
+    assert_base_instructions(agent._instructions, date_str="Today is Friday 25/07/2025.")
 
     agent = ConversationAgent(model_hrid="default-model", language="fr-fr")
     assert agent._instructions[2]() == "Answer in french."
@@ -134,13 +131,7 @@ def test_build_pydantic_agent_with_legacy_tools(settings, caplog, legacy_tool):
     assert "Ignoring legacy tool(s)" in caplog.text
     assert isinstance(agent, Agent)
 
-    instructions = agent._instructions
-    assert len(instructions) == 3
-    assert instructions[0] == "You are a helpful assistant"
-    assert instructions[1].__name__ == "add_the_date"
-    assert instructions[1]() == "Today is Friday 25/07/2025."
-    assert instructions[2].__name__ == "enforce_response_language"
-    assert instructions[2]() == ""
+    assert_base_instructions(agent._instructions, date_str="Today is Friday 25/07/2025.")
 
     assert isinstance(agent.model, OpenAIChatModel)
     assert agent.model.model_name == "model-123"

--- a/src/backend/chat/tests/views/chat/conversations/test_conversation.py
+++ b/src/backend/chat/tests/views/chat/conversations/test_conversation.py
@@ -17,6 +17,7 @@ from rest_framework import status
 
 from core.factories import UserFactory
 
+from chat.agents.conversation import PREVENT_URL_HALLUCINATION_INSTRUCTION
 from chat.ai_sdk_types import (
     Attachment,
     TextUIPart,
@@ -41,6 +42,7 @@ pytestmark = pytest.mark.django_db(transaction=True)
 FROZEN_TIMESTAMP = "2025-07-25T10:36:35.297675Z"
 ENGLISH_INSTRUCTIONS = (
     "You are a helpful test assistant :)\n\nToday is Friday 25/07/2025.\n\nAnswer in english."
+    f"\n\n{PREVENT_URL_HALLUCINATION_INSTRUCTION}"
     f"\n\n{SELF_DOCUMENTATION_TOOL_DESCRIPTION}"
 )
 
@@ -129,16 +131,34 @@ def _make_pydantic_text_response(  # pylint: disable=too-many-arguments,too-many
     }
 
 
+def _system_messages(language="english"):
+    return [
+        {"content": "You are a helpful test assistant :)", "role": "system"},
+        {"content": "Today is Friday 25/07/2025.", "role": "system"},
+        {"content": f"Answer in {language}.", "role": "system"},
+        {"content": PREVENT_URL_HALLUCINATION_INSTRUCTION, "role": "system"},
+        {"content": SELF_DOCUMENTATION_TOOL_DESCRIPTION, "role": "system"},
+    ]
+
+
 def _assert_english_system_prompts(last_request_payload):
     system_messages = [
         m["content"] for m in last_request_payload["messages"] if m["role"] == "system"
     ]
-    assert system_messages == [
-        "You are a helpful test assistant :)",
-        "Today is Friday 25/07/2025.",
-        "Answer in english.",
-        SELF_DOCUMENTATION_TOOL_DESCRIPTION,
-    ]
+    assert system_messages == [m["content"] for m in _system_messages()]
+
+
+def _decode_stream(response):
+    return replace_uuids_with_placeholder(b"".join(response.streaming_content).decode("utf-8"))
+
+
+HELLO_STREAM_CONTENT = (
+    '0:"Hello"\n'
+    '0:" there"\n'
+    'f:{"messageId":"<mocked_uuid>"}\n'
+    'd:{"finishReason":"stop","usage":{"promptTokens":0,"completionTokens":0'
+    ',"co2Impact":0.0}}\n'
+)
 
 
 @pytest.fixture(autouse=True)
@@ -210,17 +230,9 @@ def test_post_conversation_data_protocol(api_client, mock_openai_stream, hello_c
 
     assert_data_stream_response(response)
 
-    response_content = replace_uuids_with_placeholder(
-        b"".join(response.streaming_content).decode("utf-8")
-    )
+    response_content = _decode_stream(response)
 
-    assert response_content == (
-        '0:"Hello"\n'
-        '0:" there"\n'
-        'f:{"messageId":"<mocked_uuid>"}\n'
-        'd:{"finishReason":"stop","usage":{"promptTokens":0,"completionTokens":0'
-        ',"co2Impact":0.0}}\n'
-    )
+    assert response_content == HELLO_STREAM_CONTENT
 
     assert mock_openai_stream.called
 
@@ -253,9 +265,7 @@ def test_post_conversation_data_protocol_triggers_keepalives(
 
     assert_data_stream_response(response)
 
-    response_content = replace_uuids_with_placeholder(
-        b"".join(response.streaming_content).decode("utf-8")
-    )
+    response_content = _decode_stream(response)
 
     assert response_content == (
         '0:"Hello"\n'
@@ -346,9 +356,7 @@ def test_post_conversation_with_image(api_client, mock_openai_stream_image):
 
     assert_data_stream_response(response)
 
-    response_content = replace_uuids_with_placeholder(
-        b"".join(response.streaming_content).decode("utf-8")
-    )
+    response_content = _decode_stream(response)
 
     assert response_content == (
         '0:"I see a cat"\n'
@@ -363,23 +371,7 @@ def test_post_conversation_with_image(api_client, mock_openai_stream_image):
     body = json.loads(request_sent.content)
 
     # Check the exact structure expected by the AI service
-    assert body["messages"] == [
-        {
-            "content": ("You are a helpful test assistant :)"),
-            "role": "system",
-        },
-        {
-            "content": ("Today is Friday 25/07/2025."),
-            "role": "system",
-        },
-        {
-            "content": ("Answer in english."),
-            "role": "system",
-        },
-        {
-            "content": SELF_DOCUMENTATION_TOOL_DESCRIPTION,
-            "role": "system",
-        },
+    assert body["messages"] == _system_messages() + [
         {
             "content": [
                 {"text": "Hello, what do you see on this picture?", "type": "text"},
@@ -510,9 +502,7 @@ def test_post_conversation_tool_call(api_client, mock_openai_stream_tool, settin
 
     assert_data_stream_response(response)
 
-    response_content = replace_uuids_with_placeholder(
-        b"".join(response.streaming_content).decode("utf-8")
-    )
+    response_content = _decode_stream(response)
 
     assert response_content == (
         'b:{"toolCallId":"xLDcIljdsDrz0idal7tATWSMm2jhMj47","toolName":'
@@ -531,23 +521,7 @@ def test_post_conversation_tool_call(api_client, mock_openai_stream_tool, settin
     request_sent = mock_openai_stream_tool.calls[0].request
     body = json.loads(request_sent.content)
 
-    assert body["messages"] == [
-        {
-            "content": "You are a helpful test assistant :)",
-            "role": "system",
-        },
-        {
-            "content": "Today is Friday 25/07/2025.",
-            "role": "system",
-        },
-        {
-            "content": "Answer in english.",
-            "role": "system",
-        },
-        {
-            "content": SELF_DOCUMENTATION_TOOL_DESCRIPTION,
-            "role": "system",
-        },
+    assert body["messages"] == _system_messages() + [
         {"content": [{"text": "Weather in Paris?", "type": "text"}], "role": "user"},
     ]
 
@@ -684,9 +658,7 @@ def test_post_conversation_tool_call_fails(api_client, mock_openai_stream_tool, 
 
     assert_data_stream_response(response)
 
-    response_content = replace_uuids_with_placeholder(
-        b"".join(response.streaming_content).decode("utf-8")
-    )
+    response_content = _decode_stream(response)
 
     assert response_content == (
         'b:{"toolCallId":"xLDcIljdsDrz0idal7tATWSMm2jhMj47","toolName":"get_current_weather"}\n'
@@ -704,23 +676,7 @@ def test_post_conversation_tool_call_fails(api_client, mock_openai_stream_tool, 
     request_sent = mock_openai_stream_tool.calls[0].request
     body = json.loads(request_sent.content)
 
-    assert body["messages"] == [
-        {
-            "content": "You are a helpful test assistant :)",
-            "role": "system",
-        },
-        {
-            "content": "Today is Friday 25/07/2025.",
-            "role": "system",
-        },
-        {
-            "content": "Answer in french.",
-            "role": "system",
-        },
-        {
-            "content": SELF_DOCUMENTATION_TOOL_DESCRIPTION,
-            "role": "system",
-        },
+    assert body["messages"] == _system_messages("french") + [
         {"content": [{"text": "Weather in Paris?", "type": "text"}], "role": "user"},
     ]
 
@@ -777,6 +733,7 @@ def test_post_conversation_tool_call_fails(api_client, mock_openai_stream_tool, 
 
     french_instructions = (
         "You are a helpful test assistant :)\n\nToday is Friday 25/07/2025.\n\nAnswer in french."
+        f"\n\n{PREVENT_URL_HALLUCINATION_INSTRUCTION}"
         f"\n\n{SELF_DOCUMENTATION_TOOL_DESCRIPTION}"
     )
     _run_id = chat_conversation.pydantic_messages[0]["run_id"]
@@ -891,17 +848,9 @@ def test_post_conversation_model_selection_new(
 
     assert_data_stream_response(response)
 
-    response_content = replace_uuids_with_placeholder(
-        b"".join(response.streaming_content).decode("utf-8")
-    )
+    response_content = _decode_stream(response)
 
-    assert response_content == (
-        '0:"Hello"\n'
-        '0:" there"\n'
-        'f:{"messageId":"<mocked_uuid>"}\n'
-        'd:{"finishReason":"stop","usage":{"promptTokens":0,"completionTokens":0'
-        ',"co2Impact":0.0}}\n'
-    )
+    assert response_content == HELLO_STREAM_CONTENT
 
     # We check the model used in the outgoing request to the AI service
     assert json.loads(mock_openai_stream.calls.last.request.content)["model"] == "plop-model"
@@ -958,9 +907,7 @@ def test_post_conversation_data_protocol_no_stream(
 
     assert_data_stream_response(response)
 
-    response_content = replace_uuids_with_placeholder(
-        b"".join(response.streaming_content).decode("utf-8")
-    )
+    response_content = _decode_stream(response)
 
     if stream_delay:
         assert response_content == (
@@ -1045,6 +992,7 @@ def test_post_conversation_data_protocol_no_stream(
             _run_id,
             (
                 "You are an amazing assistant.\n\nToday is Friday 25/07/2025.\n\nAnswer in english."
+                f"\n\n{PREVENT_URL_HALLUCINATION_INSTRUCTION}"
                 f"\n\n{SELF_DOCUMENTATION_TOOL_DESCRIPTION}"
             ),
             ["Why the sky is blue?"],
@@ -1107,13 +1055,7 @@ async def test_post_conversation_async(api_client, mock_openai_stream, monkeypat
 
     response_content = replace_uuids_with_placeholder(response_content)
 
-    assert response_content == (
-        '0:"Hello"\n'
-        '0:" there"\n'
-        'f:{"messageId":"<mocked_uuid>"}\n'
-        'd:{"finishReason":"stop","usage":{"promptTokens":0,"completionTokens":0'
-        ',"co2Impact":0.0}}\n'
-    )
+    assert response_content == HELLO_STREAM_CONTENT
 
     assert mock_openai_stream.called
 
@@ -1299,17 +1241,9 @@ def test_post_conversation_oidc_refresh_enabled(  # pylint: disable=unused-argum
 
     assert_data_stream_response(response)
 
-    response_content = replace_uuids_with_placeholder(
-        b"".join(response.streaming_content).decode("utf-8")
-    )
+    response_content = _decode_stream(response)
 
-    assert response_content == (
-        '0:"Hello"\n'
-        '0:" there"\n'
-        'f:{"messageId":"<mocked_uuid>"}\n'
-        'd:{"finishReason":"stop","usage":{"promptTokens":0,"completionTokens":0'
-        ',"co2Impact":0.0}}\n'
-    )
+    assert response_content == HELLO_STREAM_CONTENT
 
     assert mock_openai_stream.called
 

--- a/src/backend/chat/tests/views/chat/conversations/test_conversation_concatenate_system_messages.py
+++ b/src/backend/chat/tests/views/chat/conversations/test_conversation_concatenate_system_messages.py
@@ -6,6 +6,7 @@ import pytest
 import respx
 from freezegun import freeze_time
 
+from chat.agents.conversation import PREVENT_URL_HALLUCINATION_INSTRUCTION
 from chat.factories import ChatConversationFactory, ChatProjectFactory, UserFactory
 from chat.llm_configuration import LLModel, LLMProvider
 from chat.tests.utils import assert_data_stream_response
@@ -48,6 +49,7 @@ def settings_with_concatenation(settings):
             False,
             (
                 "base system prompt\n\nToday is Friday 25/07/2025.\n\nAnswer in english.\n\n"
+                f"{PREVENT_URL_HALLUCINATION_INSTRUCTION}\n\n"
                 f"{SELF_DOCUMENTATION_TOOL_DESCRIPTION}"
             ),
         ],
@@ -55,6 +57,7 @@ def settings_with_concatenation(settings):
             True,
             (
                 "base system prompt\n\nToday is Friday 25/07/2025.\n\nAnswer in english.\n\n"
+                f"{PREVENT_URL_HALLUCINATION_INSTRUCTION}\n\n"
                 "Custom project instructions.\n\n"
                 f"{SELF_DOCUMENTATION_TOOL_DESCRIPTION}"
             ),

--- a/src/backend/chat/tests/views/chat/conversations/test_conversation_with_document_upload.py
+++ b/src/backend/chat/tests/views/chat/conversations/test_conversation_with_document_upload.py
@@ -24,6 +24,7 @@ from rest_framework import status
 
 from core.feature_flags.flags import FeatureToggle
 
+from chat.agents.conversation import PREVENT_URL_HALLUCINATION_INSTRUCTION
 from chat.agents.summarize import SummarizationAgent
 from chat.ai_sdk_types import (
     Attachment,
@@ -53,6 +54,7 @@ def _assert_document_instructions(
 ) -> None:
     """Assert document instruction format and payload fields."""
     assert f"{today_prompt_date}\n\nAnswer in english." in instructions
+    assert PREVENT_URL_HALLUCINATION_INSTRUCTION in instructions
     assert "User documents are attached to this conversation." in instructions
     assert "consider them already available" in instructions
     assert "List of documents attached to this conversation:\n" in instructions

--- a/src/backend/chat/tests/views/chat/conversations/test_conversation_with_document_url.py
+++ b/src/backend/chat/tests/views/chat/conversations/test_conversation_with_document_url.py
@@ -24,6 +24,7 @@ from pydantic_ai.messages import (
 from pydantic_ai.models.function import AgentInfo, FunctionModel
 from rest_framework import status
 
+from chat.agents.conversation import PREVENT_URL_HALLUCINATION_INSTRUCTION
 from chat.ai_sdk_types import (
     Attachment,
     TextUIPart,
@@ -57,6 +58,7 @@ def _expected_document_instructions(
         "You are a helpful test assistant :)\n\n"
         f"{today_prompt_date}\n\n"
         "Answer in english.\n\n"
+        f"{PREVENT_URL_HALLUCINATION_INSTRUCTION}\n\n"
         f"{SELF_DOCUMENTATION_TOOL_DESCRIPTION}\n\n"
         f"{DOCUMENT_SEARCH_RAG_SYSTEM_PROMPT}\n\n"
         f"{DOCUMENT_SUMMARIZE_SYSTEM_PROMPT}\n\n"
@@ -496,6 +498,7 @@ def test_post_conversation_with_local_document_url_in_history(  # pylint: disabl
         "You are a helpful test assistant :)\n\n"
         f"Today is {formatted_date}.\n\n"
         "Answer in english.\n\n"
+        f"{PREVENT_URL_HALLUCINATION_INSTRUCTION}\n\n"
         f"{SELF_DOCUMENTATION_TOOL_DESCRIPTION}"
     )
 

--- a/src/backend/chat/tests/views/chat/conversations/test_conversation_with_history.py
+++ b/src/backend/chat/tests/views/chat/conversations/test_conversation_with_history.py
@@ -12,7 +12,7 @@ from dirty_equals import IsUUID
 from freezegun import freeze_time
 from rest_framework import status
 
-from chat.agents.conversation import TitleGenerationAgent
+from chat.agents.conversation import PREVENT_URL_HALLUCINATION_INSTRUCTION, TitleGenerationAgent
 from chat.ai_sdk_types import (
     Attachment,
     TextUIPart,
@@ -1492,6 +1492,7 @@ def test_post_conversation_with_existing_tool_history(
         "instructions": (
             "You are a helpful test assistant :)\n\nToday is Friday 25/07/2025."
             "\n\nAnswer in dutch."
+            f"\n\n{PREVENT_URL_HALLUCINATION_INSTRUCTION}"
             f"\n\n{SELF_DOCUMENTATION_TOOL_DESCRIPTION}"
         ),
         "kind": "request",
@@ -1548,6 +1549,7 @@ def test_post_conversation_with_existing_tool_history(
         "instructions": (
             "You are a helpful test assistant :)\n\nToday is Friday 25/07/2025."
             "\n\nAnswer in dutch."
+            f"\n\n{PREVENT_URL_HALLUCINATION_INSTRUCTION}"
             f"\n\n{SELF_DOCUMENTATION_TOOL_DESCRIPTION}"
         ),
         "kind": "request",

--- a/src/backend/chat/tests/views/chat/conversations/test_conversation_with_image_url.py
+++ b/src/backend/chat/tests/views/chat/conversations/test_conversation_with_image_url.py
@@ -18,6 +18,7 @@ from pydantic_ai.messages import (
 from pydantic_ai.models.function import AgentInfo, FunctionModel
 from rest_framework import status
 
+from chat.agents.conversation import PREVENT_URL_HALLUCINATION_INSTRUCTION
 from chat.ai_sdk_types import (
     Attachment,
     TextUIPart,
@@ -111,6 +112,7 @@ def test_post_conversation_with_local_image_url(
                 ],
                 instructions="You are a helpful test assistant :)\n\nToday is "
                 f"{formatted_date}.\n\nAnswer in english."
+                f"\n\n{PREVENT_URL_HALLUCINATION_INSTRUCTION}"
                 f"\n\n{SELF_DOCUMENTATION_TOOL_DESCRIPTION}",
                 run_id=messages[0].run_id,
                 timestamp=timezone.now(),
@@ -186,6 +188,7 @@ def test_post_conversation_with_local_image_url(
             "instructions": (
                 "You are a helpful test assistant :)\n\nToday is Saturday 18/10/2025."
                 "\n\nAnswer in english."
+                f"\n\n{PREVENT_URL_HALLUCINATION_INSTRUCTION}"
                 f"\n\n{SELF_DOCUMENTATION_TOOL_DESCRIPTION}"
             ),
             "kind": "request",
@@ -297,6 +300,7 @@ def test_post_conversation_with_local_image_wrong_url(
                 instructions=(
                     f"You are a helpful test assistant :)\n\n{today_prompt_date}"
                     "\n\nAnswer in english."
+                    f"\n\n{PREVENT_URL_HALLUCINATION_INSTRUCTION}"
                     f"\n\n{SELF_DOCUMENTATION_TOOL_DESCRIPTION}"
                 ),
                 run_id=messages[0].run_id,
@@ -386,6 +390,7 @@ def test_post_conversation_with_remote_image_url(
                 instructions=(
                     "You are a helpful test assistant :)\n\n"
                     f"{today_prompt_date}\n\nAnswer in english."
+                    f"\n\n{PREVENT_URL_HALLUCINATION_INSTRUCTION}"
                     f"\n\n{SELF_DOCUMENTATION_TOOL_DESCRIPTION}"
                 ),
                 run_id=messages[0].run_id,
@@ -506,6 +511,7 @@ def test_post_conversation_with_local_image_url_in_history(
                 "instructions": (
                     "You are a helpful test assistant :)\n\n"
                     f"{today_prompt_date}\n\nAnswer in english."
+                    f"\n\n{PREVENT_URL_HALLUCINATION_INSTRUCTION}"
                     f"\n\n{SELF_DOCUMENTATION_TOOL_DESCRIPTION}"
                 ),
                 "kind": "request",
@@ -598,6 +604,7 @@ def test_post_conversation_with_local_image_url_in_history(
                 instructions=(
                     "You are a helpful test assistant :)\n\n"
                     f"{today_prompt_date}\n\nAnswer in english."
+                    f"\n\n{PREVENT_URL_HALLUCINATION_INSTRUCTION}"
                     f"\n\n{SELF_DOCUMENTATION_TOOL_DESCRIPTION}"
                 ),
             ),
@@ -619,6 +626,7 @@ def test_post_conversation_with_local_image_url_in_history(
                 run_id=messages[2].run_id,
                 instructions="You are a helpful test assistant :)\n\n"
                 "Today is Saturday 18/10/2025.\n\nAnswer in english."
+                f"\n\n{PREVENT_URL_HALLUCINATION_INSTRUCTION}"
                 f"\n\n{SELF_DOCUMENTATION_TOOL_DESCRIPTION}",
                 timestamp=timestamp_now,
             ),
@@ -722,6 +730,7 @@ def test_post_conversation_with_local_image_url_in_history(
         {
             "instructions": f"You are a helpful test assistant :)\n\n{today_prompt_date}"
             "\n\nAnswer in english."
+            f"\n\n{PREVENT_URL_HALLUCINATION_INSTRUCTION}"
             f"\n\n{SELF_DOCUMENTATION_TOOL_DESCRIPTION}",
             "kind": "request",
             "parts": [
@@ -767,6 +776,7 @@ def test_post_conversation_with_local_image_url_in_history(
         {
             "instructions": "You are a helpful test assistant :)\n\nToday is Saturday 18/10/2025."
             "\n\nAnswer in english."
+            f"\n\n{PREVENT_URL_HALLUCINATION_INSTRUCTION}"
             f"\n\n{SELF_DOCUMENTATION_TOOL_DESCRIPTION}",
             "kind": "request",
             "metadata": None,

--- a/src/backend/chat/tests/views/chat/conversations/test_conversation_with_project.py
+++ b/src/backend/chat/tests/views/chat/conversations/test_conversation_with_project.py
@@ -7,6 +7,7 @@ import respx
 from freezegun import freeze_time
 from rest_framework import status
 
+from chat.agents.conversation import PREVENT_URL_HALLUCINATION_INSTRUCTION
 from chat.factories import ChatConversationFactory, ChatProjectFactory, UserFactory
 from chat.tests.utils import replace_uuids_with_placeholder
 from chat.tools.descriptions import SELF_DOCUMENTATION_TOOL_DESCRIPTION
@@ -64,6 +65,7 @@ def project_hello_data_fixture():
                 "You are a helpful test assistant :)",
                 "Today is Friday 25/07/2025.",
                 "Answer in english.",
+                PREVENT_URL_HALLUCINATION_INSTRUCTION,
                 "Always reply in bullet points.",
                 SELF_DOCUMENTATION_TOOL_DESCRIPTION,
             ],
@@ -74,6 +76,7 @@ def project_hello_data_fixture():
                 "You are a helpful test assistant :)",
                 "Today is Friday 25/07/2025.",
                 "Answer in english.",
+                PREVENT_URL_HALLUCINATION_INSTRUCTION,
                 SELF_DOCUMENTATION_TOOL_DESCRIPTION,
             ],
         ],


### PR DESCRIPTION
## Purpose

Prevent_url_hallucination instruction to ConversationAgent


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AI conversation quality by preventing URL hallucination. The model now only includes URLs explicitly present in tool results, using placeholders like `[official link]` when URLs cannot be verified from provided sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->