### PR TITLE
🐛(helm) stop job pods from matching the backend disruption budget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to
 
 - 🧱(helm) bump chart to v0.0.6
 
+### Fixed
+
+- 🐛(helm) stop job pods from matching the backend disruption budget
+
 ## [0.0.17] - 2026-06-02
 
 ### Added

--- a/src/helm/conversations/Chart.yaml
+++ b/src/helm/conversations/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 type: application
 name: conversations
-version:  0.0.6
+version:  0.0.7
 appVersion: latest

--- a/src/helm/conversations/templates/backend_cronjob_model_health.yaml
+++ b/src/helm/conversations/templates/backend_cronjob_model_health.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.backend.modelHealthCronJob.enabled -}}
 {{- $envVars := include "conversations.common.env" (list . .Values.backend) -}}
 {{- $fullName := include "conversations.backend.fullname" . -}}
-{{- $component := "backend" -}}
+{{- $component := "backend-model-health" -}}
 apiVersion: batch/v1
 kind: CronJob
 metadata:

--- a/src/helm/conversations/templates/backend_job_createsuperuser.yaml
+++ b/src/helm/conversations/templates/backend_job_createsuperuser.yaml
@@ -1,6 +1,6 @@
 {{- $envVars := include "conversations.common.env" (list . .Values.backend) -}}
 {{- $fullName := include "conversations.backend.fullname" . -}}
-{{- $component := "backend" -}}
+{{- $component := "backend-createsuperuser" -}}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/src/helm/conversations/templates/backend_job_migrate.yaml
+++ b/src/helm/conversations/templates/backend_job_migrate.yaml
@@ -1,6 +1,6 @@
 {{- $envVars := include "conversations.common.env" (list . .Values.backend) -}}
 {{- $fullName := include "conversations.backend.fullname" . -}}
-{{- $component := "backend" -}}
+{{- $component := "backend-migrate" -}}
 apiVersion: batch/v1
 kind: Job
 metadata:


### PR DESCRIPTION
  ## Purpose

  The backend PodDisruptionBudget reports a sync error
  (CalculateExpectedPodCountFailed) because short-lived job pods are
  incorrectly covered by the budget meant for the long-lived backend
  deployment. A disruption budget cannot derive an expected pod count from
  jobs, so the resource fails in ArgoCD.

  ## Proposal

- [ ] Give the migrate, createsuperuser and model-health workloads their  own component identity so they are no longer selected by the  backend  disruption budget or the backend service.
- [ ] Keep the backend deployment identity unchanged so the budget and        service continue to protect and route to the real backend pods  only.
- [ ] Bump the Helm chart version so the fix is published and can be   rolled out.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Helm configuration and job labels to prevent job pods from incorrectly matching the backend disruption budget, ensuring better pod isolation and stability during deployments.

* **Chores**
  * Bumped Helm chart version to 0.0.7.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->