### PR TITLE
✨(backend) add sliding window history processor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to
 - ✨(back) add cron job to poll Albert models health
 - ✨(back) de-index inactive collections and reindex in conversation
 - ✨(back) rate-limit chat with a model-health-aware token cooldown
+- ✨(backend) add sliding window history processor
 
 ### Changed
 

--- a/docs/history-processor.md
+++ b/docs/history-processor.md
@@ -1,0 +1,85 @@
+# History Processor (Sliding Window)
+
+When a conversation grows long enough to exceed the model's context window, the backend automatically trims the oldest turns before each agent call. The full history is always preserved in the database — only the slice sent to the model is reduced.
+
+## How it works
+
+Before each agent call, `apply_sliding_window` checks whether the estimated token count of the history exceeds the conversation budget. If it does, it removes the oldest complete turns one by one until the history fits, then passes the trimmed slice to the model.
+
+A **turn** is the unit of trimming: a user message plus all the model responses and tool call/return pairs that follow it, up to the next user message. Turns are never split — either the whole turn is kept or the whole turn is dropped.
+
+The last turn is always kept, even if it alone exceeds the budget. This guarantees the current user message is never lost.
+
+```text
+Full history:   [turn 1] [turn 2] [turn 3] [turn 4]  ← exceeds budget
+After trim:                        [turn 3] [turn 4]  ← fits within budget
+Database:       [turn 1] [turn 2] [turn 3] [turn 4]  ← untouched
+```
+
+When trimming occurs, the backend emits a `context_trimmed` SSE event and the frontend displays a notice (session-only — resets on page reload):
+
+> *Some older messages are no longer in the model's context.*
+
+## Configuration
+
+Trimming is enabled by setting `max_token_context` on a model in the LLM configuration file:
+
+```json
+{
+  "hrid": "default-model",
+  "max_token_context": 128000,
+  ...
+}
+```
+
+If `max_token_context` is absent or `null` on the model configuration, it falls back to the `DEFAULT_MAX_TOKEN_CONTEXT` setting (default 8192). Set `DEFAULT_MAX_TOKEN_CONTEXT=0` in settings to disable trimming for models without an explicit context limit.
+
+### Misconfiguration warning
+
+If the computed conversation budget is 0 (e.g. `DOCUMENT_CONTEXT_SECURITY_BUFFER_TOKENS` exceeds the available tokens, or `DOCUMENT_CONTEXT_BUDGET_RATIO` is 1.0), trimming is disabled and the backend logs a warning:
+
+```
+Sliding window disabled: conversation budget is 0
+(max_token_context=N, security_buffer=M, budget_ratio=R).
+```
+
+### Budget formula
+
+The conversation budget is derived from two Django settings:
+
+| Setting | Description | Default |
+|---|---|---|
+| `DOCUMENT_CONTEXT_SECURITY_BUFFER_TOKENS` | Tokens reserved as a safety margin per pool | `1000` |
+| `DOCUMENT_CONTEXT_BUDGET_RATIO` | Fraction of the usable window allocated to documents | `0.5` |
+
+```text
+conversation_budget = int(max_token_context × (1 - DOCUMENT_CONTEXT_BUDGET_RATIO)) - DOCUMENT_CONTEXT_SECURITY_BUFFER_TOKENS
+```
+
+The security buffer is subtracted from **both** the conversation pool and the document pool independently — each pool's token count is approximated, so each pool needs its own safety margin.
+
+For example, with `max_token_context=128000`, `DOCUMENT_CONTEXT_SECURITY_BUFFER_TOKENS=1000`, and `DOCUMENT_CONTEXT_BUDGET_RATIO=0.3`:
+
+```
+conversation_budget = int(128000 × 0.7) - 1000 = 88600 tokens
+```
+
+## Token estimation
+
+Tokens are estimated without calling the model's tokenizer, using tiktoken (`cl100k_base`). This is intentionally rough — the goal is to stay well within the context limit, not to maximise usage. Each message also carries a small fixed overhead (4 tokens per part + 4 per message) to account for role markers and formatting.
+
+**Images** are counted using a flat constant of 1 500 tokens per image part (`ImageUrl` or `BinaryContent` with an `image/*` MIME type). Precise estimation is model-specific (OpenAI uses tile math, Anthropic uses a different formula), so a conservative constant keeps the estimator model-agnostic.
+
+**System prompt** tokens are subtracted from the conversation budget at calculation time using the static `configuration.system_prompt` string. Dynamic content injected at runtime (e.g. inlined document context) is not counted here — the security buffer absorbs that drift.
+
+**Agent instructions** (tool schemas, pydantic-ai framework overhead) are not counted. The security buffer is the backstop.
+
+## Local testing
+
+To trigger trimming locally, set a small `max_token_context` on the default model:
+
+```json
+"max_token_context": 500
+```
+
+After ~10 short messages the banner should appear and the chat should continue to work normally.

