### PR TITLE
💄(settings modal) updated the settings modal size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to
 
 - 🐛(helm) stop job pods from matching the backend disruption budget
 - 🐛(front) use the browser language for the default UI on first load
+- 💄(settings modal) updated the settings modal size
 
 ## [0.0.17] - 2026-06-02
 

--- a/src/frontend/apps/conversations/src/features/settings/components/SettingsModal.tsx
+++ b/src/frontend/apps/conversations/src/features/settings/components/SettingsModal.tsx
@@ -248,6 +248,9 @@ export const SettingsModal = ({ onClose, isOpen }: SettingsModalProps) => {
     tabs: settingsTabs,
     sidebarTitle: t('Settings'),
     variant: 'tab' as const,
+    constraints: {
+      minHeight: 'min(430px, calc(100dvh - 3rem))',
+    },
   } as unknown as React.ComponentProps<typeof Modal>;
 
   return <Modal {...tabModalProps} />;


### PR DESCRIPTION
fix modal settings size

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved settings modal sizing: the modal now enforces a clearer minimum height so it adapts better across viewport sizes, avoiding overflow or excessive shrinking on short screens and improving usability on mobile and small browser windows.
  * Changelog updated to reflect this fix for the unreleased entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->