### PR TITLE
🧱(helm) bump chart to v0.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,13 @@ and this project adheres to
 
 ### Added
 
-## [0.0.17] - 2026-06-02
-
 - ✨(back) add cron job to poll Albert models health
+
+### Changed
+
+- 🧱(helm) bump chart to v0.0.6
+
+## [0.0.17] - 2026-06-02
 
 ### Added
 

--- a/src/helm/conversations/Chart.yaml
+++ b/src/helm/conversations/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 type: application
 name: conversations
-version:  0.0.5
+version:  0.0.6
 appVersion: latest


### PR DESCRIPTION
Publishes the model-health CronJob template, absent from the 0.0.5
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a scheduled cron task that periodically polls Albert model health.

* **Chores**
  * Updated Helm chart version to v0.0.6.
  * Updated CHANGELOG with unreleased and 0.0.17 entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->