--- a/src/backend/chat/agents/history_processors.py
+++ b/src/backend/chat/agents/history_processors.py
@@ -1,0 +1,136 @@
+"""Sliding window history processor for LLM conversation context management."""
+
+import logging
+
+from django.conf import settings
+
+from pydantic_ai import ImageUrl
+from pydantic_ai.messages import BinaryContent, ModelMessage, ModelRequest, UserPromptPart
+
+from chat.tokens import (
+    compute_conversation_budget as _compute_conversation_budget,
+)
+from chat.tokens import (
+    count_approx_tokens,
+)
+
+# Conservative flat estimate per image part. Precise estimation is model-specific
+# so a constant keeps the estimator model-agnostic
+# while ensuring we never silently under-count images.
+_IMAGE_TOKEN_ESTIMATE = 1500
+
+logger = logging.getLogger(__name__)
+
+
+def _stringify_message_content(content) -> str:
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, (list, tuple)):
+        return " ".join(_stringify_message_content(c) for c in content)
+    if hasattr(content, "content"):
+        return _stringify_message_content(content.content)
+    if hasattr(content, "text"):
+        return _stringify_message_content(content.text)
+    return ""
+
+
+def _estimate_message_tokens(message: ModelMessage) -> int:
+    parts = getattr(message, "parts", []) or []
+    if not parts:
+        return 0
+    part_tokens = 0
+    for part in parts:
+        content = getattr(part, "content", "")
+        if isinstance(content, (list, tuple)):
+            for item in content:
+                if isinstance(item, ImageUrl):
+                    part_tokens += _IMAGE_TOKEN_ESTIMATE
+                elif isinstance(item, BinaryContent) and item.media_type.startswith("image/"):
+                    part_tokens += _IMAGE_TOKEN_ESTIMATE
+                else:
+                    text = _stringify_message_content(item).strip()
+                    if text:
+                        part_tokens += count_approx_tokens(text)
+        else:
+            text = _stringify_message_content(content).strip()
+            if text:
+                part_tokens += count_approx_tokens(text)
+        args = getattr(part, "args", "")
+        if isinstance(args, dict):
+            part_tokens += count_approx_tokens(str(args))
+        elif isinstance(args, str) and args.strip():
+            part_tokens += count_approx_tokens(args)
+    # Estimated overhead: ~4 tokens per part + ~4 tokens for message wrapper
+    return part_tokens + (4 * len(parts)) + 4
+
+
+def estimate_history_tokens(history: list[ModelMessage]) -> int:
+    """Return the approximate token count for a list of messages."""
+    return sum(_estimate_message_tokens(m) for m in history)
+
+
+def _group_into_turns(history: list[ModelMessage]) -> list[list[ModelMessage]]:
+    turns: list[list[ModelMessage]] = []
+    current_turn: list[ModelMessage] = []
+    for message in history:
+        is_user_turn_start = isinstance(message, ModelRequest) and any(
+            isinstance(p, UserPromptPart) for p in message.parts
+        )
+        if is_user_turn_start and current_turn:
+            turns.append(current_turn)
+            current_turn = []
+        current_turn.append(message)
+    if current_turn:
+        turns.append(current_turn)
+    return turns
+
+
+def resolve_conversation_budget(configuration) -> int:
+    """Return the token budget for conversation history given an LLM configuration."""
+    max_token_context = getattr(configuration, "max_token_context", None)
+    if max_token_context is None:
+        max_token_context = settings.DEFAULT_MAX_TOKEN_CONTEXT
+    security_buffer = settings.DOCUMENT_CONTEXT_SECURITY_BUFFER_TOKENS
+    budget_ratio = settings.DOCUMENT_CONTEXT_BUDGET_RATIO
+    system_prompt = getattr(configuration, "system_prompt", None)
+    system_prompt_tokens = count_approx_tokens(system_prompt) if system_prompt else 0
+    conversation_budget = max(
+        _compute_conversation_budget(max_token_context, budget_ratio, security_buffer)
+        - system_prompt_tokens,
+        0,
+    )
+    if conversation_budget == 0 and max_token_context > 0:
+        logger.warning(
+            "Sliding window disabled: conversation budget is 0 "
+            "(max_token_context=%d, security_buffer=%d, budget_ratio=%.2f).",
+            max_token_context,
+            security_buffer,
+            budget_ratio,
+        )
+    return conversation_budget
+
+
+def apply_sliding_window(
+    history: list[ModelMessage],
+    conversation_budget: int,
+) -> tuple[list[ModelMessage], bool]:
+    """Drop oldest turns until history fits within conversation_budget tokens.
+
+    Returns the (possibly trimmed) history and a flag indicating whether trimming occurred.
+    """
+    if conversation_budget == 0 or not history:
+        return history, False
+    if estimate_history_tokens(history) <= conversation_budget:
+        return history, False
+    turns = _group_into_turns(history)
+    was_trimmed = False
+    # len(turns) > 1 guarantees we never drop the last turn (the current exchange)
+    while (
+        len(turns) > 1
+        and estimate_history_tokens([m for t in turns for m in t]) > conversation_budget
+    ):
+        turns.pop(0)
+        was_trimmed = True
+    return [m for turn in turns for m in turn], was_trimmed

