### PR TITLE
✨(error) display specific error when LLM provider is down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,9 @@ and this project adheres to
 
 - 🐛(backend) remove user list endpoint
 
+### Added
+- ✨(frontend): display specific error when LLM provider is down
+
 ## [0.0.16] - 2026-05-21
 
 ### Added

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -1,0 +1,31 @@
+# LLM Provider Error Handling
+
+When the LLM provider fails, the backend emits a typed error code in the Vercel AI SDK stream. The frontend reads this code and displays a specific message.
+
+## Error mapping
+
+| Provider failure | pydantic-ai exception | Error code | User-facing message |
+|---|---|---|---|
+| HTTP 5xx except 503 (500, 502, 504…) | `ModelHTTPError` (`status_code >= 500`) | `model_unavailable` | "The AI inference provider is temporarily unavailable. Please try again later." |
+| HTTP 503 (service busy) | `ModelHTTPError` (`status_code == 503`) | `model_busy` | "The AI inference provider is too busy. Please try again later." |
+| HTTP 429 (rate limit) | `ModelHTTPError` (`status_code == 429`) | `model_rate_limited` | "The AI inference provider is overloaded. Please try again in a few minutes." |
+| HTTP 404 (not found) | `ModelHTTPError` (`status_code == 404`) | `model_not_found` | "We encountered an internal error. Our team has been alerted. Please try again later." |
+| HTTP 422 (validation error) | `HTTPValidationError` (`status_code == 422`) | `model_wrong_type` | "We encountered an internal error. Our team has been alerted. Please try again later." |
+| No TCP connection, DNS failure, timeout | `ModelAPIError` | `model_connection_error` | "Unable to reach the AI inference provider. Please try again later." |
+| Any other error | uncaught → generic Vercel AI SDK error | `generic` | "Sorry, an error occurred. Please try again." |
+
+## Status page link
+
+Set `STATUS_PAGE_URL` to display a "Check service status" link alongside provider availability errors (`model_unavailable`, `model_busy`, `model_rate_limited`, `model_connection_error`). Configuration errors (`model_not_found`, `model_wrong_type`) show a generic internal error message and do not display a status link.
+
+```bash
+STATUS_PAGE_URL=https://albert.sites.beta.gouv.fr/about/status/
+```
+
+The link is omitted when the variable is unset.
+
+## Implementation
+
+- **Backend:** `src/backend/chat/clients/pydantic_ai.py` — `_stream_content` catches provider exceptions and emits `ErrorPart` events.
+- **Frontend:** `src/frontend/apps/conversations/src/features/chat/components/ChatError.tsx` — renders the message based on `errorType` prop.
+- **Config:** `src/backend/conversations/settings.py` and `src/backend/core/api/viewsets.py` — `STATUS_PAGE_URL` is exposed via the `config/` API.

--- a/src/backend/chat/clients/pydantic_ai.py
+++ b/src/backend/chat/clients/pydantic_ai.py
@@ -97,8 +97,10 @@ from django.utils.translation import gettext_lazy as _
 
 from asgiref.sync import sync_to_async
 from langfuse import get_client
+from mistralai.client.errors import HTTPValidationError, SDKError
 from pydantic_ai import Agent, InstrumentationSettings, RunContext, RunUsage
 from pydantic_ai.capabilities import Instrumentation
