### PR TITLE
🐛(front) project modal now respects document-upload feature flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to
 - 🐛(fix) Fix streaming crash with OpenAI-compatible APIs
 - 🐛(fix) strip thinking part for models without reasoning support
 - ✨(dev) setup Tilt for local development
+ - 🐛(front) project modal now respects document-upload feature flag
 
 ## [0.0.15] - 2026-03-31
 

--- a/src/frontend/apps/conversations/src/core/config/hooks/index.ts
+++ b/src/frontend/apps/conversations/src/core/config/hooks/index.ts
@@ -1,1 +1,2 @@
+export * from './useFeatureEnabled';
 export * from './useMediaUrl';

--- a/src/frontend/apps/conversations/src/core/config/hooks/useFeatureEnabled.ts
+++ b/src/frontend/apps/conversations/src/core/config/hooks/useFeatureEnabled.ts
@@ -1,0 +1,22 @@
+import { useMemo } from 'react';
+
+import { useAnalytics } from '@/libs';
+
+import { useConfig } from '../api';
+import { FeatureFlagState } from '../api/useConfig';
+
+export const useFeatureEnabled = (featureKey: string): boolean => {
+  const { data: conf } = useConfig();
+  const { isFeatureFlagActivated } = useAnalytics();
+
+  return useMemo(() => {
+    const value = conf?.FEATURE_FLAGS?.[featureKey];
+    if (value === FeatureFlagState.ENABLED) {
+      return true;
+    }
+    if (!value || value === FeatureFlagState.DISABLED) {
+      return false;
+    }
+    return isFeatureFlagActivated(featureKey);
+  }, [conf, featureKey, isFeatureFlagActivated]);
+};

--- a/src/frontend/apps/conversations/src/features/chat/components/InputChat.tsx
+++ b/src/frontend/apps/conversations/src/features/chat/components/InputChat.tsx
@@ -1,15 +1,9 @@
-import React, {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { Box, Text } from '@/components';
 import { useToast } from '@/components/ToastProvider';
-import { FeatureFlagState, useConfig } from '@/core';
+import { useConfig, useFeatureEnabled } from '@/core';
 import { LLMModel } from '@/features/chat/api/useLLMConfiguration';
 import { InputChatActions } from '@/features/chat/components/InputChatAction';
 import { ProjectWelcomeMessage } from '@/features/chat/components/ProjectWelcomeMessage';
@@ -17,7 +11,6 @@ import { SuggestionCarousel } from '@/features/chat/components/SuggestionCarouse
 import { WelcomeMessage } from '@/features/chat/components/WelcomeMessage';
 import { useFileDragDrop } from '@/features/chat/hooks/useFileDragDrop';
 import { useFileUrls } from '@/features/chat/hooks/useFileUrls';
-import { useAnalytics } from '@/libs';
 import { useResponsiveStore } from '@/stores';
 
 import FilesIcon from '../assets/files.svg';
@@ -138,9 +131,8 @@ export const InputChat = ({
   const { isDesktop, isMobile } = useResponsiveStore();
 
   const { data: conf } = useConfig();
-  const { isFeatureFlagActivated } = useAnalytics();
-  const [fileUploadEnabled, setFileUploadEnabled] = useState(false);
-  const [webSearchEnabled, setWebSearchEnabled] = useState(false);
+  const fileUploadEnabled = useFeatureEnabled('document-upload');
+  const webSearchEnabled = useFeatureEnabled('web-search');
 
   const isFileAccepted = useCallback(
     (file: File): boolean => {
@@ -178,29 +170,6 @@ export const InputChat = ({
       },
     );
   }, [showToast, t]);
-
-  useEffect(() => {
-    if (!conf?.FEATURE_FLAGS) {
-      setWebSearchEnabled(false);
-      setFileUploadEnabled(false);
-      return;
-    }
-    const isFeatureEnabled = (featureKey: string): boolean => {
-      const configValue = conf.FEATURE_FLAGS[featureKey];
-      if (!configValue) {
-        return false;
-      } else if (configValue === FeatureFlagState.DISABLED) {
-        return false;
-      } else if (configValue === FeatureFlagState.ENABLED) {
-        return true;
-      } else {
-        return isFeatureFlagActivated(featureKey);
-      }
-    };
-
-    setWebSearchEnabled(isFeatureEnabled('web-search'));
-    setFileUploadEnabled(isFeatureEnabled('document-upload'));
-  }, [conf, isFeatureFlagActivated]);
 
   useEffect(() => {
     if (textareaRef.current && messagesLength === 0 && status === 'ready') {

--- a/src/frontend/apps/conversations/src/features/chat/components/__tests__/InputChat.test.tsx
+++ b/src/frontend/apps/conversations/src/features/chat/components/__tests__/InputChat.test.tsx
@@ -24,16 +24,7 @@ jest.mock('@/core', () => ({
       chat_upload_accept: '.pdf,.txt',
     },
   }),
-  FeatureFlagState: {
-    ENABLED: 'enabled',
-    DISABLED: 'disabled',
-  },
-}));
-
-jest.mock('@/libs', () => ({
-  useAnalytics: () => ({
-    isFeatureFlagActivated: jest.fn(() => true),
-  }),
+  useFeatureEnabled: () => true,
 }));
 
 jest.mock('@/components/ToastProvider', () => ({

--- a/src/frontend/apps/conversations/src/features/left-panel/components/projects/ModalProjectForm.tsx
+++ b/src/frontend/apps/conversations/src/features/left-panel/components/projects/ModalProjectForm.tsx
@@ -16,7 +16,7 @@ import FileGenericIcon from '@/assets/icons/uikit-custom/file-filled.svg';
 import FileImageIcon from '@/assets/icons/uikit-custom/file-image.svg';
 import FilePdfIcon from '@/assets/icons/uikit-custom/file-pdf.svg';
 import { Box, DropButton, Icon, Text, useToast } from '@/components';
-import { FeatureFlagState, useConfig } from '@/core';
+import { useConfig, useFeatureEnabled } from '@/core';
 import { useCunninghamTheme } from '@/cunningham';
 import { uploadProjectFiles } from '@/features/attachments/api/uploadProjectFiles';
 import { useDeleteProjectAttachment } from '@/features/attachments/api/useDeleteProjectAttachment';
@@ -153,8 +153,7 @@ export const ModalProjectForm = ({
   const { colorsTokens } = useCunninghamTheme();
 
   const { data: conf } = useConfig();
-  const fileUploadEnabled =
-    conf?.FEATURE_FLAGS?.['document-upload'] === FeatureFlagState.ENABLED;
+  const fileUploadEnabled = useFeatureEnabled('document-upload');
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const { data: existingAttachments } = useProjectAttachments(project?.id);


### PR DESCRIPTION
  ## Purpose

  The "document-upload" feature flag has three states (ENABLED / DISABLED / DYNAMIC
  fallback to PostHog activation). `InputChat.tsx` honored all three, but
  `ModalProjectForm.tsx` only treated `ENABLED` as truthy — so users who had
  the flag activated via PostHog could attach files in chat but not when
  creating/editing a project.

  ## Proposal

  - [x] Extract the three-state flag logic into a shared  hook 
  - [x] Use it in ModalProjectForm
  - [x] Use it in InputChat

 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Project modal now properly respects the document-upload feature flag.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/suitenumerique/conversations/pull/466)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->