--- a/src/backend/chat/clients/pydantic_ai.py
+++ b/src/backend/chat/clients/pydantic_ai.py
@@ -130,6 +130,7 @@ from core.feature_flags.helpers import is_feature_enabled
 
 from chat import models
 from chat.agents.conversation import ConversationAgent, TitleGenerationAgent
+from chat.agents.history_processors import apply_sliding_window, resolve_conversation_budget
 from chat.agents.local_media_url_processors import (
     build_project_image_urls,
     update_history_local_urls,
@@ -1321,6 +1322,10 @@ class AIAgentService:  # pylint: disable=too-many-instance-attributes
             conversation_has_own_documents,
         ) = await self._prepare_agent_run(messages)
 
+        history, was_trimmed = apply_sliding_window(
+            history, resolve_conversation_budget(self.conversation_agent.configuration)
+        )
+
         # Re-index (or report busy) when the conversation has READY attachments and
         # its index is not current. INDEXING is included: reindex_conversation handles
         # the concurrent-claim case by yielding a busy error when it cannot claim the row.
@@ -1361,6 +1366,9 @@ class AIAgentService:  # pylint: disable=too-many-instance-attributes
 
         if doc_result is None or not doc_result.success:
             return
+
+        if was_trimmed:
+            yield events_v4.DataPart(data=[{"type": "context_trimmed"}])
 
         conversation_has_own_documents = doc_result.has_documents
 

--- a/src/backend/chat/document_context_builder.py
+++ b/src/backend/chat/document_context_builder.py
@@ -2,7 +2,6 @@
 
 import asyncio
 import dataclasses
-import functools
 import json
 import logging
 from collections import deque
@@ -10,35 +9,13 @@ from typing import Literal, Sequence
 
 from django.core.files.storage import default_storage
 
-import tiktoken
 from asgiref.sync import sync_to_async
 
 from chat import models
 from chat.constants import ACCESS_FULL_CONTEXT, ACCESS_TOOL_CALL_ONLY
+from chat.tokens import compute_document_budget, count_approx_tokens
 
 logger = logging.getLogger(__name__)
-
-
-@functools.lru_cache(maxsize=1)
-def _get_token_encoding():
-    """Lazily load and cache the tiktoken encoding."""
-    return tiktoken.get_encoding("cl100k_base")
-
-
-def count_approx_tokens(text: str) -> int:
-    """Estimate token count using tiktoken."""
-    if not text:
-        return 0
-    try:
-        tiktoken_len = len(_get_token_encoding().encode(text))
-        logger.debug("Tiktoken length: %s", tiktoken_len)
-        return tiktoken_len
-    except Exception:  # pylint: disable=broad-except #noqa: BLE001
-        logger.warning("Failed to estimate tokens with tiktoken, falling back to heuristic.")
-        non_space_chars = len("".join(text.split()))
-        if non_space_chars == 0:
-            return 0
-        return non_space_chars // 3 + (1 if non_space_chars % 3 else 0)
 
 
 @sync_to_async
@@ -327,7 +304,9 @@ async def build_documents_listing(  # noqa: PLR0913 # pylint: disable=too-many-a
             project_docs=project_docs,
         )
 
