### PR TITLE
🐛(back) scope self-documentation tool to meta questions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,8 @@ and this project adheres to
 - 🐛(fix) Fix streaming crash with OpenAI-compatible APIs
 - 🐛(fix) strip thinking part for models without reasoning support
 - ✨(dev) setup Tilt for local development
- - 🐛(front) project modal now respects document-upload feature flag
+- 🐛(front) project modal now respects document-upload feature flag
+- 🐛(back) self-doc tool no longer triggers on generic or document questions
 
 ## [0.0.15] - 2026-03-31
 

--- a/src/backend/chat/clients/pydantic_ai.py
+++ b/src/backend/chat/clients/pydantic_ai.py
@@ -156,6 +156,7 @@ from chat.tools.descriptions import (
     DOCUMENT_SUMMARIZE_PROJECT_TOOL_DESCRIPTION,
     DOCUMENT_SUMMARIZE_SYSTEM_PROMPT,
     DOCUMENT_SUMMARIZE_TOOL_DESCRIPTION,
+    SELF_DOCUMENTATION_SYSTEM_PROMPT,
     SELF_DOCUMENTATION_TOOL_DESCRIPTION,
     WEB_SEARCH_TOOL_DESCRIPTION,
 )
@@ -885,9 +886,13 @@ class AIAgentService:  # pylint: disable=too-many-instance-attributes
 
         @self.conversation_agent.instructions
         def self_documentation_instruction() -> str:
-            return SELF_DOCUMENTATION_TOOL_DESCRIPTION
+            return SELF_DOCUMENTATION_SYSTEM_PROMPT
 
-        @self.conversation_agent.tool(name="self_documentation", retries=2)
+        @self.conversation_agent.tool(
+            name="self_documentation",
+            retries=2,
+            description=SELF_DOCUMENTATION_TOOL_DESCRIPTION,
+        )
         async def self_documentation(_ctx: RunContext) -> ToolReturn:
             """Return a single payload with static and runtime assistant metadata."""
             return ToolReturn(

--- a/src/backend/chat/tests/views/chat/conversations/test_conversation.py
+++ b/src/backend/chat/tests/views/chat/conversations/test_conversation.py
@@ -32,7 +32,7 @@ from chat.tests.utils import (
     assert_data_stream_response,
     replace_uuids_with_placeholder,
 )
-from chat.tools.descriptions import SELF_DOCUMENTATION_TOOL_DESCRIPTION
+from chat.tools.descriptions import SELF_DOCUMENTATION_SYSTEM_PROMPT
 
 # enable database transactions for tests:
 # transaction=True ensures that the data are available in the database
@@ -43,7 +43,7 @@ FROZEN_TIMESTAMP = "2025-07-25T10:36:35.297675Z"
 ENGLISH_INSTRUCTIONS = (
     "You are a helpful test assistant :)\n\nToday is Friday 25/07/2025.\n\nAnswer in english."
     f"\n\n{PREVENT_URL_HALLUCINATION_INSTRUCTION}"
-    f"\n\n{SELF_DOCUMENTATION_TOOL_DESCRIPTION}"
+    f"\n\n{SELF_DOCUMENTATION_SYSTEM_PROMPT}"
 )
 
 
@@ -137,7 +137,7 @@ def _system_messages(language="english"):
         {"content": "Today is Friday 25/07/2025.", "role": "system"},
         {"content": f"Answer in {language}.", "role": "system"},
         {"content": PREVENT_URL_HALLUCINATION_INSTRUCTION, "role": "system"},
-        {"content": SELF_DOCUMENTATION_TOOL_DESCRIPTION, "role": "system"},
+        {"content": SELF_DOCUMENTATION_SYSTEM_PROMPT, "role": "system"},
     ]
 
 
