### PR TITLE
🐛(front) use the browser language for the default UI on first load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to
 ### Fixed
 
 - 🐛(helm) stop job pods from matching the backend disruption budget
+- 🐛(front) use the browser language for the default UI on first load
 
 ## [0.0.17] - 2026-06-02
 

--- a/src/frontend/apps/conversations/src/core/config/ConfigProvider.tsx
+++ b/src/frontend/apps/conversations/src/core/config/ConfigProvider.tsx
@@ -34,8 +34,7 @@ export const ConfigProvider = ({ children }: PropsWithChildren) => {
       return;
     }
 
-    const targetLanguage =
-      conf.LANGUAGE_CODE || i18n.resolvedLanguage || i18n.language;
+    const targetLanguage = i18n.resolvedLanguage || i18n.language;
 
     void changeLanguageSynchronized(targetLanguage).then(() => {
       hasSyncedInitialLanguage.current = true;

--- a/src/frontend/apps/conversations/src/core/config/__tests__/ConfigProvider.test.tsx
+++ b/src/frontend/apps/conversations/src/core/config/__tests__/ConfigProvider.test.tsx
@@ -1,0 +1,62 @@
+import { render, waitFor } from '@testing-library/react';
+import i18n from 'i18next';
+
+import { AppWrapper } from '@/tests/utils';
+
+import { ConfigProvider } from '../ConfigProvider';
+import { useConfig } from '../api/useConfig';
+
+jest.mock('../api/useConfig', () => ({
+  ...jest.requireActual('../api/useConfig'),
+  useConfig: jest.fn(),
+}));
+
+jest.mock('@/features/auth', () => ({
+  ...jest.requireActual('@/features/auth'),
+  useAuthQuery: jest.fn(() => ({ data: undefined })),
+}));
+
+const mockUseConfig = useConfig as jest.Mock;
+
+const makeConfig = (overrides: Record<string, unknown> = {}) => ({
+  data: {
+    LANGUAGES: [
+      ['en-us', 'English'],
+      ['fr-fr', 'Français'],
+      ['de-de', 'Deutsch'],
+    ],
+    LANGUAGE_CODE: 'en-us',
+    ...overrides,
+  },
+});
+
+describe('ConfigProvider - initial language', () => {
+  beforeEach(() => {
+    mockUseConfig.mockReset();
+  });
+
+  // First-time visitors have no saved preference: the UI must follow the
+  // browser-detected language (resolved by i18next), not the instance's
+  // LANGUAGE_CODE, which defaults to Django's "en-us".
+  it('keeps the browser-detected language over the instance LANGUAGE_CODE', async () => {
+    await i18n.changeLanguage('fr');
+    mockUseConfig.mockReturnValue(makeConfig({ LANGUAGE_CODE: 'en-us' }));
+
+    render(<ConfigProvider>app</ConfigProvider>, { wrapper: AppWrapper });
+
+    await waitFor(() => expect(i18n.resolvedLanguage).toBe('fr'));
+  });
+
+  it('follows a non-French browser language over the instance default', async () => {
+    await i18n.changeLanguage('de');
+    const changeLanguageSpy = jest.spyOn(i18n, 'changeLanguage');
+    mockUseConfig.mockReturnValue(makeConfig({ LANGUAGE_CODE: 'fr-fr' }));
+
+    render(<ConfigProvider>app</ConfigProvider>, { wrapper: AppWrapper });
+
+    await waitFor(() => expect(i18n.resolvedLanguage).toBe('de'));
+    // The instance default must never pull the UI away from the browser.
+    expect(changeLanguageSpy).not.toHaveBeenCalledWith('fr');
+    changeLanguageSpy.mockRestore();
+  });
+});

--- a/src/frontend/apps/conversations/src/features/chat/components/Chat.tsx
+++ b/src/frontend/apps/conversations/src/features/chat/components/Chat.tsx
@@ -492,7 +492,6 @@ export const Chat = ({
         }
       });
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [messages]);
 
   // Synchronize conversationId state with prop when it changes (e.g., after navigation)


### PR DESCRIPTION
##  Purpose

  First-time visitors always landed on an English interface, even when their  browser was set to another language. The efault interface language should  follow the visitor browser, not be forced to a fixed value.

 ##  Proposal

  - On first load, derive the interface language from the browser detection  instead of the instance default, so a visitor with no saved preference sees  the UI in their own language.
  - A signed-in user saved language preference continues to take precedence.
  -  The backend default language is left untouched, so the assistant response  language and server-side locale are unaffected.
  - Add tests covering the first-load language selection to guard against the  instance default overriding browser detection again.


https://github.com/orgs/suitenumerique/projects/13/views/3?filterQuery=&pane=issue&itemId=198328014&issue=suitenumerique%7Cconversations%7C536


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Respect browser language preference for the default UI on first load instead of always using a configured default.

* **Tests**
  * Added tests to confirm browser-detected language is applied on initial visits.

* **Chores**
  * Removed an unnecessary linter suppression comment.

* **Documentation**
  * Updated changelog to note the language preference fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->