-    document_budget = max(int(max_token_context * budget_ratio) - security_buffer_tokens, 0)
+    document_budget = compute_document_budget(
+        max_token_context, budget_ratio, security_buffer_tokens
+    )
 
     async def _load_document(
         index: int, attachment: models.ChatConversationAttachment

--- a/src/backend/chat/tests/agents/test_history_processors.py
+++ b/src/backend/chat/tests/agents/test_history_processors.py
@@ -1,0 +1,291 @@
+"""Tests for chat.agents.history_processors."""
+
+import logging
+
+from django.test import override_settings
+
+from pydantic_ai import ImageUrl
+from pydantic_ai.messages import (
+    BinaryContent,
+    ModelRequest,
+    ModelResponse,
+    TextPart,
+    ToolCallPart,
+    ToolReturnPart,
+    UserPromptPart,
+)
+
+from chat.agents.history_processors import (
+    _IMAGE_TOKEN_ESTIMATE,
+    _estimate_message_tokens,
+    _group_into_turns,
+    _stringify_message_content,
+    apply_sliding_window,
+    estimate_history_tokens,
+    resolve_conversation_budget,
+)
+from chat.tokens import count_approx_tokens
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+
+def user_msg(text: str) -> ModelRequest:
+    """Build a minimal user ModelRequest."""
+    return ModelRequest(parts=[UserPromptPart(content=text)], kind="request")
+
+
+def assistant_msg(text: str) -> ModelResponse:
+    """Build a minimal assistant ModelResponse."""
+    return ModelResponse(parts=[TextPart(content=text)], kind="response")
+
+
+def tool_call_msg(tool_call_id: str = "tc1") -> ModelResponse:
+    """Build a ModelResponse containing a single tool call."""
+    return ModelResponse(
+        parts=[ToolCallPart(tool_name="web_search", tool_call_id=tool_call_id, args="{}")],
+        kind="response",
+    )
+
+
+def tool_return_msg(tool_call_id: str = "tc1") -> ModelRequest:
+    """Build a ModelRequest containing a single tool return."""
+    return ModelRequest(
+        parts=[ToolReturnPart(tool_name="web_search", tool_call_id=tool_call_id, content="result")],
+        kind="request",
+    )
+
+
+# ── _estimate_message_tokens ─────────────────────────────────────────────────
+
+
+def test_estimate_message_tokens_empty_parts():
+    """Messages with no parts return 0 tokens."""
+    msg = ModelRequest(parts=[], kind="request")
+    assert _estimate_message_tokens(msg) == 0
+
+
+def test_estimate_message_tokens_tool_call():
+    """ToolCallPart with args='{}' accounts for arg tokens plus per-message overhead."""
+    # args="{}" → tiktoken("{}")=1 token; overhead: 4*1+4=8 → total 9
+    msg = tool_call_msg()
+    assert _estimate_message_tokens(msg) == 9
+
+
+def test_estimate_message_tokens_image_url_adds_constant():
+    """An ImageUrl part adds the flat IMAGE_TOKEN_ESTIMATE constant."""
+    msg = ModelRequest(
+        parts=[UserPromptPart(content=[ImageUrl(url="https://example.com/photo.jpg")])],
+        kind="request",
+    )
+    # overhead: 4*1 parts + 4 message = 8
+    assert _estimate_message_tokens(msg) == _IMAGE_TOKEN_ESTIMATE + 8
+
+
+def test_estimate_message_tokens_binary_image_adds_constant():
+    """A BinaryContent image part adds the flat IMAGE_TOKEN_ESTIMATE constant."""
+    msg = ModelRequest(
+        parts=[UserPromptPart(content=[BinaryContent(data=b"\x89PNG", media_type="image/png")])],
+        kind="request",
+    )
+    assert _estimate_message_tokens(msg) == _IMAGE_TOKEN_ESTIMATE + 8
+
+
+# ── estimate_history_tokens ───────────────────────────────────────────────────
+
+
+def test_estimate_history_tokens_empty():
+    """Empty history returns 0 tokens."""
+    assert estimate_history_tokens([]) == 0
+
+
+def test_estimate_history_tokens_two_messages():
+    """Token count for a user+assistant exchange matches the sum of individual estimates."""
+    history = [user_msg("hello world"), assistant_msg("hello world")]
+    assert estimate_history_tokens(history) == 24
+
+
+# ── _group_into_turns ─────────────────────────────────────────────────────────
+
+
+def test_group_into_turns_single_turn():
+    """A single user+assistant exchange forms one turn."""
+    history = [user_msg("hi"), assistant_msg("hello")]
+    turns = _group_into_turns(history)
+    assert len(turns) == 1
+    assert turns[0] == history
+
+
+def test_group_into_turns_two_turns():
+    """Two user+assistant exchanges form two turns."""
+    h = [user_msg("q1"), assistant_msg("a1"), user_msg("q2"), assistant_msg("a2")]
+    turns = _group_into_turns(h)
+    assert len(turns) == 2
+    assert turns[0] == [h[0], h[1]]
+    assert turns[1] == [h[2], h[3]]
+
+
+def test_group_into_turns_tool_calls_stay_in_same_turn():
+    """Tool call/return messages stay grouped with the user turn that triggered them."""
+    h = [
+        user_msg("search this"),
+        tool_call_msg(),
+        tool_return_msg(),
+        assistant_msg("found it"),
+        user_msg("thanks"),
+        assistant_msg("welcome"),
+    ]
+    turns = _group_into_turns(h)
+    assert len(turns) == 2
+    assert turns[0] == h[:4]
+    assert turns[1] == h[4:]
+
+
+def test_group_into_turns_empty():
+    """Empty history produces no turns."""
+    assert not _group_into_turns([])
+
+
+# ── apply_sliding_window ──────────────────────────────────────────────────────
+
+
+def test_apply_sliding_window_no_trim_needed():
+    """History within budget is returned unchanged with trimmed=False."""
+    history = [user_msg("hi"), assistant_msg("hello")]
+    result, trimmed = apply_sliding_window(history, 10_000)
+    assert result == history
+    assert trimmed is False
+
+
+def test_apply_sliding_window_budget_zero_disables():
+    """Budget of 0 disables trimming regardless of history size."""
+    history = [user_msg("a" * 4000), assistant_msg("b" * 4000)]
+    result, trimmed = apply_sliding_window(history, 0)
+    assert result == history
+    assert trimmed is False
+
+
+def test_apply_sliding_window_trims_oldest_turn():
+    """Oldest turn is evicted when total history exceeds budget."""
+    # old_turn: user("a"*400)+assistant("b"*400) ≈ 216 tokens
+    # new_turn: user("c"*400)+assistant("d"*400) ≈ 216 tokens
+    # total ≈ 432 tokens; budget=250 → old_turn evicted
+    old_turn = [user_msg("a" * 400), assistant_msg("b" * 400)]
+    new_turn = [user_msg("c" * 400), assistant_msg("d" * 400)]
+    result, trimmed = apply_sliding_window(old_turn + new_turn, 250)
+    assert trimmed is True
+    assert result == new_turn
+
+
+def test_apply_sliding_window_keeps_last_turn_even_if_too_big():
+    """A single oversized turn is kept as-is; trimmed remains False."""
+    big_turn = [user_msg("a" * 4000), assistant_msg("b" * 4000)]
+    result, trimmed = apply_sliding_window(big_turn, 100)
+    assert result == big_turn
+    assert trimmed is False
+
+
+# ── resolve_conversation_budget ───────────────────────────────────────────────
+
+
+@override_settings(
+    DEFAULT_MAX_TOKEN_CONTEXT=8192,
+    DOCUMENT_CONTEXT_SECURITY_BUFFER_TOKENS=1000,
+    DOCUMENT_CONTEXT_BUDGET_RATIO=0.5,
+)
+def test_resolve_conversation_budget_no_max_context_uses_default():
+    """Models without max_token_context fall back to DEFAULT_MAX_TOKEN_CONTEXT."""
+
+    class Cfg:  # pylint: disable=missing-class-docstring
+        max_token_context = None
+
+    # int(8192*0.5)-1000=3096
+    assert resolve_conversation_budget(Cfg()) == 3096
+
+
+def test_resolve_conversation_budget_zero_max_context():
+    """max_token_context=0 returns 0 (trimming disabled)."""
+
+    class Cfg:  # pylint: disable=missing-class-docstring
+        max_token_context = 0
+
+    assert resolve_conversation_budget(Cfg()) == 0
+
+
+@override_settings(
+    DOCUMENT_CONTEXT_SECURITY_BUFFER_TOKENS=1000,
+    DOCUMENT_CONTEXT_BUDGET_RATIO=0.5,
+)
+def test_resolve_conversation_budget_formula():
+    """Budget is computed as int(max*(1-ratio))-buffer."""
+
+    class Cfg:  # pylint: disable=missing-class-docstring
+        max_token_context = 10_000
+
+    # int(10000*0.5)-1000=4000
+    assert resolve_conversation_budget(Cfg()) == 4000
+
+
+@override_settings(
+    DOCUMENT_CONTEXT_SECURITY_BUFFER_TOKENS=0,
+    DOCUMENT_CONTEXT_BUDGET_RATIO=0.0,
+)
+def test_resolve_conversation_budget_zero_ratio():
+    """budget_ratio=0 allocates the full context window to conversation."""
+
+    class Cfg:  # pylint: disable=missing-class-docstring
+        max_token_context = 10_000
+
+    assert resolve_conversation_budget(Cfg()) == 10_000
+
+
+@override_settings(DOCUMENT_CONTEXT_SECURITY_BUFFER_TOKENS=10_000)
+def test_resolve_conversation_budget_logs_warning_when_buffer_exceeds_context(caplog):
+    """A warning is logged when the security buffer leaves no tokens for conversation."""
+
+    class Cfg:  # pylint: disable=missing-class-docstring
+        max_token_context = 5_000
+
+    with caplog.at_level(logging.WARNING, logger="chat.agents.history_processors"):
+        result = resolve_conversation_budget(Cfg())
+
+    assert result == 0
+    assert "Sliding window disabled" in caplog.text
+
+
+@override_settings(
+    DOCUMENT_CONTEXT_SECURITY_BUFFER_TOKENS=0,
+    DOCUMENT_CONTEXT_BUDGET_RATIO=0.0,
+)
+def test_resolve_conversation_budget_deducts_system_prompt():
+    """System prompt tokens are subtracted from the conversation budget."""
+    system_prompt = "You are a helpful assistant."
+
+    class CfgNoPrompt:  # pylint: disable=missing-class-docstring
+        max_token_context = 10_000
+        system_prompt = None
+
+    class CfgWithPrompt:  # pylint: disable=missing-class-docstring
+        max_token_context = 10_000
+        system_prompt = "You are a helpful assistant."
+
+    budget_without = resolve_conversation_budget(CfgNoPrompt())
+    budget_with = resolve_conversation_budget(CfgWithPrompt())
+    assert budget_with == budget_without - count_approx_tokens(system_prompt)
+
+
+# ── _stringify_message_content ───────────────────────────────────────────────
+
+
+def test_stringify_none_returns_empty():
+    """None content stringifies to empty string."""
+    assert _stringify_message_content(None) == ""
+
+
+def test_stringify_str_returns_same():
+    """String content is returned unchanged."""
+    assert _stringify_message_content("hello") == "hello"
+
+
+def test_stringify_list_joins():
+    """List content items are joined with a space."""
+    assert _stringify_message_content(["a", "b"]) == "a b"

--- a/src/backend/chat/tests/clients/pydantic_ai/test_langfuse_tracing.py
+++ b/src/backend/chat/tests/clients/pydantic_ai/test_langfuse_tracing.py
@@ -41,6 +41,15 @@ def base_settings(settings):
     settings.AI_AGENT_TOOLS = []
 
 
+@pytest.fixture(autouse=True)
+def mock_token_counter(monkeypatch):
+    """Prevent tiktoken from making network calls during sliding window token estimation."""
+    monkeypatch.setattr(
+        "chat.agents.history_processors.count_approx_tokens",
+        lambda _text: 10,
+    )
+
+
 @pytest.fixture(name="ui_messages")
 def ui_messages_fixture():
     """Fixture for test UI messages."""
@@ -68,7 +77,10 @@ def agent_model_fixture():
 @pytest.mark.asyncio
 @responses.activate
 async def test_langfuse_span_created_when_enabled_and_analytics_allowed(
-    agent_model, ui_messages, settings, langfuse_client
+    agent_model,
+    ui_messages,
+    settings,
+    langfuse_client,
 ):
     """Test Langfuse span is created when enabled and user allows analytics."""
     settings.LANGFUSE_ENABLED = True
@@ -109,7 +121,10 @@ async def test_langfuse_span_created_when_enabled_and_analytics_allowed(
 @pytest.mark.asyncio
 @responses.activate
 async def test_langfuse_span_created_when_enabled_and_analytics_disabled(
-    agent_model, ui_messages, settings, langfuse_client
+    agent_model,
+    ui_messages,
+    settings,
+    langfuse_client,
 ):
     """Test Langfuse span is created even when user disallows analytics."""
     settings.LANGFUSE_ENABLED = True

--- a/src/backend/chat/tests/test_ai_agent_service_co2.py
+++ b/src/backend/chat/tests/test_ai_agent_service_co2.py
@@ -154,6 +154,7 @@ async def test_finalize_emits_finish_message_with_co2(service, co2_impact):
         patch.object(service, "_agent_stop_streaming", new=AsyncMock()),
         patch.object(service, "_prepare_update_conversation"),
         patch("chat.clients.pydantic_ai.sync_to_async", side_effect=_fake_sync_to_async),
+        patch("chat.clients.pydantic_ai.record_and_compute_cooldown", return_value=0),
     ):
         events = [
             event

--- a/src/backend/chat/tokens.py
+++ b/src/backend/chat/tokens.py
@@ -1,0 +1,41 @@
+"""Token counting and budget utilities shared across chat modules."""
+
+import functools
+import logging
+
+import tiktoken
+
+logger = logging.getLogger(__name__)
+
+
+@functools.lru_cache(maxsize=1)
+def _get_token_encoding():
+    return tiktoken.get_encoding("cl100k_base")
+
+
+def count_approx_tokens(text: str) -> int:
+    """Estimate token count using tiktoken."""
+    if not text:
+        return 0
+    try:
+        return len(_get_token_encoding().encode(text))
+    except Exception:  # pylint: disable=broad-except #noqa: BLE001
+        logger.warning("Failed to estimate tokens with tiktoken, falling back to heuristic.")
+        non_space_chars = len("".join(text.split()))
+        if non_space_chars == 0:
+            return 0
+        return (non_space_chars + 2) // 3
+
+
+def compute_document_budget(
+    max_token_context: int, budget_ratio: float, security_buffer: int
+) -> int:
+    """Return the token budget for document inlining."""
+    return max(int(max_token_context * budget_ratio) - security_buffer, 0)
+
+
+def compute_conversation_budget(
+    max_token_context: int, budget_ratio: float, security_buffer: int
+) -> int:
+    """Return the token budget for conversation history."""
+    return max(int(max_token_context * (1 - budget_ratio)) - security_buffer, 0)

--- a/src/backend/conversations/settings.py
+++ b/src/backend/conversations/settings.py
@@ -962,6 +962,15 @@ USER QUESTION:
         environ_name="DOCUMENT_CONTEXT_SECURITY_BUFFER_TOKENS",
         environ_prefix=None,
     )
+    # Fallback context window for models that don't declare max_token_context.
+    # 8192 is the smallest modern standard (GPT-4 base, Llama 3, Gemma); after
+    # applying security buffer and budget ratio the conversation budget lands at
+    # ~3 600 tokens, safely within even a genuine 4K-context model.
+    DEFAULT_MAX_TOKEN_CONTEXT = values.PositiveIntegerValue(
+        default=8192,
+        environ_name="DEFAULT_MAX_TOKEN_CONTEXT",
+        environ_prefix=None,
+    )
 
     # Tavily API
     TAVILY_API_KEY = values.Value(

--- a/src/backend/core/tests/conftest.py
+++ b/src/backend/core/tests/conftest.py
@@ -7,5 +7,7 @@ import pytest
 
 @pytest.fixture(autouse=True)
 def clear_cache():
-    """Fixture to clear the cache before each test."""
+    """Fixture to clear the cache before and after each test."""
+    cache.clear()
+    yield
     cache.clear()

--- a/src/frontend/apps/conversations/src/features/chat/api/useChat.tsx
+++ b/src/frontend/apps/conversations/src/features/chat/api/useChat.tsx
@@ -86,6 +86,21 @@ async function fetchChatCooldown(): Promise<{ cooldown_seconds: number }> {
   return response.json() as Promise<{ cooldown_seconds: number }>;
 }
 
+interface ContextTrimmedEvent {
+  type: 'context_trimmed';
+}
+
+export function isContextTrimmedEvent(
+  item: unknown,
+): item is ContextTrimmedEvent {
+  return (
+    typeof item === 'object' &&
+    item !== null &&
+    'type' in item &&
+    item.type === 'context_trimmed'
+  );
+}
+
 export function useChat(options: Omit<UseChatOptions, 'fetch'>) {
   const queryClient = useQueryClient();
 

--- a/src/frontend/apps/conversations/src/features/chat/components/Chat.tsx
+++ b/src/frontend/apps/conversations/src/features/chat/components/Chat.tsx
@@ -16,7 +16,7 @@ import { useTranslation } from 'react-i18next';
 import { APIError, errorCauses, fetchAPI } from '@/api';
 import { Box, Loader, Text } from '@/components';
 import { useUploadFile } from '@/features/attachments/hooks/useUploadFile';
-import { useChat } from '@/features/chat/api/useChat';
+import { isContextTrimmedEvent, useChat } from '@/features/chat/api/useChat';
 import { getConversation } from '@/features/chat/api/useConversation';
 import { useCreateChatConversation } from '@/features/chat/api/useCreateConversation';
 import {
@@ -183,6 +183,7 @@ export const Chat = ({
   const { mutate: createChatConversation } = useCreateChatConversation();
   const queryClient = useQueryClient();
   const [isReadingInstructions, setIsReadingInstructions] = useState(false);
+  const [contextTrimmed, setContextTrimmed] = useState(false);
   const readingInstructionsStartRef = useRef<number>(0);
   const aprilFools = useAprilFools();
 
@@ -245,6 +246,7 @@ export const Chat = ({
     stop: stopChat,
     setMessages,
     cooldownUntil,
+    data,
   } = useChat({
     id: conversationId,
     initialMessages: initialConversationMessages,
@@ -586,6 +588,17 @@ export const Chat = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [shouldRetry, input, files]);
 
+  useEffect(() => {
+    setContextTrimmed(false);
+  }, [conversationId]);
+
+  useEffect(() => {
+    if (!data || !Array.isArray(data)) return;
+    if (data.some(isContextTrimmedEvent)) {
+      setContextTrimmed(true);
+    }
+  }, [data]);
+
   // Fetch initial conversation messages if initialConversationId is provided and no pending input
   useEffect(() => {
     hasScrolledToBottomOnLoadRef.current = false; // Réinitialiser au début du chargement
@@ -851,6 +864,21 @@ export const Chat = ({
                 </React.Fragment>
               );
             })}
+          </Box>
+        )}
+        {contextTrimmed && (
+          <Box
+            $direction="row"
+            $align="center"
+            $gap="6px"
+            $width="100%"
+            $maxWidth="var(--chat-content-max-width, 750px)"
+            $margin={{ all: 'auto' }}
+            $padding={{ left: '13px', top: 'xs', bottom: 'xs' }}
+          >
+            <Text $theme="neutral" $variation="tertiary" $size="sm">
+              {t("Some older messages are no longer in the model's context.")}
+            </Text>
           </Box>
         )}
         {!aprilFools.isActive &&

--- a/src/frontend/apps/e2e/__tests__/app-conversations/home.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-conversations/home.spec.ts
@@ -8,7 +8,6 @@ test.beforeEach(async ({ page }) => {
 
 test.describe('Home page', () => {
   test.use({ storageState: { cookies: [], origins: [] } });
-
   test('checks all the elements are visible', async ({ page }) => {
     await page.goto('/home/');
 


### PR DESCRIPTION
## Purpose

  Long conversations can exceed the model's context window and cause agent calls to fail. This PR implements a sliding window mechanism that  automatically trims the oldest turns from history before each agent call, keeping the conversation within budget without losing any data in the  database.

  ## Proposal

  - [x] Add `chat/agents/history_processors.py` — pure-function module with token estimation, turn grouping, and sliding window logic (TDD, 24 tests)
  - [x] Wire `apply_sliding_window` into `_run_agent()` in `pydantic_ai.py` — trims history in-memory before the agent call, emits a `context_trimmed` SSE event when trimming occurs (only after document parsing succeeds)
  - [x] Frontend banner in `Chat.tsx` — shows a persistent notice when the backend signals that older messages were dropped from context; resets on  conversation change
  - [x] Log a warning when `DOCUMENT_CONTEXT_SECURITY_BUFFER_TOKENS >= max_token_context` — misconfiguration that would silently disable trimming is now surfaced in logs
  - [x] Add `docs/history-processor.md` — documents the trimming behaviour, budget formula, misconfiguration warning, and local testing instructions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Conversation sliding-window trimming: older whole turns removed (never split), always keep last turn; emits a streamed "context_trimmed" event and shows a session-only banner; full history retained in DB.

* **Documentation**
  * Expanded docs on trimming behavior, token estimation, budget configuration, and local testing.

* **Tests**
  * Added unit tests for token counting, turn grouping, budget computation, and trimming behavior.

* **Chores**
  * Added default max-context setting and shared token/budget utilities; updated changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->