@@ -734,7 +734,7 @@ def test_post_conversation_tool_call_fails(api_client, mock_openai_stream_tool, 
     french_instructions = (
         "You are a helpful test assistant :)\n\nToday is Friday 25/07/2025.\n\nAnswer in french."
         f"\n\n{PREVENT_URL_HALLUCINATION_INSTRUCTION}"
-        f"\n\n{SELF_DOCUMENTATION_TOOL_DESCRIPTION}"
+        f"\n\n{SELF_DOCUMENTATION_SYSTEM_PROMPT}"
     )
     _run_id = chat_conversation.pydantic_messages[0]["run_id"]
     assert chat_conversation.pydantic_messages == [
@@ -993,7 +993,7 @@ def test_post_conversation_data_protocol_no_stream(
             (
                 "You are an amazing assistant.\n\nToday is Friday 25/07/2025.\n\nAnswer in english."
                 f"\n\n{PREVENT_URL_HALLUCINATION_INSTRUCTION}"
-                f"\n\n{SELF_DOCUMENTATION_TOOL_DESCRIPTION}"
+                f"\n\n{SELF_DOCUMENTATION_SYSTEM_PROMPT}"
             ),
             ["Why the sky is blue?"],
         ),

--- a/src/backend/chat/tests/views/chat/conversations/test_conversation_concatenate_system_messages.py
+++ b/src/backend/chat/tests/views/chat/conversations/test_conversation_concatenate_system_messages.py
@@ -10,7 +10,7 @@ from chat.agents.conversation import PREVENT_URL_HALLUCINATION_INSTRUCTION
 from chat.factories import ChatConversationFactory, ChatProjectFactory, UserFactory
 from chat.llm_configuration import LLModel, LLMProvider
 from chat.tests.utils import assert_data_stream_response
-from chat.tools.descriptions import SELF_DOCUMENTATION_TOOL_DESCRIPTION
+from chat.tools.descriptions import SELF_DOCUMENTATION_SYSTEM_PROMPT
 
 # enable database transactions for tests:
 # transaction=True ensures that the data are available in the database
@@ -50,7 +50,7 @@ def settings_with_concatenation(settings):
             (
                 "base system prompt\n\nToday is Friday 25/07/2025.\n\nAnswer in english.\n\n"
                 f"{PREVENT_URL_HALLUCINATION_INSTRUCTION}\n\n"
-                f"{SELF_DOCUMENTATION_TOOL_DESCRIPTION}"
+                f"{SELF_DOCUMENTATION_SYSTEM_PROMPT}"
             ),
         ],
         [
@@ -59,7 +59,7 @@ def settings_with_concatenation(settings):
                 "base system prompt\n\nToday is Friday 25/07/2025.\n\nAnswer in english.\n\n"
                 f"{PREVENT_URL_HALLUCINATION_INSTRUCTION}\n\n"
                 "Custom project instructions.\n\n"
-                f"{SELF_DOCUMENTATION_TOOL_DESCRIPTION}"
+                f"{SELF_DOCUMENTATION_SYSTEM_PROMPT}"
             ),
         ],
     ),

--- a/src/backend/chat/tests/views/chat/conversations/test_conversation_with_document_url.py
+++ b/src/backend/chat/tests/views/chat/conversations/test_conversation_with_document_url.py
@@ -38,7 +38,7 @@ from chat.tests.utils import replace_uuids_with_placeholder
 from chat.tools.descriptions import (
     DOCUMENT_SEARCH_RAG_SYSTEM_PROMPT,
     DOCUMENT_SUMMARIZE_SYSTEM_PROMPT,
-    SELF_DOCUMENTATION_TOOL_DESCRIPTION,
+    SELF_DOCUMENTATION_SYSTEM_PROMPT,
 )
 
 # enable database transactions for tests:
