### PR TITLE
🐛(oidc) fix access-denied redirect leaking internal port

### DIFF
--- a/src/backend/core/authentication/views.py
+++ b/src/backend/core/authentication/views.py
@@ -9,7 +9,11 @@ from lasuite.oidc_login.views import (
 from core.authentication.backends import OIDCRoleAccessDenied
 
 # Frontend path shown to users whose account is not allowed to access the app.
-ACCESS_DENIED_PATH = "/unauthorized"
+# Keep the trailing slash: the frontend is a Next.js static export with
+# trailingSlash=true, so the canonical URL is /unauthorized/. Redirecting to the
+# bare path makes the frontend nginx issue a directory redirect that leaks its
+# internal listen port (e.g. :8080) and breaks behind the TLS ingress.
+ACCESS_DENIED_PATH = "/unauthorized/"
 
 
 class OIDCAuthenticationCallbackView(LaSuiteOIDCAuthenticationCallbackView):

--- a/src/backend/core/tests/authentication/test_views.py
+++ b/src/backend/core/tests/authentication/test_views.py
@@ -1,0 +1,35 @@
+"""Unit tests for the authentication callback view."""
+
+from django.http import HttpResponseRedirect
+from django.test.utils import override_settings
+
+from core.authentication import views
+from core.authentication.backends import OIDCRoleAccessDenied
+from core.authentication.views import OIDCAuthenticationCallbackView
+
+
+@override_settings(LOGIN_REDIRECT_URL_FAILURE="https://example.com")
+def test_callback_redirects_denied_user_to_unauthorized_page(rf, monkeypatch):
+    """A role-denied user is redirected to the frontend access-denied page.
+
+    The target must keep its trailing slash: the frontend is a Next.js static
+    export with trailingSlash=true, so /unauthorized/ is the canonical URL. A
+    bare /unauthorized would make the frontend nginx issue a directory redirect
+    that leaks its internal port and breaks behind the TLS ingress.
+    """
+
+    def raise_denied(self, request):  # pylint: disable=unused-argument
+        raise OIDCRoleAccessDenied("denied")
+
+    monkeypatch.setattr(views.LaSuiteOIDCAuthenticationCallbackView, "get", raise_denied)
+
+    view = OIDCAuthenticationCallbackView()
+    request = rf.get("/oidc/callback/")
+    request.session = {}
+    view.request = request
+
+    response = view.get(request)
+
+    assert isinstance(response, HttpResponseRedirect)
+    assert response.status_code == 302
+    assert response.url == "https://example.com/unauthorized/"

--- a/src/frontend/apps/conversations/conf/default.conf
+++ b/src/frontend/apps/conversations/conf/default.conf
@@ -3,6 +3,11 @@ server {
   listen 3000;
   server_name localhost;
 
+  # Emit relative Location headers on directory redirects. Behind the TLS
+  # ingress, absolute redirects would otherwise leak nginx's own scheme/port
+  # (e.g. http://host:8080/), which is unreachable publicly.
+  absolute_redirect off;
+
   root /usr/share/nginx/html;
 
   location / {


### PR DESCRIPTION
  ## Purpose

  Users denied by the OIDC role gate were not reaching the access-denied
  page. Instead the redirect bounced them to an internal port that is not
  reachable behind the TLS ingress, so the browser hung or timed out
  rather than showing why access was refused.

  ## Proposal

  - [ ] Redirect denied users to the canonical access-denied URL so the frontend serves the page directly with no further redirect.
  - [ ] Harden the frontend web server so its redirects preserve the public scheme and host instead of exposing the internal port.
  - [ ] Add a test covering the access-denied redirect target.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure authorization-denied redirects include a trailing slash so users land on the correct unauthorized page.
  * Prevent exposure of internal server scheme/port by emitting relative Location headers for directory redirects behind a proxy.

* **Tests**
  * Added a unit test verifying denied OIDC callbacks redirect to the configured unauthorized URL (including trailing slash).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->