### PR TITLE
🔒️(front) disable yarn install scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [unreleased] - 2026-05-21
+
+### Changed
+
+- 🔒️(front) disable yarn install scripts in docker build
+
 ## [0.0.16] - 2026-05-21
 
 ### Added

--- a/src/frontend/.yarnrc
+++ b/src/frontend/.yarnrc
@@ -1,0 +1,1 @@
+ignore-scripts true

--- a/src/frontend/Dockerfile
+++ b/src/frontend/Dockerfile
@@ -9,6 +9,7 @@ WORKDIR /home/frontend/
 
 COPY ./src/frontend/package.json ./package.json
 COPY ./src/frontend/yarn.lock ./yarn.lock
+COPY ./src/frontend/.yarnrc ./.yarnrc
 COPY ./src/frontend/apps/conversations/package.json ./apps/conversations/package.json
 COPY ./src/frontend/packages/eslint-config-conversations/package.json ./packages/eslint-config-conversations/package.json
 

--- a/src/mail/.yarnrc
+++ b/src/mail/.yarnrc
@@ -1,0 +1,1 @@
+ignore-scripts true


### PR DESCRIPTION
Postinstall scripts deactivated for security purpose

## Purpose

  Harden the frontend Docker build by disabling yarn's post-install scripts,  so  compromised transitive dependencies cannot execute arbitrary code during yarn install.

 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an unreleased changelog entry noting build behavior.

* **Chores**
  * Build configurations updated so package-install scripts are ignored during Docker image builds for frontend and mail components.
  * Frontend build now includes the updated package manager config in the dependency stage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/suitenumerique/conversations/pull/497?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->