+from pydantic_ai.exceptions import ModelAPIError, ModelHTTPError
 from pydantic_ai.messages import (
     BinaryContent,
     DocumentUrl,
@@ -183,6 +185,27 @@ User = get_user_model()
 
 CACHE_TIMEOUT = 30 * 60  # 30 minutes timeout
 DOCUMENT_URL_PREFIX = "/media-key/"
+
+_HTTP_STATUS_TO_ERROR_CODE = {
+    429: "model_rate_limited",
+    503: "model_busy",
+    404: "model_not_found",
+    422: "model_wrong_type",
+}
+
+# Expected operational errors that should not trigger ERROR-level logging or Sentry alerts.
+_EXPECTED_STATUS_CODES = {429, 503}
+
+
+def _resolve_http_error_code(status_code: int | None) -> str | None:
+    """Map an HTTP status code to an error code string, or None to re-raise."""
+    if status_code is None:
+        return None
+    if status_code in _HTTP_STATUS_TO_ERROR_CODE:
+        return _HTTP_STATUS_TO_ERROR_CODE[status_code]
+    if status_code >= 500:
+        return "model_unavailable"
+    return None
 
 
 def get_model_configuration(model_hrid: str):
@@ -346,6 +369,19 @@ class AIAgentService:  # pylint: disable=too-many-instance-attributes
     # Async internals
     # --------------------------------------------------------------------- #
 
+    async def _persist_user_message_on_error(self, user_message: UIMessage) -> None:
+        """Persist the user message when an LLM error prevents normal finalization.
+
+        In normal flow, _prepare_update_conversation saves both user and assistant
+        messages after a successful LLM response. On error that path is never reached,
+        so we save the user message here to keep it visible on page reload.
+        Role-based guard prevents double-appending on repeated errors.
+        """
+        if self.conversation.messages and self.conversation.messages[-1].role == "user":
+            return
+        self.conversation.messages = list(self.conversation.messages) + [user_message]
+        await sync_to_async(self.conversation.save)(update_fields=["messages"])
+
     async def _stream_content(
         self, messages: List[UIMessage], force_web_search: bool = False, encoder_fn: Callable = None
     ):
@@ -356,9 +392,43 @@ class AIAgentService:  # pylint: disable=too-many-instance-attributes
                 span = stack.enter_context(get_client().start_as_current_span(name="conversation"))
                 span.update_trace(user_id=str(self.user.sub), session_id=str(self.conversation.pk))
 
-            async for event in self._run_agent(messages, force_web_search):
-                if stream_text := encoder_fn(event):
-                    yield stream_text
+            try:
+                async for event in self._run_agent(messages, force_web_search):
+                    if stream_text := encoder_fn(event):
+                        yield stream_text
+            except (ModelHTTPError, HTTPValidationError, SDKError) as exc:
+                # HTTPValidationError and SDKError are mistral-specific exceptions not
+                # wrapped by pydantic_ai into ModelHTTPError.
+                error_code = _resolve_http_error_code(exc.status_code)
+                if error_code is None:
+                    raise
+                log = logger.warning if exc.status_code in _EXPECTED_STATUS_CODES else logger.error
+                log(
+                    "LLM provider HTTP error (status=%s) for conversation %s: %s",
+                    exc.status_code,
+                    self.conversation.pk,
+                    exc,
+                )
+                if messages:
+                    await self._persist_user_message_on_error(messages[-1])
+                error_event = events_v4.ErrorPart(error=error_code)
+                if encoded := encoder_fn(error_event):
+                    yield encoded
+                else:
+                    raise
+            except ModelAPIError as exc:
+                logger.warning(
+                    "LLM provider connection error for conversation %s: %s",
+                    self.conversation.pk,
+                    exc,
+                )
+                if messages:
+                    await self._persist_user_message_on_error(messages[-1])
+                error_event = events_v4.ErrorPart(error="model_connection_error")
+                if encoded := encoder_fn(error_event):
+                    yield encoded
+                else:
+                    raise
 
     async def stream_text_async(self, messages: List[UIMessage], force_web_search: bool = False):
         """Return only the assistant text deltas (legacy text mode)."""
@@ -1414,10 +1484,11 @@ class AIAgentService:  # pylint: disable=too-many-instance-attributes
 
         self.conversation.agent_usage = usage
 
-        self.conversation.messages += [
-            model_message_to_ui_message(_merged_final_output_request),
-            _output_ui_message,
-        ]
+        if not (self.conversation.messages and self.conversation.messages[-1].role == "user"):
+            self.conversation.messages += [
+                model_message_to_ui_message(_merged_final_output_request)
+            ]
+        self.conversation.messages += [_output_ui_message]
 
         final_output_json = json.loads(
             ModelMessagesTypeAdapter.dump_json(final_output).decode("utf-8")

--- a/src/backend/chat/tests/clients/pydantic_ai/test_stream_methods.py
+++ b/src/backend/chat/tests/clients/pydantic_ai/test_stream_methods.py
@@ -1,9 +1,12 @@
 """Unit tests for AIAgentService stream methods."""
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
+import httpx
 import pytest
 from asgiref.sync import sync_to_async
+from mistralai.client.errors import HTTPValidationError, HTTPValidationErrorData, SDKError
+from pydantic_ai.exceptions import ModelAPIError, ModelHTTPError
 
 from chat.ai_sdk_types import UIMessage
 from chat.clients.pydantic_ai import AIAgentService
@@ -11,6 +14,19 @@ from chat.factories import ChatConversationFactory
 from chat.vercel_ai_sdk.core import events_v4
 
 pytestmark = pytest.mark.django_db()
+
+
+class AsyncRaiseIterator:
+    """Async iterator that raises the given exception on the first iteration."""
+
+    def __init__(self, exc):
+        self.exc = exc
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        raise self.exc
 
 
 @pytest.fixture(autouse=True)
@@ -109,3 +125,229 @@ async def test_stream_data_async_formats_as_sdk_events(ui_messages):
             'd:{"finishReason":"stop","usage":{"promptTokens":120,"completionTokens":456,'
             '"co2Impact":0.0}}\n',
         ]
+
+
+@pytest.mark.asyncio
+async def test_stream_data_async_emits_model_busy_on_503():
+    """503 ModelHTTPError emits model_busy ErrorPart."""
+    conversation = await sync_to_async(ChatConversationFactory)()
+    service = AIAgentService(conversation, user=conversation.owner)
+
+    def mock_run_agent(*args, **kwargs):
+        return AsyncRaiseIterator(ModelHTTPError(status_code=503, model_name="test-model"))
+
+    with patch.object(service, "_run_agent", side_effect=mock_run_agent):
+        results = []
+        async for result in service.stream_data_async([]):
+            results.append(result)
+
+    assert results == ['3:"model_busy"\n']
+
+
+@pytest.mark.asyncio
+async def test_stream_data_async_emits_model_unavailable_on_5xx():
+    """Generic 5xx ModelHTTPError emits model_unavailable ErrorPart."""
+    conversation = await sync_to_async(ChatConversationFactory)()
+    service = AIAgentService(conversation, user=conversation.owner)
+
+    def mock_run_agent(*args, **kwargs):
+        return AsyncRaiseIterator(ModelHTTPError(status_code=500, model_name="test-model"))
+
+    with patch.object(service, "_run_agent", side_effect=mock_run_agent):
+        results = []
+        async for result in service.stream_data_async([]):
+            results.append(result)
+
+    assert results == ['3:"model_unavailable"\n']
+
+
+@pytest.mark.asyncio
+async def test_stream_data_async_emits_model_rate_limited_on_429():
+    """429 ModelHTTPError emits model_rate_limited ErrorPart."""
+    conversation = await sync_to_async(ChatConversationFactory)()
+    service = AIAgentService(conversation, user=conversation.owner)
+
+    def mock_run_agent(*args, **kwargs):
+        return AsyncRaiseIterator(ModelHTTPError(status_code=429, model_name="test-model"))
+
+    with patch.object(service, "_run_agent", side_effect=mock_run_agent):
+        results = []
+        async for result in service.stream_data_async([]):
+            results.append(result)
+
+    assert results == ['3:"model_rate_limited"\n']
+
+
+@pytest.mark.asyncio
+async def test_stream_data_async_emits_model_connection_error_on_api_error():
+    """ModelAPIError (e.g. connection refused) emits model_connection_error ErrorPart."""
+    conversation = await sync_to_async(ChatConversationFactory)()
+    service = AIAgentService(conversation, user=conversation.owner)
+
+    def mock_run_agent(*args, **kwargs):
+        return AsyncRaiseIterator(
+            ModelAPIError(model_name="test-model", message="Connection error.")
+        )
+
+    with patch.object(service, "_run_agent", side_effect=mock_run_agent):
+        results = []
+        async for result in service.stream_data_async([]):
+            results.append(result)
+
+    assert results == ['3:"model_connection_error"\n']
+
+
+@pytest.mark.asyncio
+async def test_stream_data_async_emits_model_busy_on_sdk_error_503():
+    """Mistral SDKError with 503 emits model_busy ErrorPart."""
+    conversation = await sync_to_async(ChatConversationFactory)()
+    service = AIAgentService(conversation, user=conversation.owner)
+
+    mock_response = MagicMock(spec=httpx.Response)
+    mock_response.status_code = 503
+    mock_response.text = ""
+    mock_response.headers = httpx.Headers()
+
+    def mock_run_agent(*args, **kwargs):
+        return AsyncRaiseIterator(
+            SDKError(message="service unavailable", raw_response=mock_response)
+        )
+
+    with patch.object(service, "_run_agent", side_effect=mock_run_agent):
+        results = []
+        async for result in service.stream_data_async([]):
+            results.append(result)
+
+    assert results == ['3:"model_busy"\n']
+
+
+@pytest.mark.asyncio
+async def test_stream_data_async_emits_model_wrong_type_on_http_validation_error_422():
+    """Mistral HTTPValidationError with 422 emits model_wrong_type ErrorPart."""
+    conversation = await sync_to_async(ChatConversationFactory)()
+    service = AIAgentService(conversation, user=conversation.owner)
+
+    mock_response = MagicMock(spec=httpx.Response)
+    mock_response.status_code = 422
+    mock_response.text = ""
+    mock_response.headers = httpx.Headers()
+
+    def mock_run_agent(*args, **kwargs):
+        return AsyncRaiseIterator(
+            HTTPValidationError(data=HTTPValidationErrorData(), raw_response=mock_response)
+        )
+
+    with patch.object(service, "_run_agent", side_effect=mock_run_agent):
+        results = []
+        async for result in service.stream_data_async([]):
+            results.append(result)
+
+    assert results == ['3:"model_wrong_type"\n']
+
+
+@pytest.mark.asyncio
+async def test_stream_data_async_reraises_unknown_exceptions():
+    """Unknown exceptions are not swallowed — they propagate."""
+    conversation = await sync_to_async(ChatConversationFactory)()
+    service = AIAgentService(conversation, user=conversation.owner)
+
+    def mock_run_agent(*args, **kwargs):
+        return AsyncRaiseIterator(ValueError("unexpected"))
+
+    with patch.object(service, "_run_agent", side_effect=mock_run_agent):
+        with pytest.raises(ValueError, match="unexpected"):
+            async for _ in service.stream_data_async([]):
+                pass
+
+
+@pytest.mark.asyncio
+async def test_stream_text_async_reraises_http_error():
+    """ModelHTTPError is re-raised on text protocol path
+    (encode_text returns None for ErrorPart)."""
+    conversation = await sync_to_async(ChatConversationFactory)()
+    service = AIAgentService(conversation, user=conversation.owner)
+
+    def mock_run_agent(*args, **kwargs):
+        return AsyncRaiseIterator(ModelHTTPError(status_code=503, model_name="test-model"))
+
+    with patch.object(service, "_run_agent", side_effect=mock_run_agent):
+        with pytest.raises(ModelHTTPError):
+            async for _ in service.stream_text_async([]):
+                pass
+
+
+@pytest.mark.asyncio
+async def test_stream_text_async_reraises_connection_error():
+    """ModelAPIError is re-raised on text protocol path (encode_text returns None for ErrorPart)."""
+    conversation = await sync_to_async(ChatConversationFactory)()
+    service = AIAgentService(conversation, user=conversation.owner)
+
+    def mock_run_agent(*args, **kwargs):
+        return AsyncRaiseIterator(
+            ModelAPIError(model_name="test-model", message="Connection error.")
+        )
+
+    with patch.object(service, "_run_agent", side_effect=mock_run_agent):
+        with pytest.raises(ModelAPIError):
+            async for _ in service.stream_text_async([]):
+                pass
+
+
+@pytest.mark.asyncio
+async def test_stream_data_async_persists_user_message_on_http_error(ui_messages):
+    """On LLM provider error, the user message is saved to conversation.messages."""
+    conversation = await sync_to_async(ChatConversationFactory)()
+    assert conversation.messages == []
+
+    service = AIAgentService(conversation, user=conversation.owner)
+
+    def mock_run_agent(*args, **kwargs):
+        return AsyncRaiseIterator(ModelHTTPError(status_code=503, model_name="test-model"))
+
+    with patch.object(service, "_run_agent", side_effect=mock_run_agent):
+        async for _ in service.stream_data_async(ui_messages):
+            pass
+
+    await sync_to_async(conversation.refresh_from_db)()
+    assert len(conversation.messages) == 1
+    assert conversation.messages[0].role == "user"
+    assert conversation.messages[0].id == ui_messages[0].id
+
+
+@pytest.mark.asyncio
+async def test_stream_data_async_persists_user_message_on_connection_error(ui_messages):
+    """On ModelAPIError, the user message is saved to conversation.messages."""
+    conversation = await sync_to_async(ChatConversationFactory)()
+    service = AIAgentService(conversation, user=conversation.owner)
+
+    def mock_run_agent(*args, **kwargs):
+        return AsyncRaiseIterator(
+            ModelAPIError(model_name="test-model", message="Connection error.")
+        )
+
+    with patch.object(service, "_run_agent", side_effect=mock_run_agent):
+        async for _ in service.stream_data_async(ui_messages):
+            pass
+
+    await sync_to_async(conversation.refresh_from_db)()
+    assert len(conversation.messages) == 1
+    assert conversation.messages[0].role == "user"
+
+
+@pytest.mark.asyncio
+async def test_stream_data_async_does_not_duplicate_user_message_on_repeated_error(ui_messages):
+    """Repeated errors with the same message do not accumulate duplicates."""
+    conversation = await sync_to_async(ChatConversationFactory)()
+    service = AIAgentService(conversation, user=conversation.owner)
+
+    def mock_run_agent(*args, **kwargs):
+        return AsyncRaiseIterator(ModelHTTPError(status_code=503, model_name="test-model"))
+
+    with patch.object(service, "_run_agent", side_effect=mock_run_agent):
+        async for _ in service.stream_data_async(ui_messages):
+            pass
+        async for _ in service.stream_data_async(ui_messages):
+            pass
+
+    await sync_to_async(conversation.refresh_from_db)()
+    assert len(conversation.messages) == 1

--- a/src/backend/chat/vercel_ai_sdk/encoder/encoder.py
+++ b/src/backend/chat/vercel_ai_sdk/encoder/encoder.py
@@ -66,6 +66,10 @@ class EventEncoder:
         Returns:
             str | None: The encoded event as a string,
             or None if the event type is not adapted to the SDK version.
+
+        Note: Only TextPart/TextDeltaEvent are handled. ErrorPart events are silently
+        dropped on the text protocol path — the `data` protocol (encode()) is the only
+        supported path for surfacing provider errors to the frontend.
         """
         if self.version == EventEncoderVersion.V4 and isinstance(event, TextPart):
             return event.text

--- a/src/backend/conversations/settings.py
+++ b/src/backend/conversations/settings.py
@@ -510,6 +510,8 @@ class Base(BraveSettings, Configuration):
         default=False, environ_name="POSTHOG_MW_CAPTURE_EXCEPTIONS", environ_prefix=None
     )
 
+    STATUS_PAGE_URL = values.Value(None, environ_name="STATUS_PAGE_URL", environ_prefix=None)
+
     # Easy thumbnails
     THUMBNAIL_EXTENSION = "webp"
     THUMBNAIL_TRANSPARENCY_EXTENSION = "webp"

--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -141,6 +141,7 @@ class ConfigView(drf.views.APIView):
         """
         array_settings = [
             "ACTIVATION_REQUIRED",
+            "STATUS_PAGE_URL",
             "ENVIRONMENT",
             "FRONTEND_CSS_URL",
             "FRONTEND_CONTACT_EMAIL",

--- a/src/backend/core/tests/test_api_config.py
+++ b/src/backend/core/tests/test_api_config.py
@@ -22,6 +22,7 @@ pytestmark = pytest.mark.django_db
 
 @override_settings(
     FRONTEND_CONTACT_EMAIL="contact@test.com",
+    STATUS_PAGE_URL="https://status.example.com",
     FRONTEND_CSS_URL="http://testcss/",
     FRONTEND_DOCUMENTATION_URL="http://testdocs/",
     FRONTEND_THEME="test-theme",
@@ -47,6 +48,7 @@ def test_api_config(is_authenticated):
     assert response.status_code == HTTP_200_OK
     assert response.json() == {
         "ACTIVATION_REQUIRED": False,
+        "STATUS_PAGE_URL": "https://status.example.com",
         "ENVIRONMENT": "test",
         "FEATURE_FLAGS": {"document-upload": "enabled", "web-search": "enabled"},
         "FILE_UPLOAD_MODE": "presigned_url",
@@ -181,6 +183,7 @@ def test_api_config_with_original_theme_customization(is_authenticated, settings
 
 @override_settings(
     FRONTEND_CONTACT_EMAIL="contact@test.com",
+    STATUS_PAGE_URL="https://status.example.com",
     FRONTEND_CSS_URL="http://testcss/",
     FRONTEND_DOCUMENTATION_URL="http://testdocs/",
     FRONTEND_THEME="test-theme",
@@ -207,6 +210,7 @@ async def test_api_config_async(is_authenticated):
     assert response.status_code == HTTP_200_OK
     assert response.json() == {
         "ACTIVATION_REQUIRED": False,
+        "STATUS_PAGE_URL": "https://status.example.com",
         "ENVIRONMENT": "test",
         "FEATURE_FLAGS": {"document-upload": "enabled", "web-search": "enabled"},
         "FILE_UPLOAD_MODE": "presigned_url",
@@ -234,6 +238,32 @@ async def test_api_config_async(is_authenticated):
         "status_banner": None,
         "maintenance": None,
     }
+
+
+@override_settings(
+    STATUS_PAGE_URL=None,
+    THEME_CUSTOMIZATION_FILE_PATH="",
+    RAG_FILES_ACCEPTED_FORMATS=["application/pdf"],
+)
+def test_api_config_albert_status_page_url_none():
+    """STATUS_PAGE_URL defaults to None and is included in config."""
+    client = APIClient()
+    response = client.get("/api/v1.0/config/")
+    assert response.status_code == HTTP_200_OK
+    assert response.json()["STATUS_PAGE_URL"] is None
+
+
+@override_settings(
+    STATUS_PAGE_URL="https://status.example.com",
+    THEME_CUSTOMIZATION_FILE_PATH="",
+    RAG_FILES_ACCEPTED_FORMATS=["application/pdf"],
+)
+def test_api_config_albert_status_page_url_set():
+    """STATUS_PAGE_URL is propagated to the config endpoint when set."""
+    client = APIClient()
+    response = client.get("/api/v1.0/config/")
+    assert response.status_code == HTTP_200_OK
+    assert response.json()["STATUS_PAGE_URL"] == "https://status.example.com"
 
 
 def _set_banner(**fields):

--- a/src/frontend/apps/conversations/src/core/config/api/useConfig.tsx
+++ b/src/frontend/apps/conversations/src/core/config/api/useConfig.tsx
@@ -35,6 +35,7 @@ export interface MaintenanceConfig {
 
 export interface ConfigResponse {
   ACTIVATION_REQUIRED: boolean;
+  STATUS_PAGE_URL?: string | null;
   ENVIRONMENT: string;
   FEATURE_FLAGS: FeatureFlags;
   FRONTEND_CSS_URL?: string;

--- a/src/frontend/apps/conversations/src/features/chat/components/Chat.tsx
+++ b/src/frontend/apps/conversations/src/features/chat/components/Chat.tsx
@@ -27,7 +27,7 @@ import {
   KEY_LIST_PROJECT,
   ProjectsResponse,
 } from '@/features/chat/api/useProjects';
-import { ChatError } from '@/features/chat/components/ChatError';
+import { ChatError, ChatErrorType } from '@/features/chat/components/ChatError';
 import { InputChat } from '@/features/chat/components/InputChat';
 import { MessageItem } from '@/features/chat/components/MessageItem';
 import { useClipboard } from '@/hook';
@@ -38,6 +38,15 @@ import { useAprilFools } from '../hooks/useAprilFools';
 import { useChatPreferencesStore } from '../stores/useChatPreferencesStore';
 import { usePendingChatStore } from '../stores/usePendingChatStore';
 import { useScrollStore } from '../stores/useScrollStore';
+
+const PROVIDER_ERROR_CODES = new Set<ChatErrorType>([
+  'model_unavailable',
+  'model_rate_limited',
+  'model_connection_error',
+  'model_not_found',
+  'model_wrong_type',
+  'model_busy',
+]);
 
 // Define Attachment type locally (mirroring backend structure)
 export interface Attachment {
@@ -122,6 +131,7 @@ export const Chat = ({
     title: string;
     message: React.ReactNode;
   } | null>(null);
+  const [chatErrorType, setChatErrorType] = useState<ChatErrorType>('generic');
 
   const { setIsAtTop } = useScrollStore();
 
@@ -214,7 +224,15 @@ export const Chat = ({
         title: t('Attachment summary not supported'),
         message: t('The summary feature is not supported yet.'),
       });
+      return;
     }
+
+    if (PROVIDER_ERROR_CODES.has(error.message as ChatErrorType)) {
+      setChatErrorType(error.message as ChatErrorType);
+    } else {
+      setChatErrorType('generic');
+    }
+
     console.error('Chat error:', error);
   };
 
@@ -724,6 +742,7 @@ export const Chat = ({
       options.experimental_attachments = attachments;
     }
 
+    setChatErrorType('generic');
     lastSubmissionRef.current = {
       input,
       files,
@@ -856,6 +875,7 @@ export const Chat = ({
         ) : null}
         {status === 'error' && !isUploadingFiles && (
           <ChatError
+            errorType={chatErrorType}
             hasLastSubmission={!!lastSubmissionRef.current}
             onRetry={handleRetry}
           />
@@ -890,6 +910,7 @@ export const Chat = ({
           selectedModel={selectedModel}
           onModelSelect={handleModelSelect}
           isUploadingFiles={isUploadingFiles}
+          errorType={status === 'error' ? chatErrorType : undefined}
         />
       </Box>
       <Modal

--- a/src/frontend/apps/conversations/src/features/chat/components/ChatError.tsx
+++ b/src/frontend/apps/conversations/src/features/chat/components/ChatError.tsx
@@ -3,15 +3,41 @@ import { useRouter } from 'next/router';
 import { useTranslation } from 'react-i18next';
 
 import { Box, Icon, Text } from '@/components';
+import { useConfig } from '@/core';
+
+import { getChatErrorMessage } from './chatErrorMessages';
+
+export type ChatErrorType =
+  | 'generic'
+  | 'model_unavailable'
+  | 'model_rate_limited'
+  | 'model_connection_error'
+  | 'model_not_found'
+  | 'model_wrong_type'
+  | 'model_busy';
 
 interface ChatErrorProps {
+  errorType: ChatErrorType;
   hasLastSubmission: boolean;
   onRetry: () => void;
 }
 
-export const ChatError = ({ hasLastSubmission, onRetry }: ChatErrorProps) => {
+export const ChatError = ({
+  errorType,
+  hasLastSubmission,
+  onRetry,
+}: ChatErrorProps) => {
   const { t } = useTranslation();
   const router = useRouter();
+  const { data: config } = useConfig();
+  const statusPageUrl = config?.STATUS_PAGE_URL;
+  const isProviderError = errorType !== 'generic';
+  const showStatusLink = new Set<ChatErrorType>([
+    'model_unavailable',
+    'model_rate_limited',
+    'model_connection_error',
+    'model_busy',
+  ]).has(errorType);
 
   return (
     <Box
@@ -22,16 +48,34 @@ export const ChatError = ({ hasLastSubmission, onRetry }: ChatErrorProps) => {
       $margin={{ all: 'auto', top: 'base', bottom: 'md' }}
       $padding={{ left: '13px' }}
     >
-      <Text $variation="550" $theme="greyscale">
-        {t('Sorry, an error occurred. Please try again.')}
-      </Text>
+      {isProviderError ? (
+        <Box $direction="row" $gap="12px" $align="center">
+          <Text $variation="700" $size="1.375rem" $theme="greyscale">
+            {getChatErrorMessage(t, errorType)}
+          </Text>
+          {statusPageUrl && showStatusLink && (
+            <a
+              href={statusPageUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label={t('Check service status')}
+            >
+              <Icon iconName="info" $size="1.375rem" $color="greyscale" />
+            </a>
+          )}
+        </Box>
+      ) : (
+        <Text $variation="550" $theme="greyscale">
+          {getChatErrorMessage(t, errorType)}
+        </Text>
+      )}
       <Box
         $direction="row"
         $gap="6px"
         $align="center"
         $margin={{ top: '10px' }}
       >
-        {hasLastSubmission ? (
+        {!isProviderError && (
           <Button
             size="nano"
             color="neutral"
@@ -54,7 +98,8 @@ export const ChatError = ({ hasLastSubmission, onRetry }: ChatErrorProps) => {
           >
             {t('Retry')}
           </Button>
-        ) : (
+        )}
+        {!isProviderError && !hasLastSubmission && (
           <Button
             size="nano"
             color="brand"

--- a/src/frontend/apps/conversations/src/features/chat/components/InputChat.tsx
+++ b/src/frontend/apps/conversations/src/features/chat/components/InputChat.tsx
@@ -5,6 +5,7 @@ import { Box, Text } from '@/components';
 import { useToast } from '@/components/ToastProvider';
 import { useConfig, useFeatureEnabled } from '@/core';
 import { LLMModel } from '@/features/chat/api/useLLMConfiguration';
+import { ChatErrorType } from '@/features/chat/components/ChatError';
 import { InputChatActions } from '@/features/chat/components/InputChatAction';
 import { ProjectWelcomeMessage } from '@/features/chat/components/ProjectWelcomeMessage';
 import { SuggestionCarousel } from '@/features/chat/components/SuggestionCarousel';
@@ -17,6 +18,14 @@ import FilesIcon from '../assets/files.svg';
 
 import { AttachmentList } from './AttachmentList';
 import { ScrollDown } from './ScrollDown';
+import { getChatErrorMessage } from './chatErrorMessages';
+
+const INPUT_ENABLED_STATUSES = [
+  'ready',
+  'streaming',
+  'submitted',
+  'error',
+] as const;
 
 interface InputChatProps {
   messagesLength: number;
@@ -34,6 +43,7 @@ interface InputChatProps {
   selectedModel?: LLMModel | null;
   onModelSelect?: (model: LLMModel) => void;
   isUploadingFiles?: boolean;
+  errorType?: ChatErrorType;
 }
 
 const STYLES = {
@@ -122,6 +132,7 @@ export const InputChat = ({
   selectedModel,
   onModelSelect,
   isUploadingFiles = false,
+  errorType,
 }: InputChatProps) => {
   const { t } = useTranslation();
   const { showToast } = useToast();
@@ -237,8 +248,16 @@ export const InputChat = ({
   });
 
   const isInputDisabled =
-    (status !== 'ready' && status !== 'streaming' && status !== 'submitted') ||
-    isUploadingFiles;
+    !INPUT_ENABLED_STATUSES.includes(
+      status as (typeof INPUT_ENABLED_STATUSES)[number],
+    ) ||
+    isUploadingFiles ||
+    (!!errorType && errorType !== 'generic');
+
+  const textareaPlaceholder =
+    errorType && errorType !== 'generic'
+      ? getChatErrorMessage(t, errorType)
+      : undefined;
 
   const containerCss = useMemo(
     () => `
@@ -248,13 +267,10 @@ export const InputChat = ({
     [isDesktop],
   );
 
-  const textareaStyle = useMemo(
-    () => ({
-      ...TEXTAREA_STYLE,
-      opacity: status === 'error' ? '0.5' : '1',
-    }),
-    [status],
-  );
+  const textareaStyle = {
+    ...TEXTAREA_STYLE,
+    opacity: '1',
+  };
 
   const formPadding = isDesktop ? STYLES.formPadding : STYLES.formPaddingMobile;
 
@@ -430,6 +446,7 @@ export const InputChat = ({
               <textarea
                 ref={textareaRef}
                 aria-label={t('Enter your message or a question')}
+                placeholder={textareaPlaceholder}
                 value={input ?? ''}
                 name="inputchat-textarea"
                 onChange={handleTextareaChange}
@@ -440,7 +457,9 @@ export const InputChat = ({
                 style={textareaStyle}
               />
 
-              {!input && <SuggestionCarousel messagesLength={messagesLength} />}
+              {!input && !textareaPlaceholder && (
+                <SuggestionCarousel messagesLength={messagesLength} />
+              )}
 
               <input
                 accept={conf?.chat_upload_accept}

--- a/src/frontend/apps/conversations/src/features/chat/components/InputChatAction.tsx
+++ b/src/frontend/apps/conversations/src/features/chat/components/InputChatAction.tsx
@@ -47,6 +47,8 @@ const MOBILE_WEB_BUTTON_CSS = `
   }
 `;
 
+const ACTIONS_OPACITY_CSS = 'opacity: 1;';
+
 const ACTIVE_WEB_BUTTON_CSS = `
   .research-web-button {
     background-color: var(--c--contextuals--background--semantic--brand--secondary) !important;
@@ -96,12 +98,6 @@ export const InputChatActions = memo(
   }: InputChatActionsProps) => {
     const { t } = useTranslation();
 
-    // Memoized dynamic styles
-    const actionsOpacityCss = useMemo(
-      () => `opacity: ${status === 'error' ? '0.5' : '1'};`,
-      [status],
-    );
-
     const webSearchWrapperCss = useMemo(() => {
       let css = '';
       if (isMobile) {
@@ -119,7 +115,7 @@ export const InputChatActions = memo(
         $gap="sm"
         $padding={STYLES.actionsGap}
         $align="space-between"
-        $css={actionsOpacityCss}
+        $css={ACTIONS_OPACITY_CSS}
       >
         {/* Left side: Attach + Web Search */}
         <Box

--- a/src/frontend/apps/conversations/src/features/chat/components/__tests__/ChatError.test.tsx
+++ b/src/frontend/apps/conversations/src/features/chat/components/__tests__/ChatError.test.tsx
@@ -1,0 +1,135 @@
+import { render, screen } from '@testing-library/react';
+
+import '@/i18n/initI18n';
+import { AppWrapper } from '@/tests/utils';
+
+import { ChatError } from '../ChatError';
+
+let mockStatusPageUrl: string | undefined = 'https://status.example.com';
+
+jest.mock('next/router', () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+jest.mock('@/core', () => ({
+  useConfig: () => ({
+    data: { STATUS_PAGE_URL: mockStatusPageUrl },
+  }),
+}));
+
+describe('ChatError', () => {
+  beforeEach(() => {
+    mockStatusPageUrl = 'https://status.example.com';
+  });
+  it('renders generic error with retry button when errorType is generic and has last submission', () => {
+    render(
+      <ChatError
+        errorType="generic"
+        hasLastSubmission={true}
+        onRetry={jest.fn()}
+      />,
+      { wrapper: AppWrapper },
+    );
+    expect(
+      screen.getByText('Sorry, an error occurred. Please try again.'),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument();
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+
+  it('renders generic error with new conversation button when no last submission', () => {
+    render(
+      <ChatError
+        errorType="generic"
+        hasLastSubmission={false}
+        onRetry={jest.fn()}
+      />,
+      { wrapper: AppWrapper },
+    );
+    expect(
+      screen.getByText('Sorry, an error occurred. Please try again.'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /start a new conversation/i }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+
+  it('renders model_unavailable message and status page link', () => {
+    render(
+      <ChatError
+        errorType="model_unavailable"
+        hasLastSubmission={false}
+        onRetry={jest.fn()}
+      />,
+      { wrapper: AppWrapper },
+    );
+    expect(
+      screen.getByText(
+        'The AI inference provider is temporarily unavailable. Please try again later.',
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /retry/i }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole('link')).toHaveAttribute('href', mockStatusPageUrl);
+  });
+
+  it('renders model_rate_limited message and status page link', () => {
+    render(
+      <ChatError
+        errorType="model_rate_limited"
+        hasLastSubmission={false}
+        onRetry={jest.fn()}
+      />,
+      { wrapper: AppWrapper },
+    );
+    expect(
+      screen.getByText(
+        'The AI inference provider is overloaded. Please try again in a few minutes.',
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /retry/i }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole('link')).toHaveAttribute('href', mockStatusPageUrl);
+  });
+
+  it('renders model_connection_error message and status page link', () => {
+    render(
+      <ChatError
+        errorType="model_connection_error"
+        hasLastSubmission={false}
+        onRetry={jest.fn()}
+      />,
+      { wrapper: AppWrapper },
+    );
+    expect(
+      screen.getByText(
+        'Unable to reach the AI inference provider. Please try again later.',
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /retry/i }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole('link')).toHaveAttribute('href', mockStatusPageUrl);
+  });
+
+  it('renders provider error without status link when statusPageUrl is not configured', () => {
+    mockStatusPageUrl = undefined;
+    render(
+      <ChatError
+        errorType="model_unavailable"
+        hasLastSubmission={false}
+        onRetry={jest.fn()}
+      />,
+      { wrapper: AppWrapper },
+    );
+    expect(
+      screen.getByText(
+        'The AI inference provider is temporarily unavailable. Please try again later.',
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+});

--- a/src/frontend/apps/conversations/src/features/chat/components/__tests__/InputChat.test.tsx
+++ b/src/frontend/apps/conversations/src/features/chat/components/__tests__/InputChat.test.tsx
@@ -145,14 +145,14 @@ describe('InputChat', () => {
     expect(handleInputChange).toHaveBeenCalled();
   });
 
-  it('should disable textarea when status is error', () => {
+  it('should keep textarea enabled when status is error', () => {
     render(<InputChat {...defaultProps} status="error" />, {
       wrapper: AppWrapper,
     });
 
     expect(
       screen.getByRole('textbox', { name: 'Enter your message or a question' }),
-    ).toBeDisabled();
+    ).toBeEnabled();
   });
 
   it('should keep textarea enabled when status is streaming', () => {

--- a/src/frontend/apps/conversations/src/features/chat/components/chatErrorMessages.ts
+++ b/src/frontend/apps/conversations/src/features/chat/components/chatErrorMessages.ts
@@ -1,0 +1,31 @@
+import { TFunction } from 'i18next';
+
+import { ChatErrorType } from './ChatError';
+
+export const getChatErrorMessage = (
+  t: TFunction,
+  errorType: ChatErrorType,
+): string => {
+  const messages: Record<ChatErrorType, string> = {
+    generic: t('Sorry, an error occurred. Please try again.'),
+    model_unavailable: t(
+      'The AI inference provider is temporarily unavailable. Please try again later.',
+    ),
+    model_rate_limited: t(
+      'The AI inference provider is overloaded. Please try again in a few minutes.',
+    ),
+    model_connection_error: t(
+      'Unable to reach the AI inference provider. Please try again later.',
+    ),
+    model_not_found: t(
+      'We encountered an internal error. Our team has been alerted. Please try again later.',
+    ),
+    model_wrong_type: t(
+      'We encountered an internal error. Our team has been alerted. Please try again later.',
+    ),
+    model_busy: t(
+      'The AI inference provider is too busy. Please try again later.',
+    ),
+  };
+  return messages[errorType];
+};

--- a/src/frontend/apps/e2e/__tests__/app-conversations/common.ts
+++ b/src/frontend/apps/e2e/__tests__/app-conversations/common.ts
@@ -26,6 +26,7 @@ export const CONFIG = {
   LANGUAGE_CODE: 'en-us',
   POSTHOG_KEY: {},
   SENTRY_DSN: null,
+  STATUS_PAGE_URL: null,
   theme_customization: {},
   chat_upload_accept:
     'application/vnd.openxmlformats-officedocument.wordprocessingml.document,' +

--- a/src/frontend/apps/e2e/__tests__/app-conversations/home.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-conversations/home.spec.ts
@@ -8,6 +8,7 @@ test.beforeEach(async ({ page }) => {
 
 test.describe('Home page', () => {
   test.use({ storageState: { cookies: [], origins: [] } });
+
   test('checks all the elements are visible', async ({ page }) => {
     await page.goto('/home/');
 


### PR DESCRIPTION
## Purpose

When an LLM provider is temporarily down, rate-limited, or unreachable, users  currently see a generic error with no context. This PR surfaces specific, actionable   error messages so users understand what happened and where to check for status  updates.

##  Proposal

 ### Backend 

- Catch ModelHTTPError (429 → model_rate_limited, 5xx → model_unavailable)   and ModelAPIError (→ model_connection_error) in the streaming layer and emit typed  error codes to the frontend instead of crashing silently. 
- Expose  ALBERT_STATUS_PAGE_URL through the existing /api/v1.0/config/ endpoint so the  frontend can link to the operator's status page.
 ### Frontend 

- Replace the generic error display with a ChatError component that shows   a message tailored to the error type. 

### UX
- Re-enable the message input during error and streaming states so users can  type their next message without having to reload.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Categorized provider error handling with optional “service status” link surfaced in the UI.

* **Improvements**
  * Error UI varies by error type and hides action buttons for provider-specific errors.
  * Input and suggestion UI reflect provider error states (provider-specific placeholders; input disabled for provider errors).
  * Config API exposes a STATUS_PAGE_URL to control the status link.

* **Documentation**
  * Added end-to-end error mapping and guidance for provider failures.

* **Tests**
  * Added/updated unit and e2e tests covering error rendering and config exposure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/suitenumerique/conversations/pull/495?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->