### PR TITLE
🚸(front) switch to new conversation when creating a project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to
 - ⬆️(back) upgrade lxml and pypdf
 - ✨(back) set allow_smart_web_search to False for all users
 - ✨(back) make allow_conversation_analytics user setting readonly in admin
+- 🚸(front) switch to new conversation when creating a project
 
 ### Fixed
 

--- a/src/frontend/apps/conversations/src/features/left-panel/components/projects/ModalProjectForm.tsx
+++ b/src/frontend/apps/conversations/src/features/left-panel/components/projects/ModalProjectForm.tsx
@@ -7,6 +7,7 @@ import {
   TextArea,
 } from '@gouvfr-lasuite/cunningham-react';
 import { useQueryClient } from '@tanstack/react-query';
+import { useRouter } from 'next/router';
 import { useCallback, useReducer, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { css } from 'styled-components';
@@ -26,6 +27,7 @@ import {
 } from '@/features/attachments/api/useProjectAttachments';
 import { useCreateProject } from '@/features/chat/api/useCreateProject';
 import { useUpdateProject } from '@/features/chat/api/useUpdateProject';
+import { usePendingChatStore } from '@/features/chat/stores/usePendingChatStore';
 import { ChatProject } from '@/features/chat/types';
 
 import { ModalIconColorPicker } from './ModalIconColorPicker';
@@ -513,6 +515,9 @@ export const ModalProjectForm = ({
     ? (colorsTokens[colorToken as keyof typeof colorsTokens] ?? undefined)
     : undefined;
 
+  const router = useRouter();
+  const setProjectId = usePendingChatStore((s) => s.setProjectId);
+
   const { mutateAsync: createProjectAsync, isPending: isCreating } =
     useCreateProject();
 
@@ -586,6 +591,11 @@ export const ModalProjectForm = ({
           4000,
         );
         onClose();
+
+        // Switch to a new conversation in the context of the freshly
+        // created project so the user doesn't have to click it manually.
+        setProjectId(created.id);
+        void router.push('/chat/');
       } catch (error) {
         const err = error as { cause?: string[]; message?: string };
         const errorMessage =

--- a/src/frontend/apps/conversations/src/features/left-panel/components/projects/__tests__/ModalProjectForm.test.tsx
+++ b/src/frontend/apps/conversations/src/features/left-panel/components/projects/__tests__/ModalProjectForm.test.tsx
@@ -9,6 +9,12 @@ import { ChatProject } from '@/features/chat/types';
 
 import { ModalProjectForm } from '../ModalProjectForm';
 
+const mockPush = jest.fn();
+jest.mock('next/router', () => ({
+  ...jest.requireActual('next/router'),
+  useRouter: () => ({ push: mockPush }),
+}));
+
 jest.mock('@/components', () => ({
   ...jest.requireActual('@/components'),
   useToast: jest.fn(),
@@ -178,6 +184,7 @@ describe('ModalProjectForm', () => {
       );
     });
     expect(mockOnClose).toHaveBeenCalled();
+    expect(mockPush).toHaveBeenCalledWith('/chat/');
   });
 
   it('shows API error message on failed create', async () => {

--- a/src/frontend/apps/e2e/__tests__/app-conversations/projects.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-conversations/projects.spec.ts
@@ -56,7 +56,10 @@ test.describe('Projects', () => {
     await createProject(page, projectName);
 
     // Hover the project item to reveal actions
-    const projectItem = page.getByText(projectName);
+    const projectItem = page.getByRole('button', {
+      name: `Start new conversation in ${projectName}`,
+      exact: true,
+    });
     await projectItem.hover();
 
     // Open the actions menu
@@ -86,7 +89,12 @@ test.describe('Projects', () => {
     await expect(page.getByText('The project has been updated.')).toBeVisible();
 
     // Updated name should appear
-    await expect(page.getByText(updatedName)).toBeVisible();
+    await expect(
+      page.getByRole('button', {
+        name: `Start new conversation in ${updatedName}`,
+        exact: true,
+      }),
+    ).toBeVisible();
   });
 
   test('it deletes a project', async ({ page, browserName }) => {
@@ -95,7 +103,12 @@ test.describe('Projects', () => {
     await createProject(page, projectName);
 
     // Hover and open actions
-    await page.getByText(projectName).hover();
+    await page
+      .getByRole('button', {
+        name: `Start new conversation in ${projectName}`,
+        exact: true,
+      })
+      .hover();
     await page.getByLabel(`Actions list for project ${projectName}`).click();
 
     // Click delete
@@ -117,7 +130,12 @@ test.describe('Projects', () => {
     await expect(page.getByText('The project has been deleted.')).toBeVisible();
 
     // Project should no longer be visible
-    await expect(page.getByText(projectName)).toBeHidden();
+    await expect(
+      page.getByRole('button', {
+        name: `Start new conversation in ${projectName}`,
+        exact: true,
+      }),
+    ).toBeHidden();
   });
 
   test('it expands and collapses a project', async ({ page, browserName }) => {


### PR DESCRIPTION


## Purpose

  After creating a new project, the user has to manually click on it in the  left panel to start a conversation associated with that project. This minor  UX glitch added an unecessary step.

https://github.com/orgs/suitenumerique/projects/13/views/3?filterQuery=&pane=issue&itemId=189050928&issue=suitenumerique%7Cconversations%7C477


## Proposal

 - [x] After a project is created, set it as the pending chat context       and navigate to a new conversation ,       mirroring the existing project-click behavio
 - [x] Behavior unchanged for editing an existing project



https://github.com/user-attachments/assets/3f63bc78-e7ec-470d-a4b8-eeb669e811c9




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Creating a new project now automatically switches to the conversation/chat view for that project.

* **Tests**
  * Tests updated to verify navigation to the chat view occurs after project creation.

* **Chores**
  * Changelog updated with an entry documenting the new behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/suitenumerique/conversations/pull/479?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->