### PR TITLE
🔖(minor) bump release to 0.0.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [unreleased]
+## [0.0.18] - 2026-06-12
 
 ### Added
 
@@ -346,7 +346,8 @@ and this project adheres to
 - ✨(onboarding) add activation code logic for launch #62
 - 💄(chat) add code highlighting for LLM responses #67
 
-[unreleased]: https://github.com/suitenumerique/conversations/compare/v0.0.17...main
+[unreleased]: https://github.com/suitenumerique/conversations/compare/v0.0.18...main
+[0.0.18]: https://github.com/suitenumerique/conversations/releases/v0.0.18
 [0.0.17]: https://github.com/suitenumerique/conversations/releases/v0.0.17
 [0.0.16]: https://github.com/suitenumerique/conversations/releases/v0.0.16
 [0.0.15]: https://github.com/suitenumerique/conversations/releases/v0.0.15

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "conversations"
-version = "0.0.16"
+version = "0.0.18"
 authors = [{ "name" = "DINUM", "email" = "dev@mail.numerique.gouv.fr" }]
 classifiers = [
     "Development Status :: 5 - Production/Stable",

--- a/src/backend/uv.lock
+++ b/src/backend/uv.lock
@@ -12,7 +12,7 @@ required-markers = [
 ]
 
 [options]
-exclude-newer = "2026-05-21T08:32:35.937709Z"
+exclude-newer = "2026-06-05T09:21:59.98999Z"
 exclude-newer-span = "P7D"
 
 [manifest]
@@ -462,7 +462,7 @@ wheels = [
 
 [[package]]
 name = "conversations"
-version = "0.0.16"
+version = "0.0.18"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },

--- a/src/frontend/apps/conversations/package.json
+++ b/src/frontend/apps/conversations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app-conversations",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/frontend/apps/e2e/package.json
+++ b/src/frontend/apps/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app-e2e",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "private": true,
   "scripts": {
     "lint": "eslint .",

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "conversations",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "private": true,
   "workspaces": {
     "packages": [

--- a/src/frontend/packages/eslint-config-conversations/package.json
+++ b/src/frontend/packages/eslint-config-conversations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-conversations",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "license": "MIT",
   "scripts": {
     "lint": "eslint ."

--- a/src/frontend/packages/i18n/package.json
+++ b/src/frontend/packages/i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "packages-i18n",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "private": true,
   "scripts": {
     "extract-translation": "yarn extract-translation:conversations",

--- a/src/mail/package.json
+++ b/src/mail/package.json
@@ -18,5 +18,5 @@
   "repository": "https://github.com/numerique-gouv/conversations",
   "author": "DINUM",
   "license": "MIT",
-  "version": "0.0.17"
+  "version": "0.0.18"
 }


### PR DESCRIPTION
Added

- ✨(back) add cron job to poll Albert models health
- ✨(back) de-index inactive collections and reindex in conversation
- ✨(back) rate-limit chat with a model-health-aware token cooldown
- ✨(backend) add sliding window history processor
- ✨(banner) add dynamic health banners

Changed

- 🧱(helm) bump chart to v0.0.6
- 🚸(front) replace help button with a dropdown menu
- 🔒️(back) restrict sign-in to users with an allowed OIDC role
- ♻️(back) rename model health status "orange" to "yellow"

Fixed

- 🐛(helm) stop job pods from matching the backend disruption budget
- 🐛(front) use the browser language for the default UI on first load
- 💄(settings modal) updated the settings modal size



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.0.18 across all packages and modules.
  * Changelog updated with a new v0.0.18 release entry dated 2026-06-12 and adjusted comparison links.
  * Package metadata across frontend, backend, mail, and tooling packages synchronized to the new version to ensure consistent releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->