### PR TITLE
🚸(back) improve chat admin filtering and display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to
 
 - 🔒️(front) disable yarn install scripts in docker build
 - ⬆️(dependencies) update back and front dependencies
+- 🚸(back) improve chat admin filtering, search and display columns
 
 ### Fixed
 

--- a/src/backend/chat/admin.py
+++ b/src/backend/chat/admin.py
@@ -9,16 +9,23 @@ from . import models
 class ChatConversationAdmin(admin.ModelAdmin):
     """Admin class for the ChatConversation model"""
 
-    search_fields = ("id", "title", "owner__email", "owner__sub")
+    search_fields = ("id", "title", "owner__email", "owner__sub", "project__title")
     ordering = ("-updated_at",)
+    date_hierarchy = "created_at"
 
     autocomplete_fields = ("owner", "project")
-    list_select_related = ("project",)
+    list_select_related = ("owner", "project")
+    list_filter = (
+        ("project", admin.EmptyFieldListFilter),
+        ("collection_id", admin.EmptyFieldListFilter),
+    )
 
     list_display = (
         "id",
         "title",
+        "owner",
         "project",
+        "collection_id",
         "created_at",
         "updated_at",
     )
@@ -29,33 +36,54 @@ class ChatConversationAttachmentAdmin(admin.ModelAdmin):
     """Admin class for the ChatConversationAttachment model"""
 
     search_fields = (
+        "id",
         "conversation__id",
         "project__id",
         "file_name",
+        "key",
+        "rag_document_id",
+        "uploaded_by__email",
     )
     ordering = ("-created_at",)
+    date_hierarchy = "created_at"
     list_per_page = 50
     show_full_result_count = False
     readonly_fields = ("content_type", "upload_state", "size")
     list_display = (
         "id",
         "file_name",
+        "scope",
         "content_type",
         "upload_state",
         "size",
         "conversation",
         "project",
         "uploaded_by",
+        "rag_document_id",
+        "conversion_from",
         "created_at",
         "updated_at",
     )
     autocomplete_fields = ("conversation", "project", "uploaded_by")
-    list_filter = ("content_type",)
+    list_filter = (
+        "content_type",
+        ("rag_document_id", admin.EmptyFieldListFilter),
+        ("conversion_from", admin.EmptyFieldListFilter),
+    )
     list_select_related = (
         "conversation",
         "project",
         "uploaded_by",
     )
+
+    @admin.display(description="Scope")
+    def scope(self, obj):
+        """Show whether the attachment is owned by a conversation or a project."""
+        if obj.conversation_id:
+            return "conversation"
+        if obj.project_id:
+            return "project"
+        return "-"
 
 
 @admin.register(models.ChatProject)
@@ -64,6 +92,7 @@ class ChatProjectAdmin(admin.ModelAdmin):
 
     search_fields = ("id", "title")
     ordering = ("-updated_at",)
+    date_hierarchy = "created_at"
     list_filter = ("color", "icon")
     autocomplete_fields = ("owner",)
     list_select_related = ("owner",)
@@ -71,6 +100,7 @@ class ChatProjectAdmin(admin.ModelAdmin):
         "id",
         "title",
         "owner",
+        "collection_id",
         "icon",
         "color",
         "created_at",


### PR DESCRIPTION
 ## Purpose

  Make the Django admin more usable for inspecting chat conversations,  attachments and projects - faster lookup, better filtering, and more  visible context columns.

  ## Proposal

- [ ] Improve the conversation admin with broader search, a date      hierarchy, and filters for unassigned records
- [ ] Improve the attachment admin with broader search, a date      hierarchy, filters, and a column showing whether each attachment      belongs to a conversation or a project
- [ ] Improve the project admin with a date hierarchy and extra context

https://github.com/orgs/suitenumerique/projects/13/views/3?filterQuery=&pane=issue&itemId=195079022&issue=suitenumerique%7Cconversations%7C524

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated changelog reflecting admin interface enhancements

* **New Features**
  * Enhanced chat admin interface with expanded search functionality across conversations and attachments
  * Improved filtering with additional filter options for projects, collections, and attachment sources
  * Extended display columns to include owner, collection ID, and attachment scope information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->