### PR TITLE
 🚸(chat) surface max attachment size on upload failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to
 - 🚸(front) replace help button with a dropdown menu
 - 🔒️(back) restrict sign-in to users with an allowed OIDC role
 - ♻️(back) rename model health status "orange" to "yellow"
+- 🚸(front) explain the attachment size limit when an upload fails
 
 ### Fixed
 

--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -170,6 +170,7 @@ class ConfigView(drf.views.APIView):
         dict_settings["chat_upload_accept"] = ",".join(settings.RAG_FILES_ACCEPTED_FORMATS)
         dict_settings["project_files_max_count"] = settings.PROJECT_FILES_MAX_COUNT
         dict_settings["project_images_max_count"] = settings.PROJECT_IMAGES_MAX_COUNT
+        dict_settings["attachment_max_size"] = settings.ATTACHMENT_MAX_SIZE // (1024 * 1024)
 
         dict_settings["status_banner"] = self._get_banner()
         dict_settings["maintenance"] = self._get_maintenance()

--- a/src/backend/core/tests/test_api_config.py
+++ b/src/backend/core/tests/test_api_config.py
@@ -73,6 +73,7 @@ def test_api_config(is_authenticated):
         "chat_upload_accept": "application/pdf,text/plain",
         "project_files_max_count": 10,
         "project_images_max_count": 3,
+        "attachment_max_size": 10,
         "status_banner": None,
         "maintenance": None,
     }
@@ -235,6 +236,7 @@ async def test_api_config_async(is_authenticated):
         "chat_upload_accept": "application/pdf,text/plain",
         "project_files_max_count": 10,
         "project_images_max_count": 3,
+        "attachment_max_size": 10,
         "status_banner": None,
         "maintenance": None,
     }

--- a/src/frontend/apps/conversations/src/core/config/api/useConfig.tsx
+++ b/src/frontend/apps/conversations/src/core/config/api/useConfig.tsx
@@ -56,6 +56,7 @@ export interface ConfigResponse {
   chat_upload_accept?: string;
   project_files_max_count?: number;
   project_images_max_count?: number;
+  attachment_max_size?: number;
 }
 
 const LOCAL_STORAGE_KEY = 'conversations_config';

--- a/src/frontend/apps/conversations/src/features/chat/components/Chat.tsx
+++ b/src/frontend/apps/conversations/src/features/chat/components/Chat.tsx
@@ -15,6 +15,7 @@ import { useTranslation } from 'react-i18next';
 
 import { APIError, errorCauses, fetchAPI } from '@/api';
 import { Box, Loader, Text } from '@/components';
+import { useConfig } from '@/core';
 import { useUploadFile } from '@/features/attachments/hooks/useUploadFile';
 import { isContextTrimmedEvent, useChat } from '@/features/chat/api/useChat';
 import { getConversation } from '@/features/chat/api/useConversation';
@@ -61,6 +62,7 @@ export const Chat = ({
   initialConversationId: string | undefined;
 }) => {
   const { t } = useTranslation();
+  const { data: config } = useConfig();
   const copyToClipboard = useClipboard();
   const { isMobile } = useResponsiveStore();
 
@@ -211,12 +213,18 @@ export const Chat = ({
   // Show error modal for upload errors
   useEffect(() => {
     if (isErrorAttachment && errorAttachment) {
+      const maxSize = config?.attachment_max_size;
       setChatErrorModal({
         title: t('Upload Error'),
-        message: t('Failed to upload file'),
+        message: maxSize
+          ? t(
+              'Failed to upload file. It may be due to the attachment size. Max size: {{maxSize}} MB',
+              { maxSize },
+            )
+          : t('Failed to upload file. It may be due to the attachment size.'),
       });
     }
-  }, [isErrorAttachment, errorAttachment, t]);
+  }, [isErrorAttachment, errorAttachment, config?.attachment_max_size, t]);
 
   // Handle errors from the chat API
   const onErrorChat = (error: Error) => {

--- a/src/frontend/apps/e2e/__tests__/app-conversations/common.ts
+++ b/src/frontend/apps/e2e/__tests__/app-conversations/common.ts
@@ -52,6 +52,7 @@ export const CONFIG = {
   maintenance: null,
   project_files_max_count: 10,
   project_images_max_count: 3,
+  attachment_max_size: 10,
   status_banner: null,
 } as const;
 


### PR DESCRIPTION
## Purpose

  When a file upload failed in the chat, the user only saw a generic "Failed  to upload file" message with no indication of why. A common cause is  exceeding the maximum attachment size, but the limit was never communicated  to the user.

 ## Proposal

  - [ ] Expose the maximum attachment size through the public configuration  endpoint so the frontend can display it.
  - [ ] Update the chat upload-failure message to mention the size limit and  show the configured maximum.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Upload error messages now display the configured maximum attachment size (in MB) when uploads fail due to size limits.

* **Tests**
  * Updated backend, frontend, and end-to-end tests to assert the attachment size limit is exposed and applied consistently.

* **Documentation**
  * Changelog updated to note the UI now explains the attachment size limit on upload failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->