@@ -61,7 +61,7 @@ def _expected_document_instructions(
         f"{today_prompt_date}\n\n"
         "Answer in english.\n\n"
         f"{PREVENT_URL_HALLUCINATION_INSTRUCTION}\n\n"
-        f"{SELF_DOCUMENTATION_TOOL_DESCRIPTION}\n\n"
+        f"{SELF_DOCUMENTATION_SYSTEM_PROMPT}\n\n"
         f"{DOCUMENT_SEARCH_RAG_SYSTEM_PROMPT}\n\n"
         f"{DOCUMENT_SUMMARIZE_SYSTEM_PROMPT}\n\n"
         "[Internal context] User documents are attached to this conversation. "
@@ -501,7 +501,7 @@ def test_post_conversation_with_local_document_url_in_history(  # pylint: disabl
         f"Today is {formatted_date}.\n\n"
         "Answer in english.\n\n"
         f"{PREVENT_URL_HALLUCINATION_INSTRUCTION}\n\n"
-        f"{SELF_DOCUMENTATION_TOOL_DESCRIPTION}"
+        f"{SELF_DOCUMENTATION_SYSTEM_PROMPT}"
     )
 
     chat_conversation = ChatConversationFactory(

--- a/src/backend/chat/tests/views/chat/conversations/test_conversation_with_history.py
+++ b/src/backend/chat/tests/views/chat/conversations/test_conversation_with_history.py
@@ -22,7 +22,7 @@ from chat.ai_sdk_types import (
 )
 from chat.factories import ChatConversationFactory
 from chat.tests.utils import replace_uuids_with_placeholder
-from chat.tools.descriptions import SELF_DOCUMENTATION_TOOL_DESCRIPTION
+from chat.tools.descriptions import SELF_DOCUMENTATION_SYSTEM_PROMPT
 
 # enable database transactions for tests:
 # transaction=True ensures that the data are available in the database
@@ -1493,7 +1493,7 @@ def test_post_conversation_with_existing_tool_history(
             "You are a helpful test assistant :)\n\nToday is Friday 25/07/2025."
             "\n\nAnswer in dutch."
             f"\n\n{PREVENT_URL_HALLUCINATION_INSTRUCTION}"
-            f"\n\n{SELF_DOCUMENTATION_TOOL_DESCRIPTION}"
+            f"\n\n{SELF_DOCUMENTATION_SYSTEM_PROMPT}"
         ),
         "kind": "request",
         "metadata": None,
@@ -1550,7 +1550,7 @@ def test_post_conversation_with_existing_tool_history(
             "You are a helpful test assistant :)\n\nToday is Friday 25/07/2025."
             "\n\nAnswer in dutch."
             f"\n\n{PREVENT_URL_HALLUCINATION_INSTRUCTION}"
-            f"\n\n{SELF_DOCUMENTATION_TOOL_DESCRIPTION}"
+            f"\n\n{SELF_DOCUMENTATION_SYSTEM_PROMPT}"
         ),
         "kind": "request",
         "metadata": None,

--- a/src/backend/chat/tests/views/chat/conversations/test_conversation_with_image_url.py
+++ b/src/backend/chat/tests/views/chat/conversations/test_conversation_with_image_url.py
@@ -26,7 +26,7 @@ from chat.ai_sdk_types import (
 )
 from chat.factories import ChatConversationFactory
 from chat.tests.utils import replace_uuids_with_placeholder
-from chat.tools.descriptions import SELF_DOCUMENTATION_TOOL_DESCRIPTION
+from chat.tools.descriptions import SELF_DOCUMENTATION_SYSTEM_PROMPT
 
 # enable database transactions for tests:
 # transaction=True ensures that the data are available in the database
@@ -113,7 +113,7 @@ def test_post_conversation_with_local_image_url(
                 instructions="You are a helpful test assistant :)\n\nToday is "
                 f"{formatted_date}.\n\nAnswer in english."
                 f"\n\n{PREVENT_URL_HALLUCINATION_INSTRUCTION}"
-                f"\n\n{SELF_DOCUMENTATION_TOOL_DESCRIPTION}",
+                f"\n\n{SELF_DOCUMENTATION_SYSTEM_PROMPT}",
                 run_id=messages[0].run_id,
                 timestamp=timezone.now(),
             )
@@ -189,7 +189,7 @@ def test_post_conversation_with_local_image_url(
                 "You are a helpful test assistant :)\n\nToday is Saturday 18/10/2025."
                 "\n\nAnswer in english."
                 f"\n\n{PREVENT_URL_HALLUCINATION_INSTRUCTION}"
-                f"\n\n{SELF_DOCUMENTATION_TOOL_DESCRIPTION}"
+                f"\n\n{SELF_DOCUMENTATION_SYSTEM_PROMPT}"
             ),
             "kind": "request",
             "metadata": None,
@@ -301,7 +301,7 @@ def test_post_conversation_with_local_image_wrong_url(
                     f"You are a helpful test assistant :)\n\n{today_prompt_date}"
                     "\n\nAnswer in english."
                     f"\n\n{PREVENT_URL_HALLUCINATION_INSTRUCTION}"
-                    f"\n\n{SELF_DOCUMENTATION_TOOL_DESCRIPTION}"
+                    f"\n\n{SELF_DOCUMENTATION_SYSTEM_PROMPT}"
                 ),
                 run_id=messages[0].run_id,
             )
@@ -391,7 +391,7 @@ def test_post_conversation_with_remote_image_url(
                     "You are a helpful test assistant :)\n\n"
                     f"{today_prompt_date}\n\nAnswer in english."
                     f"\n\n{PREVENT_URL_HALLUCINATION_INSTRUCTION}"
-                    f"\n\n{SELF_DOCUMENTATION_TOOL_DESCRIPTION}"
+                    f"\n\n{SELF_DOCUMENTATION_SYSTEM_PROMPT}"
                 ),
                 run_id=messages[0].run_id,
                 timestamp=timezone.now(),
@@ -512,7 +512,7 @@ def test_post_conversation_with_local_image_url_in_history(
                     "You are a helpful test assistant :)\n\n"
                     f"{today_prompt_date}\n\nAnswer in english."
                     f"\n\n{PREVENT_URL_HALLUCINATION_INSTRUCTION}"
-                    f"\n\n{SELF_DOCUMENTATION_TOOL_DESCRIPTION}"
+                    f"\n\n{SELF_DOCUMENTATION_SYSTEM_PROMPT}"
                 ),
                 "kind": "request",
                 "parts": [
@@ -605,7 +605,7 @@ def test_post_conversation_with_local_image_url_in_history(
                     "You are a helpful test assistant :)\n\n"
                     f"{today_prompt_date}\n\nAnswer in english."
                     f"\n\n{PREVENT_URL_HALLUCINATION_INSTRUCTION}"
-                    f"\n\n{SELF_DOCUMENTATION_TOOL_DESCRIPTION}"
+                    f"\n\n{SELF_DOCUMENTATION_SYSTEM_PROMPT}"
                 ),
             ),
             ModelResponse(
@@ -627,7 +627,7 @@ def test_post_conversation_with_local_image_url_in_history(
                 instructions="You are a helpful test assistant :)\n\n"
                 "Today is Saturday 18/10/2025.\n\nAnswer in english."
                 f"\n\n{PREVENT_URL_HALLUCINATION_INSTRUCTION}"
-                f"\n\n{SELF_DOCUMENTATION_TOOL_DESCRIPTION}",
+                f"\n\n{SELF_DOCUMENTATION_SYSTEM_PROMPT}",
                 timestamp=timestamp_now,
             ),
         ]
@@ -731,7 +731,7 @@ def test_post_conversation_with_local_image_url_in_history(
             "instructions": f"You are a helpful test assistant :)\n\n{today_prompt_date}"
             "\n\nAnswer in english."
             f"\n\n{PREVENT_URL_HALLUCINATION_INSTRUCTION}"
-            f"\n\n{SELF_DOCUMENTATION_TOOL_DESCRIPTION}",
+            f"\n\n{SELF_DOCUMENTATION_SYSTEM_PROMPT}",
             "kind": "request",
             "parts": [
                 {
@@ -777,7 +777,7 @@ def test_post_conversation_with_local_image_url_in_history(
             "instructions": "You are a helpful test assistant :)\n\nToday is Saturday 18/10/2025."
             "\n\nAnswer in english."
             f"\n\n{PREVENT_URL_HALLUCINATION_INSTRUCTION}"
-            f"\n\n{SELF_DOCUMENTATION_TOOL_DESCRIPTION}",
+            f"\n\n{SELF_DOCUMENTATION_SYSTEM_PROMPT}",
             "kind": "request",
             "metadata": None,
             "parts": [

--- a/src/backend/chat/tests/views/chat/conversations/test_conversation_with_project.py
+++ b/src/backend/chat/tests/views/chat/conversations/test_conversation_with_project.py
@@ -10,7 +10,7 @@ from rest_framework import status
 from chat.agents.conversation import PREVENT_URL_HALLUCINATION_INSTRUCTION
 from chat.factories import ChatConversationFactory, ChatProjectFactory, UserFactory
 from chat.tests.utils import replace_uuids_with_placeholder
-from chat.tools.descriptions import SELF_DOCUMENTATION_TOOL_DESCRIPTION
+from chat.tools.descriptions import SELF_DOCUMENTATION_SYSTEM_PROMPT
 
 pytestmark = pytest.mark.django_db(transaction=True)
 
@@ -67,7 +67,7 @@ def project_hello_data_fixture():
                 "Answer in english.",
                 PREVENT_URL_HALLUCINATION_INSTRUCTION,
                 "Always reply in bullet points.",
-                SELF_DOCUMENTATION_TOOL_DESCRIPTION,
+                SELF_DOCUMENTATION_SYSTEM_PROMPT,
             ],
         ],
         [
@@ -77,7 +77,7 @@ def project_hello_data_fixture():
                 "Today is Friday 25/07/2025.",
                 "Answer in english.",
                 PREVENT_URL_HALLUCINATION_INSTRUCTION,
-                SELF_DOCUMENTATION_TOOL_DESCRIPTION,
+                SELF_DOCUMENTATION_SYSTEM_PROMPT,
             ],
         ],
     ),

--- a/src/backend/chat/tools/descriptions.py
+++ b/src/backend/chat/tools/descriptions.py
@@ -110,9 +110,35 @@ Examples of queries that do NOT need web_search tool:
 - "Résume ce texte"
 """
 
-SELF_DOCUMENTATION_TOOL_DESCRIPTION = (
-    "For questions about your "
-    "identity, model, capabilities, limitations, privacy, "
-    "internet access, accepted files, or hosting, call the "
-    "self_documentation tool before answering."
+SELF_DOCUMENTATION_SYSTEM_PROMPT = (
+    "For meta questions about this assistant itself (identity, model, "
+    "capabilities, limitations, privacy, internet access, accepted files, "
+    "or hosting), call the self_documentation tool before answering. "
+    "Do not call it for questions about attached documents, web search "
+    "or general knowledge."
 )
+
+SELF_DOCUMENTATION_TOOL_DESCRIPTION = """
+Call self_documentation ONLY for meta questions where the user asks about
+THIS assistant itself: its identity, the underlying model, its capabilities
+or limitations, privacy and data handling, internet access, which file types
+it accepts, attachment size limits, or how and where it is hosted.
+
+Do NOT use this tool for:
+- General knowledge questions or normal conversation
+- Questions about the content of attached documents (use the document search
+  or summarize tools instead)
+- Coding, writing, translation, or any other task-oriented request
+
+Examples that MUST trigger self_documentation:
+- "Which model are you?"
+- "What can you do?"
+- "Do you have internet access?"
+- "What file types can I upload?"
+- "Where is my data stored?"
+
+Examples that must NOT trigger self_documentation:
+- "Summarize this document"
+- "Explain how a for loop works"
+- "What does this report say about Q3 revenue?"
+"""


### PR DESCRIPTION
The assistant sometimes triggers the self doc without good reason

## Purpose


  The self_documentation tool was registered without an explicit  `description=`,
  so the model selected it based on its function docstring and over-fired  it  on generic questions and document-related queries instead of only assistant  meta questions.

cf. https://github.com/orgs/suitenumerique/projects/13/views/3?filterQuery=&pane=issue&itemId=189043392&issue=suitenumerique%7Cconversations%7C476

## Proposal

 - [ ] Pass an explicit description=… to the   tool, with positive and negative examples (see the web_search tool  style)
- [ ] Split the guidance into two constants, matching the existing RAG pattern:   a short SELF_DOCUMENTATION_SYSTEM_PROMPT for the agent instruction and the  detailed SELF_DOCUMENTATION_TOOL_DESCRIPTION for the tool schema  
- [ ] Update  tests
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Self-documentation tool no longer triggers for generic questions or when users upload documents.
  * Project modal now correctly respects the document-upload feature flag.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/suitenumerique/conversations/pull/475?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->