### PR TITLE
✨(front) allow typing while LLM is generating a response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,9 @@ and this project adheres to
 ### Changed
 
 - ✨(settings) new settings modal
+- ✨(front) allow typing while LLM is generating a response
 - 🐛(fix) source links should open a new tab
 - 💄(ui) codeblock light mode
-- ✨(front) allow typing while LLM is generating a response
 - ⬆️(dependencies) update back and front dependencies
 - 💄(ui) new header
 - ✨(back) add debug mode setup for local development

--- a/src/frontend/apps/conversations/src/features/chat/components/InputChat.tsx
+++ b/src/frontend/apps/conversations/src/features/chat/components/InputChat.tsx
@@ -236,7 +236,9 @@ export const InputChat = ({
     onFilesRejected: () => showToastError(),
   });
 
-  const isInputDisabled = status !== 'ready' || isUploadingFiles;
+  const isInputDisabled =
+    (status !== 'ready' && status !== 'streaming' && status !== 'submitted') ||
+    isUploadingFiles;
 
   const containerCss = useMemo(
     () => `
@@ -272,12 +274,13 @@ export const InputChat = ({
     (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
       if (e.key === 'Enter' && !e.ctrlKey && !e.shiftKey) {
         e.preventDefault();
+        if (status === 'streaming' || status === 'submitted') return;
         const textarea = e.target as HTMLTextAreaElement;
         textarea.style.height = '0';
         e.currentTarget.form?.requestSubmit?.();
       }
     },
-    [],
+    [status],
   );
 
   const handlePaste = useCallback(

--- a/src/frontend/apps/conversations/src/features/chat/components/__tests__/InputChat.test.tsx
+++ b/src/frontend/apps/conversations/src/features/chat/components/__tests__/InputChat.test.tsx
@@ -155,24 +155,24 @@ describe('InputChat', () => {
     ).toBeDisabled();
   });
 
-  it('should disable textarea when status is streaming', () => {
+  it('should keep textarea enabled when status is streaming', () => {
     render(<InputChat {...defaultProps} status="streaming" />, {
       wrapper: AppWrapper,
     });
 
     expect(
       screen.getByRole('textbox', { name: 'Enter your message or a question' }),
-    ).toBeDisabled();
+    ).toBeEnabled();
   });
 
-  it('should disable textarea when status is submitted', () => {
+  it('should keep textarea enabled when status is submitted', () => {
     render(<InputChat {...defaultProps} status="submitted" />, {
       wrapper: AppWrapper,
     });
 
     expect(
       screen.getByRole('textbox', { name: 'Enter your message or a question' }),
-    ).toBeDisabled();
+    ).toBeEnabled();
   });
 
   it('should not submit form when pressing Enter and status is streaming', async () => {


### PR DESCRIPTION
allow typing while LLM is generating a response  - sorry maxence


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable status banner supporting different severity levels, with customizable title, content, and optional start/end visibility windows
  * Message textarea now remains enabled while the LLM is generating a response

* **Bug Fixes**
  * Fixed chat input behavior to prevent unintended interaction blocking during active LLM generation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/suitenumerique/conversations/pull/483?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->