### PR TITLE
✨(test) pin document parser for deterministic test behavior

### DIFF
--- a/.env
+++ b/.env
@@ -1,14 +1,5 @@
 DJANGO_CONFIGURATION=Test
 DJANGO_SETTINGS_MODULE=conversations.settings
-DJANGO_SECRET_KEY=ThisIsAnExampleKeyForTestPurposeOnly
-OIDC_OP_JWKS_ENDPOINT=/endpoint-for-test-purpose-only
 DB_HOST=localhost
-DB_NAME=conversations
-DB_USER=dinum
-DB_PASSWORD=pass
 DB_PORT=15432
-
-STORAGES_STATICFILES_BACKEND=django.contrib.staticfiles.storage.StaticFilesStorage
 AWS_S3_ENDPOINT_URL=http://localhost:9000
-AWS_S3_ACCESS_KEY_ID=conversations
-AWS_S3_SECRET_ACCESS_KEY=password

--- a/.github/workflows/conversations.yml
+++ b/.github/workflows/conversations.yml
@@ -124,20 +124,16 @@ jobs:
         # needed because the postgres container does not provide a healthcheck
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
+    # Only infra topology is set here; the deterministic behavior settings come
+    # from env.d/test, loaded by pytest-dotenv (see src/backend/pyproject.toml).
+    # These inline values are part of the process env, so they take precedence
+    # over the repo-root .env's host-oriented ports.
     env:
       DJANGO_CONFIGURATION: Test
       DJANGO_SETTINGS_MODULE: conversations.settings
-      DJANGO_SECRET_KEY: ThisIsAnExampleKeyForTestPurposeOnly
-      OIDC_OP_JWKS_ENDPOINT: /endpoint-for-test-purpose-only
       DB_HOST: localhost
-      DB_NAME: conversations
-      DB_USER: dinum
-      DB_PASSWORD: pass
       DB_PORT: 5432
-      STORAGES_STATICFILES_BACKEND: django.contrib.staticfiles.storage.StaticFilesStorage
       AWS_S3_ENDPOINT_URL: http://localhost:9000
-      AWS_S3_ACCESS_KEY_ID: conversations
-      AWS_S3_SECRET_ACCESS_KEY: password
 
     steps:
       - name: Checkout repository

--- a/bin/pytest
+++ b/bin/pytest
@@ -3,6 +3,5 @@
 source "$(dirname "${BASH_SOURCE[0]}")/_config.sh"
 
 _dc_run \
-    -e DJANGO_CONFIGURATION=Test \
-    app-dev \
+    app-test \
     pytest "$@"

--- a/compose.yml
+++ b/compose.yml
@@ -89,6 +89,43 @@ services:
         createbuckets:
           condition: service_started
 
+  app-test:
+    # Mirrors app-dev but loads env.d/test instead of env.d/development/common,
+    # so tests never inherit developer-local settings. Used by bin/pytest.
+    build:
+      context: .
+      target: backend-development
+      args:
+        DOCKER_USER: ${DOCKER_USER:-1000}
+    user: ${DOCKER_USER:-1000}
+    image: conversations:backend-development
+    environment:
+      - PYLINTHOME=/app/.pylint.d
+      - PYTHONPATH=/app
+      - DJANGO_CONFIGURATION=Test
+      - DJANGO_SETTINGS_MODULE=conversations.settings
+    env_file:
+      - env.d/test
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    networks:
+      - default
+      - lasuite
+    volumes:
+      - ./src/backend:/app
+      - ./data/static:/data/static
+      - /app/.venv
+    depends_on:
+        postgresql:
+            condition: service_healthy
+            restart: true
+        maildev:
+          condition: service_started
+        redis:
+          condition: service_started
+        createbuckets:
+          condition: service_started
+
   celery-dev:
     build:
       context: .

--- a/env.d/test
+++ b/env.d/test
@@ -1,0 +1,44 @@
+# Dedicated, deterministic test environment.
+#
+# Loaded by the `app-test` compose service (docker `make test`) and, for host-run
+# pytest and CI, by pytest-dotenv (see [tool.pytest.ini_options] in
+# src/backend/pyproject.toml). It deliberately does NOT load
+# env.d/development/common, so tests never inherit developer-local values.
+#
+# Only settings whose Base coded default is unsuitable for tests are listed here.
+# Everything else falls back to Base's defaults, which are already deterministic
+# once env.d/development/common is not loaded. Infra topology (DB_HOST/DB_PORT,
+# AWS_S3_ENDPOINT_URL) is intentionally absent: it stays env-overridable so the
+# same file works inside docker (compose hostnames) and on the host / CI (the
+# repo-root .env or the CI job env point at the published ports).
+
+# Django (Base default is None, which Django rejects)
+DJANGO_SECRET_KEY=ThisIsAnExampleKeyForTestPurposeOnly
+
+# Media / S3 credentials (Base defaults are None)
+AWS_S3_ACCESS_KEY_ID=conversations
+AWS_S3_SECRET_ACCESS_KEY=password
+# Presigned URLs are signed for the frontend-facing domain, not the in-cluster
+# MinIO hostname.
+AWS_S3_DOMAIN_REPLACE=http://localhost:9000
+
+# OIDC (Base defaults are None; the endpoints must be non-empty so
+# mozilla-django-oidc's RS256 config check passes on authenticated requests.
+# Tests exercising the real OIDC flows override these with mocked URLs.)
+OIDC_RP_CLIENT_SECRET=test-client-secret
+OIDC_OP_JWKS_ENDPOINT=http://oidc.test/jwks
+OIDC_OP_AUTHORIZATION_ENDPOINT=http://oidc.test/authorize
+OIDC_OP_TOKEN_ENDPOINT=http://oidc.test/token
+OIDC_OP_USER_ENDPOINT=http://oidc.test/userinfo
+OIDC_OP_LOGOUT_ENDPOINT=http://oidc.test/logout
+
+# AI / LLM (Base defaults are None; conversation view tests mock this provider
+# via respx and assert on these values. Unit tests that assert configuration
+# propagation set their own distinct values.)
+AI_BASE_URL=https://www.external-ai-service.com/
+AI_API_KEY=test-api-key
+AI_MODEL=test-model
+
+# External RAG / search providers (Base defaults are None)
+ALBERT_API_KEY=test-key
+FIND_API_KEY=test-key

--- a/src/backend/activation_codes/tests/test_integration.py
+++ b/src/backend/activation_codes/tests/test_integration.py
@@ -53,9 +53,8 @@ def test_complete_activation_flow(api_client, settings):
 
 
 @pytest.mark.django_db
-def test_activation_not_required_flow(api_client, settings):
+def test_activation_not_required_flow(api_client):
     """Test that when activation is not required, users can access without codes."""
-    settings.ACTIVATION_REQUIRED = False
 
     user = UserFactory(email="freeuser@example.com", password="password123")
 

--- a/src/backend/activation_codes/tests/test_permissions.py
+++ b/src/backend/activation_codes/tests/test_permissions.py
@@ -24,9 +24,8 @@ def view_fixture():
 
 
 @pytest.mark.django_db
-def test_is_activated_user_permission_activation_not_required(request_factory, view, settings):
+def test_is_activated_user_permission_activation_not_required(request_factory, view):
     """Test that permission allows access when activation is not required."""
-    settings.ACTIVATION_REQUIRED = False
     user = UserFactory()
 
     request = request_factory.get("/")

--- a/src/backend/activation_codes/tests/test_viewsets.py
+++ b/src/backend/activation_codes/tests/test_viewsets.py
@@ -57,9 +57,8 @@ def test_activation_status_authenticated_activated(api_client, settings):
 
 
 @pytest.mark.django_db
-def test_activation_status_activation_not_required(api_client, settings):
+def test_activation_status_activation_not_required(api_client):
     """Test activation status when activation is not required."""
-    settings.ACTIVATION_REQUIRED = False
     user = UserFactory()
     api_client.force_authenticate(user=user)
 

--- a/src/backend/chat/tests/agent_rag/document_converter/test_adaptive_pdf_parser.py
+++ b/src/backend/chat/tests/agent_rag/document_converter/test_adaptive_pdf_parser.py
@@ -52,13 +52,11 @@ OCR_MAX_RETRIES = 3
 def ai_settings(settings):
     """Mock Django settings for OCR configuration."""
     settings.MIN_AVG_CHARS_FOR_TEXT_EXTRACTION = MIN_AVG_CHARS_FOR_TEXT_EXTRACTION
-    settings.MIN_TEXT_COVERAGE_FOR_TEXT_EXTRACTION = 0.7
     settings.OCR_HRID = "test-ocr-hrid"
     settings.OCR_MODEL = "test-ocr-model"
     settings.OCR_TIMEOUT = 60
     settings.OCR_MAX_RETRIES = OCR_MAX_RETRIES
     settings.OCR_RETRY_DELAY = OCR_RETRY_DELAY
-    settings.OCR_BATCH_PAGES = 10
     settings.LLM_CONFIGURATIONS = {
         "test-ocr-hrid": MagicMock(
             provider=MagicMock(

--- a/src/backend/chat/tests/agent_rag/document_rag_backends/test_albert_rag_backend.py
+++ b/src/backend/chat/tests/agent_rag/document_rag_backends/test_albert_rag_backend.py
@@ -19,15 +19,14 @@ from httpx import Response
 
 from chat.agent_rag.document_rag_backends.albert_rag_backend import AlbertRagBackend
 
-ALBERT_BASE_URL = "https://albert.test"
+# Matches the ALBERT_API_URL default in the Test settings class.
+ALBERT_BASE_URL = "https://albert.api.etalab.gouv.fr"
 SEARCH_URL = f"{ALBERT_BASE_URL}/v1/search"
 
 
 @pytest.fixture(name="albert_backend")
-def albert_backend_fixture(settings):
-    """A backend pointing at a test API and a fixed collection."""
-    settings.ALBERT_API_URL = ALBERT_BASE_URL
-    settings.ALBERT_API_KEY = "test-key"
+def albert_backend_fixture():
+    """A backend with a fixed collection, using the Test settings Albert API."""
     return AlbertRagBackend(collection_id="123")
 
 

--- a/src/backend/chat/tests/agent_rag/test_indexing.py
+++ b/src/backend/chat/tests/agent_rag/test_indexing.py
@@ -22,12 +22,6 @@ pytestmark = pytest.mark.django_db
 @pytest.fixture(autouse=True)
 def ai_settings(settings):
     """Configure Albert backend + parser for the indexing tests."""
-    settings.RAG_DOCUMENT_SEARCH_BACKEND = (
-        "chat.agent_rag.document_rag_backends.albert_rag_backend.AlbertRagBackend"
-    )
-    settings.RAG_DOCUMENT_PARSER = "chat.agent_rag.document_converter.parser.AlbertParser"
-    settings.ALBERT_API_URL = "https://albert.api.etalab.gouv.fr"
-    settings.ALBERT_API_KEY = "albert-api-key"
     return settings
 
 

--- a/src/backend/chat/tests/agent_rag/web_search/test_albert_api.py
+++ b/src/backend/chat/tests/agent_rag/web_search/test_albert_api.py
@@ -10,13 +10,6 @@ from chat.agent_rag.constants import RAGWebResult, RAGWebResults, RAGWebUsage
 from chat.agent_rag.web_search.albert_api import AlbertWebSearchManager
 
 
-@pytest.fixture(autouse=True)
-def albert_api_settings(settings):
-    """Fixture to set Albert API settings for tests."""
-    settings.ALBERT_API_URL = "http://test-albert-api.com"
-    settings.ALBERT_API_KEY = "test-key"
-
-
 @pytest.mark.parametrize(
     "url, expected",
     [
@@ -31,13 +24,10 @@ def test_clean_url(url, expected):
 
 
 @responses.activate
-def test_web_search_success(settings):
+def test_web_search_success():
     """Test a successful web search."""
-    settings.RAG_WEB_SEARCH_MAX_RESULTS = 20
-    settings.RAG_WEB_SEARCH_CHUNK_NUMBER = 10
-
     mock_albert_api = responses.post(
-        "http://test-albert-api.com/v1/search",
+        "https://albert.api.etalab.gouv.fr/v1/search",
         json={
             "data": [
                 {
@@ -72,8 +62,8 @@ def test_web_search_success(settings):
     assert json.loads(request.body) == {
         "prompt": "test query",
         "web_search": True,
-        "web_search_k": 20,  # Default value from settings
-        "k": 10,  # Default value from settings
+        "web_search_k": 5,  # Default value from settings
+        "k": 4,  # Default value from settings
     }
 
 
@@ -86,7 +76,7 @@ def test_web_search_empty_query():
 @responses.activate
 def test_web_search_http_error():
     """Test web_search with an HTTP error from the API."""
-    responses.post("http://test-albert-api.com/v1/search", status=500)
+    responses.post("https://albert.api.etalab.gouv.fr/v1/search", status=500)
     with pytest.raises(requests.HTTPError):
         AlbertWebSearchManager().web_search("test query")
 
@@ -95,7 +85,7 @@ def test_web_search_http_error():
 def test_web_search_json_decode_error():
     """Test web_search with a JSON decode error from the API."""
     responses.post(
-        "http://test-albert-api.com/v1/search",
+        "https://albert.api.etalab.gouv.fr/v1/search",
         body="invalid json",
         status=200,
         content_type="application/json",

--- a/src/backend/chat/tests/agents/test_build_conversation_agent.py
+++ b/src/backend/chat/tests/agents/test_build_conversation_agent.py
@@ -33,7 +33,6 @@ def base_settings(settings):
     settings.AI_API_KEY = "test-key"
     settings.AI_MODEL = "model-123"
     settings.AI_AGENT_INSTRUCTIONS = "You are a helpful assistant"
-    settings.AI_AGENT_TOOLS = []
 
 
 def test_build_pydantic_agent_success_no_tools():

--- a/src/backend/chat/tests/agents/test_history_processors.py
+++ b/src/backend/chat/tests/agents/test_history_processors.py
@@ -187,11 +187,6 @@ def test_apply_sliding_window_keeps_last_turn_even_if_too_big():
 # ── resolve_conversation_budget ───────────────────────────────────────────────
 
 
-@override_settings(
-    DEFAULT_MAX_TOKEN_CONTEXT=8192,
-    DOCUMENT_CONTEXT_SECURITY_BUFFER_TOKENS=1000,
-    DOCUMENT_CONTEXT_BUDGET_RATIO=0.5,
-)
 def test_resolve_conversation_budget_no_max_context_uses_default():
     """Models without max_token_context fall back to DEFAULT_MAX_TOKEN_CONTEXT."""
 
@@ -211,10 +206,6 @@ def test_resolve_conversation_budget_zero_max_context():
     assert resolve_conversation_budget(Cfg()) == 0
 
 
-@override_settings(
-    DOCUMENT_CONTEXT_SECURITY_BUFFER_TOKENS=1000,
-    DOCUMENT_CONTEXT_BUDGET_RATIO=0.5,
-)
 def test_resolve_conversation_budget_formula():
     """Budget is computed as int(max*(1-ratio))-buffer."""
 

--- a/src/backend/chat/tests/agents/test_title_generation_agent.py
+++ b/src/backend/chat/tests/agents/test_title_generation_agent.py
@@ -2,21 +2,9 @@
 
 # pylint: disable=protected-access
 
-import pytest
 from pydantic_ai.models.openai import OpenAIChatModel
 
 from chat.agents.conversation import TitleGenerationAgent
-
-
-@pytest.fixture(autouse=True)
-def base_settings(settings):
-    """Set up base settings for the tests."""
-    settings.AI_BASE_URL = "https://api.llm.com/v1/"
-    settings.AI_API_KEY = "test-key"
-    settings.AI_MODEL = "model-XYZ"
-    settings.AI_AGENT_INSTRUCTIONS = "You are a helpful assistant"
-    settings.AI_AGENT_TOOLS = []
-    settings.LLM_DEFAULT_MODEL_HRID = "default-model"
 
 
 def test_title_generation_agent_uses_default_model_hrid(settings):
@@ -24,7 +12,6 @@ def test_title_generation_agent_uses_default_model_hrid(settings):
     settings.AI_MODEL = "custom-llm-model"
     settings.AI_BASE_URL = "https://custom.api.com/v1/"
     settings.AI_API_KEY = "custom-key"
-    settings.LLM_DEFAULT_MODEL_HRID = "default-model"
 
     agent = TitleGenerationAgent()
 
@@ -38,9 +25,9 @@ def test_title_generation_agent_model_configuration():
     agent = TitleGenerationAgent()
 
     assert isinstance(agent._model, OpenAIChatModel)
-    assert agent._model.model_name == "model-XYZ"
-    assert str(agent._model.client.base_url) == "https://api.llm.com/v1/"
-    assert agent._model.client.api_key == "test-key"
+    assert agent._model.model_name == "test-model"
+    assert str(agent._model.client.base_url) == "https://www.external-ai-service.com/"
+    assert agent._model.client.api_key == "test-api-key"
 
 
 def test_title_generation_agent_has_no_tools():

--- a/src/backend/chat/tests/clients/pydantic_ai/test_check_should_enable_rag.py
+++ b/src/backend/chat/tests/clients/pydantic_ai/test_check_should_enable_rag.py
@@ -19,16 +19,6 @@ from chat.factories import (
 pytestmark = pytest.mark.django_db
 
 
-@pytest.fixture(autouse=True)
-def base_settings(settings):
-    """Minimum LLM settings to instantiate AIAgentService."""
-    settings.AI_BASE_URL = "https://api.llm.com/v1/"
-    settings.AI_API_KEY = "test-key"
-    settings.AI_MODEL = "model-123"
-    settings.AI_AGENT_INSTRUCTIONS = "You are a helpful assistant"
-    settings.AI_AGENT_TOOLS = []
-
-
 def _check(conversation, *, conversation_has_documents=False):
     service = AIAgentService(conversation, user=conversation.owner)
     return async_to_sync(service._check_should_enable_rag)(conversation_has_documents)

--- a/src/backend/chat/tests/clients/pydantic_ai/test_document_context_window.py
+++ b/src/backend/chat/tests/clients/pydantic_ai/test_document_context_window.py
@@ -37,7 +37,6 @@ def _parse_listing(instruction: str) -> dict:
 @pytest.fixture()
 def _llm_config_with_context(settings):
     """Configure a model with max_token_context for context window tests."""
-    settings.DOCUMENT_CONTEXT_BUDGET_RATIO = 0.5
     settings.LLM_CONFIGURATIONS = {
         "default-model": LLModel(
             hrid="default-model",
@@ -374,7 +373,6 @@ def test_document_context_uses_configurable_ratio(_llm_config_with_context, monk
 @pytest.fixture()
 def _llm_config_two_models(settings):
     """Two LLM configs so cache-key-by-model can be exercised."""
-    settings.DOCUMENT_CONTEXT_BUDGET_RATIO = 0.5
     settings.DOCUMENT_CONTEXT_SECURITY_BUFFER_TOKENS = 0
     provider = LLMProvider(hrid="p", base_url="https://example.com", api_key="key")
     settings.LLM_CONFIGURATIONS = {

--- a/src/backend/chat/tests/clients/pydantic_ai/test_handle_input_documents_indexing.py
+++ b/src/backend/chat/tests/clients/pydantic_ai/test_handle_input_documents_indexing.py
@@ -24,17 +24,6 @@ PYDANTIC_AI_LOGGER = "chat.clients.pydantic_ai"
 pytestmark = pytest.mark.django_db(transaction=True)
 
 
-@pytest.fixture(autouse=True, name="base_settings")
-def base_settings_fixture(settings):
-    """Minimum LLM settings to instantiate AIAgentService."""
-    settings.AI_BASE_URL = "https://api.llm.com/v1/"
-    settings.AI_API_KEY = "test-key"
-    settings.AI_MODEL = "model-123"
-    settings.AI_AGENT_INSTRUCTIONS = "You are a helpful assistant"
-    settings.AI_AGENT_TOOLS = []
-    settings.REINDEX_CLAIM_TIMEOUT_SECONDS = 600
-
-
 _USER_MESSAGE = [
     UIMessage(
         id="msg-1",

--- a/src/backend/chat/tests/clients/pydantic_ai/test_langfuse_tracing.py
+++ b/src/backend/chat/tests/clients/pydantic_ai/test_langfuse_tracing.py
@@ -44,16 +44,6 @@ def langfuse_client_fixture():
 
 
 @pytest.fixture(autouse=True)
-def base_settings(settings):
-    """Set up base settings for the tests."""
-    settings.AI_BASE_URL = "https://api.llm.com/v1/"
-    settings.AI_API_KEY = "test-key"
-    settings.AI_MODEL = "model-123"
-    settings.AI_AGENT_INSTRUCTIONS = "You are a helpful assistant"
-    settings.AI_AGENT_TOOLS = []
-
-
-@pytest.fixture(autouse=True)
 def mock_token_counter(monkeypatch):
     """Prevent tiktoken from making network calls during sliding window token estimation."""
     monkeypatch.setattr(
@@ -184,9 +174,8 @@ async def test_langfuse_span_created_when_enabled_and_analytics_disabled(
 
 @pytest.mark.asyncio
 @responses.activate
-async def test_no_langfuse_span_when_disabled(agent_model, ui_messages, settings, langfuse_client):
+async def test_no_langfuse_span_when_disabled(agent_model, ui_messages, langfuse_client):
     """Test Langfuse span is not created when Langfuse is disabled."""
-    settings.LANGFUSE_ENABLED = False
 
     # Mock Langfuse HTTP endpoints (should not be called)
     responses.add(
@@ -252,10 +241,9 @@ async def test_instrumentation_settings_with_analytics_disabled(settings):
 
 
 @pytest.mark.asyncio
-async def test_instrumentation_disabled_when_langfuse_disabled(settings):
+async def test_instrumentation_disabled_when_langfuse_disabled():
     """Test service correctly sets flags when Langfuse is disabled."""
     # pylint: disable=protected-access
-    settings.LANGFUSE_ENABLED = False
 
     user = await sync_to_async(UserFactory)(allow_conversation_analytics=True)
     conversation = await sync_to_async(ChatConversationFactory)(owner=user)
@@ -295,10 +283,9 @@ def test_store_analytics_flag_when_langfuse_enabled_and_user_disallows(settings)
     assert service._store_analytics is False
 
 
-def test_store_analytics_flag_when_langfuse_disabled(settings):
+def test_store_analytics_flag_when_langfuse_disabled():
     """Test _store_analytics is False when Langfuse is disabled."""
     # pylint: disable=protected-access
-    settings.LANGFUSE_ENABLED = False
 
     user = UserFactory(allow_conversation_analytics=True)
     conversation = ChatConversationFactory(owner=user)

--- a/src/backend/chat/tests/clients/pydantic_ai/test_parse_input_documents.py
+++ b/src/backend/chat/tests/clients/pydantic_ai/test_parse_input_documents.py
@@ -17,16 +17,6 @@ from chat.factories import ChatConversationFactory
 pytestmark = pytest.mark.django_db(transaction=True)
 
 
-@pytest.fixture(autouse=True, name="base_settings")
-def base_settings_fixture(settings):
-    """Minimum settings to instantiate AIAgentService."""
-    settings.AI_BASE_URL = "https://api.llm.com/v1/"
-    settings.AI_API_KEY = "test-key"
-    settings.AI_MODEL = "model-123"
-    settings.AI_AGENT_INSTRUCTIONS = "You are a helpful assistant"
-    settings.AI_AGENT_TOOLS = []
-
-
 def _mock_backend(rag_document_id):
     """Return a mock backend class whose store returns the given rag_document_id."""
     store = MagicMock()

--- a/src/backend/chat/tests/clients/pydantic_ai/test_project_instructions.py
+++ b/src/backend/chat/tests/clients/pydantic_ai/test_project_instructions.py
@@ -8,16 +8,6 @@ from chat.factories import ChatConversationFactory, ChatProjectFactory
 pytestmark = pytest.mark.django_db
 
 
-@pytest.fixture(autouse=True)
-def base_settings(settings):
-    """Set up base settings for the tests."""
-    settings.AI_BASE_URL = "https://api.llm.com/v1/"
-    settings.AI_API_KEY = "test-key"
-    settings.AI_MODEL = "model-123"
-    settings.AI_AGENT_INSTRUCTIONS = "You are a helpful assistant"
-    settings.AI_AGENT_TOOLS = []
-
-
 def _get_instruction_names(service):
     """Return the names of dynamic (callable) instructions registered on the conversation agent."""
     # pylint: disable=protected-access

--- a/src/backend/chat/tests/clients/pydantic_ai/test_stream_methods.py
+++ b/src/backend/chat/tests/clients/pydantic_ai/test_stream_methods.py
@@ -29,16 +29,6 @@ class AsyncRaiseIterator:
         raise self.exc
 
 
-@pytest.fixture(autouse=True)
-def base_settings(settings):
-    """Set up base settings for the tests."""
-    settings.AI_BASE_URL = "https://api.llm.com/v1/"
-    settings.AI_API_KEY = "test-key"
-    settings.AI_MODEL = "model-123"
-    settings.AI_AGENT_INSTRUCTIONS = "You are a helpful assistant"
-    settings.AI_AGENT_TOOLS = []
-
-
 @pytest.fixture(name="ui_messages")
 def ui_messages_fixture():
     """Fixture for test UI messages."""

--- a/src/backend/chat/tests/clients/pydantic_ai/test_thinking_history_stripping.py
+++ b/src/backend/chat/tests/clients/pydantic_ai/test_thinking_history_stripping.py
@@ -74,16 +74,6 @@ def test_strip_thinking_parts_mixed_history():
     assert result[2] is response_without_thinking
 
 
-@pytest.fixture(autouse=True, name="base_settings")
-def base_settings_fixture(settings):
-    """Configure minimal LLM settings."""
-    settings.AI_BASE_URL = "https://api.llm.com/v1/"
-    settings.AI_API_KEY = "test-key"
-    settings.AI_MODEL = "model-123"
-    settings.AI_AGENT_INSTRUCTIONS = "You are a helpful assistant"
-    settings.AI_AGENT_TOOLS = []
-
-
 def _pydantic_messages_with_thinking():
     """Return pydantic_messages JSON with a ModelResponse containing a ThinkingPart."""
     messages = [

--- a/src/backend/chat/tests/management/commands/test_deindex_inactive_collections.py
+++ b/src/backend/chat/tests/management/commands/test_deindex_inactive_collections.py
@@ -22,9 +22,8 @@ def _make_backend_mock(**delete_kwargs):
 
 
 @pytest.mark.django_db(transaction=True)
-def test_deindexes_inactive_conversation(settings):
+def test_deindexes_inactive_conversation():
     """Active collection on inactive conversation is deleted and collection_id nulled."""
-    settings.RAG_COLLECTION_INACTIVITY_DAYS = 30
     conversation = ChatConversationFactory(collection_id="albert-123")
     ChatConversation.objects.filter(pk=conversation.pk).update(
         updated_at=timezone.now() - timedelta(days=31)
@@ -45,9 +44,8 @@ def test_deindexes_inactive_conversation(settings):
 
 
 @pytest.mark.django_db(transaction=True)
-def test_skips_active_conversation(settings):
+def test_skips_active_conversation():
     """Collection on a recently active conversation is not deleted."""
-    settings.RAG_COLLECTION_INACTIVITY_DAYS = 30
     conversation = ChatConversationFactory(collection_id="albert-456")
     # updated_at is auto_now so it is already recent — no override needed
 
@@ -64,9 +62,8 @@ def test_skips_active_conversation(settings):
 
 
 @pytest.mark.django_db(transaction=True)
-def test_skips_conversation_without_collection(settings):
+def test_skips_conversation_without_collection():
     """Conversation without a collection_id is never processed."""
-    settings.RAG_COLLECTION_INACTIVITY_DAYS = 30
     conversation = ChatConversationFactory(collection_id=None)
     ChatConversation.objects.filter(pk=conversation.pk).update(
         updated_at=timezone.now() - timedelta(days=31)
@@ -84,9 +81,8 @@ def test_skips_conversation_without_collection(settings):
 
 
 @pytest.mark.django_db(transaction=True)
-def test_continues_on_error(settings):
+def test_continues_on_error():
     """If the first conversation fails, the second one is still processed."""
-    settings.RAG_COLLECTION_INACTIVITY_DAYS = 30
 
     conv1 = ChatConversationFactory(collection_id="albert-fail")
     conv2 = ChatConversationFactory(collection_id="albert-ok")
@@ -118,9 +114,8 @@ def test_continues_on_error(settings):
 
 
 @pytest.mark.django_db(transaction=True)
-def test_rollback_restores_exact_pre_deindex_state(settings):
+def test_rollback_restores_exact_pre_deindex_state():
     """On delete_collection failure, conversation and attachment state are restored exactly."""
-    settings.RAG_COLLECTION_INACTIVITY_DAYS = 30
     # Use ERROR (not INDEXED) to prove index_state is restored verbatim, not hardcoded.
     conv = ChatConversationFactory(
         collection_id="albert-fail", index_state=CollectionIndexState.ERROR
@@ -156,9 +151,8 @@ def test_rollback_restores_exact_pre_deindex_state(settings):
 
 
 @pytest.mark.django_db(transaction=True)
-def test_treats_404_as_deindexed(settings):
+def test_treats_404_as_deindexed():
     """A 404 from delete_collection means the collection is already gone — keep cleared state."""
-    settings.RAG_COLLECTION_INACTIVITY_DAYS = 30
     conv = ChatConversationFactory(
         collection_id="albert-gone", index_state=CollectionIndexState.INDEXED
     )
@@ -188,9 +182,8 @@ def test_treats_404_as_deindexed(settings):
 
 
 @pytest.mark.django_db(transaction=True)
-def test_does_not_update_updated_at(settings):
+def test_does_not_update_updated_at():
     """Running the command must not change updated_at on the conversation."""
-    settings.RAG_COLLECTION_INACTIVITY_DAYS = 30
     conversation = ChatConversationFactory(collection_id="albert-789")
     past = timezone.now() - timedelta(days=31)
     ChatConversation.objects.filter(pk=conversation.pk).update(updated_at=past)

--- a/src/backend/chat/tests/management/commands/test_fetch_model_health.py
+++ b/src/backend/chat/tests/management/commands/test_fetch_model_health.py
@@ -15,22 +15,19 @@ from core.models import ModelHealthSettings
 
 from chat.models import ModelHealth
 
-ALBERT_HEALTH_URL = "https://albert.test.fr/health/models"
+# Matches the ALBERT_HEALTH_URL default in the Test settings class.
+ALBERT_HEALTH_URL = "https://albert.api.etalab.gouv.fr/health/models"
 
 
 @pytest.fixture(autouse=True)
-def albert_settings(settings, clear_cache):  # pylint: disable=unused-argument
-    """Set common Albert API settings shared by all tests."""
-    settings.ALBERT_HEALTH_URL = ALBERT_HEALTH_URL
-    settings.ALBERT_HEALTH_TIMEOUT = 10
+def _clear_cache_between_tests(clear_cache):  # pylint: disable=unused-argument
+    """Reset the cache shared by all tests."""
 
 
 @pytest.mark.django_db
 @responses_lib.activate
-def test_fetch_model_health_inserts_rows_and_sets_cache(settings):
+def test_fetch_model_health_inserts_rows_and_sets_cache():
     """On success: one DB row per model + Redis key set, Bearer token sent."""
-    settings.ALBERT_API_KEY = "test-api-key"
-
     responses_lib.add(
         responses_lib.GET,
         ALBERT_HEALTH_URL,
@@ -44,7 +41,7 @@ def test_fetch_model_health_inserts_rows_and_sets_cache(settings):
 
     call_command("fetch_model_health", "--provider", "albert")
 
-    assert responses_lib.calls[0].request.headers["Authorization"] == "Bearer test-api-key"
+    assert responses_lib.calls[0].request.headers["Authorization"] == "Bearer test-key"
     assert ModelHealth.objects.count() == 2
     row = ModelHealth.objects.get(provider="albert", model_id="BAAI/bge-m3")
     assert row.status == "green"

--- a/src/backend/chat/tests/test_assistant_health.py
+++ b/src/backend/chat/tests/test_assistant_health.py
@@ -29,8 +29,6 @@ def llm_configs():
 @pytest.fixture(autouse=True)
 def patch_settings(settings, llm_configs):
     settings.LLM_DEFAULT_MODEL_HRID = "main-model"
-    settings.LLM_FALLBACK_MODEL_HRID_1 = ""
-    settings.LLM_FALLBACK_MODEL_HRID_2 = ""
     settings.LLM_CONFIGURATIONS = llm_configs
 
 
@@ -233,6 +231,7 @@ def test_main_red_fb1_unknown_hrid_unavailable(settings):
     assert result["blocked"] is True
 
 
+@pytest.mark.django_db
 def test_main_red_fb1_empty_fb2_red_unavailable(settings, llm_configs):
     # fb1="" (not configured → down) + fb2=red (down) → all_down=True → unavailable.
     settings.LLM_FALLBACK_MODEL_HRID_2 = "fallback-2"
@@ -244,6 +243,7 @@ def test_main_red_fb1_empty_fb2_red_unavailable(settings, llm_configs):
 # --- fallback partially configured ------------------------------------------
 
 
+@pytest.mark.django_db
 def test_fb1_empty_fb2_yellow_degraded(settings, llm_configs):
     # fb1="" (down) but fb2=yellow (not down) → all_down=False → degraded.
     settings.LLM_FALLBACK_MODEL_HRID_2 = "fallback-2"

--- a/src/backend/chat/tests/test_malware_detection.py
+++ b/src/backend/chat/tests/test_malware_detection.py
@@ -26,12 +26,6 @@ PROJECT_CALLBACKS = {
 @pytest.fixture(name="ai_settings")
 def fixture_ai_settings(settings):
     """Configure Albert backend for project indexing tests."""
-    settings.RAG_DOCUMENT_SEARCH_BACKEND = (
-        "chat.agent_rag.document_rag_backends.albert_rag_backend.AlbertRagBackend"
-    )
-    settings.RAG_DOCUMENT_PARSER = "chat.agent_rag.document_converter.parser.AlbertParser"
-    settings.ALBERT_API_URL = "https://albert.api.etalab.gouv.fr"
-    settings.ALBERT_API_KEY = "albert-api-key"
     return settings
 
 

--- a/src/backend/chat/tests/test_settings_isolation.py
+++ b/src/backend/chat/tests/test_settings_isolation.py
@@ -1,0 +1,55 @@
+"""Guard tests ensuring the test settings are deterministic.
+
+Tests run against a dedicated environment (``env.d/test``) loaded by the
+``app-test`` compose service in docker and by pytest-dotenv on the host / in CI;
+``env.d/development/common`` is never loaded. These tests fail loudly if that
+mechanism breaks — either because a developer-local value leaks in (a setting no
+longer resolves to Base's coded default) or because ``env.d/test`` is not loaded
+(a setting it pins is missing).
+
+``settings`` is pytest-django's fixture, which proxies to ``django.conf.settings``.
+"""
+
+import os
+
+
+def test_env_test_file_is_loaded(settings):
+    """Settings pinned in env.d/test must resolve to their test values."""
+    assert settings.AI_MODEL == "test-model"
+    assert settings.AI_API_KEY == "test-api-key"
+    assert settings.AI_BASE_URL == "https://www.external-ai-service.com/"
+    assert settings.ALBERT_API_KEY == "test-key"
+    assert settings.FIND_API_KEY == "test-key"
+    assert settings.SECRET_KEY
+
+
+def test_no_developer_env_leaks_into_tests(settings):
+    """Behavior settings absent from env.d/test must use Base's coded default.
+
+    A developer-local env.d/development/common (which may set e.g.
+    RAG_DOCUMENT_PARSER=AdaptivePdfParser) must not leak in, so these resolve to
+    Base's deterministic defaults.
+    """
+    assert settings.RAG_DOCUMENT_PARSER.endswith("AlbertParser")
+    assert settings.RAG_DOCUMENT_SEARCH_BACKEND.endswith("AlbertRagBackend")
+    assert settings.LLM_DEFAULT_MODEL_HRID == "default-model"
+
+
+def test_test_only_mechanics_are_pinned(settings):
+    """Test-specific backends and mechanics stay in the Test settings class."""
+    assert settings.CACHES["default"]["BACKEND"].endswith("LocMemCache")
+    assert settings.CELERY_TASK_ALWAYS_EAGER is True
+    assert settings.MALWARE_DETECTION["BACKEND"].endswith("dummy.DummyBackend")
+
+
+def test_infra_settings_point_at_the_expected_topology(settings):
+    """Infra endpoints resolve from the environment (docker default or override).
+
+    Defaults are the docker-compose hostnames; host-run pytest and CI point them
+    at the published ports through the repo-root .env or the job env.
+    """
+    assert settings.DATABASES["default"]["HOST"] == os.environ.get("DB_HOST", "postgresql")
+    assert settings.DATABASES["default"]["PORT"] == int(os.environ.get("DB_PORT", "5432"))
+    assert settings.AWS_S3_ENDPOINT_URL == os.environ.get(
+        "AWS_S3_ENDPOINT_URL", "http://minio:9000"
+    )

--- a/src/backend/chat/tests/tools/test_document_generic_search_rag.py
+++ b/src/backend/chat/tests/tools/test_document_generic_search_rag.py
@@ -293,9 +293,8 @@ def test_document_search_rag_tool_execution(settings):
     }
 
 
-def test_get_specific_rag_search_tool_config_with_empty_settings(settings):
+def test_get_specific_rag_search_tool_config_with_empty_settings():
     """Test get_specific_rag_search_tool_config with empty SPECIFIC_RAG_DOCUMENT_SEARCH_TOOLS."""
-    settings.SPECIFIC_RAG_DOCUMENT_SEARCH_TOOLS = {}
 
     user = UserFactory()
     config = get_specific_rag_search_tool_config(user)

--- a/src/backend/chat/tests/tools/test_document_search_rag.py
+++ b/src/backend/chat/tests/tools/test_document_search_rag.py
@@ -46,12 +46,7 @@ def _albert_chunk(content="snippet", document_name="doc.pdf", score=0.9):
 
 @pytest.fixture(name="albert_settings")
 def albert_settings_fixture(settings):
-    """Point the RAG backend setting + Albert API at deterministic test values."""
-    settings.RAG_DOCUMENT_SEARCH_BACKEND = (
-        "chat.agent_rag.document_rag_backends.albert_rag_backend.AlbertRagBackend"
-    )
-    settings.ALBERT_API_URL = "https://albert.test"
-    settings.ALBERT_API_KEY = "test-key"
+    """Expose the settings (Albert API defaults from Test) to build mock URLs."""
     return settings
 
 

--- a/src/backend/chat/tests/views/attachments/test_project_attachments.py
+++ b/src/backend/chat/tests/views/attachments/test_project_attachments.py
@@ -23,12 +23,6 @@ pytestmark = pytest.mark.django_db
 @pytest.fixture(name="albert_settings")
 def fixture_albert_settings(settings):
     """Configure Albert backend so per-document delete hits a known URL."""
-    settings.RAG_DOCUMENT_SEARCH_BACKEND = (
-        "chat.agent_rag.document_rag_backends.albert_rag_backend.AlbertRagBackend"
-    )
-    settings.RAG_DOCUMENT_PARSER = "chat.agent_rag.document_converter.parser.AlbertParser"
-    settings.ALBERT_API_URL = "https://albert.api.etalab.gouv.fr"
-    settings.ALBERT_API_KEY = "albert-api-key"
     return settings
 
 

--- a/src/backend/chat/tests/views/chat/conversations/test_conversation.py
+++ b/src/backend/chat/tests/views/chat/conversations/test_conversation.py
@@ -170,9 +170,6 @@ HELLO_STREAM_CONTENT = (
 @pytest.fixture(autouse=True)
 def ai_settings(settings):
     """Fixture to set AI service URLs for testing."""
-    settings.AI_BASE_URL = "https://www.external-ai-service.com/"
-    settings.AI_API_KEY = "test-api-key"
-    settings.AI_MODEL = "test-model"
     settings.AI_AGENT_INSTRUCTIONS = "You are a helpful test assistant :)"
 
     return settings
@@ -645,9 +642,8 @@ def test_post_conversation_tool_call(api_client, mock_openai_stream_tool, settin
 
 @freeze_time("2025-07-25T10:36:35.297675Z")
 @respx.mock
-def test_post_conversation_tool_call_fails(api_client, mock_openai_stream_tool, settings):
+def test_post_conversation_tool_call_fails(api_client, mock_openai_stream_tool):
     """Ensure tool calls are correctly forwarded and streamed back when failing."""
-    settings.AI_AGENT_TOOLS = []
 
     chat_conversation = ChatConversationFactory(owner__language="fr-fr")
     url = f"/api/v1.0/chats/{chat_conversation.pk}/conversation/?protocol=data"

--- a/src/backend/chat/tests/views/chat/conversations/test_conversation_image_guard.py
+++ b/src/backend/chat/tests/views/chat/conversations/test_conversation_image_guard.py
@@ -36,11 +36,7 @@ UNREADABLE_MARKER = "cannot read or process images"
 
 @pytest.fixture(autouse=True)
 def ai_settings(settings):
-    settings.AI_BASE_URL = "https://www.external-ai-service.com/"
-    settings.AI_API_KEY = "test-api-key"
-    settings.AI_MODEL = "test-model"
     settings.AI_AGENT_INSTRUCTIONS = "You are a helpful test assistant :)"
-    settings.LANGFUSE_ENABLED = False
 
 
 def _configure_model(settings, *, supports_image):
@@ -61,7 +57,6 @@ def _configure_model(settings, *, supports_image):
             ),
         ),
     }
-    settings.LLM_DEFAULT_MODEL_HRID = "default-model"
 
 
 @pytest.fixture(name="text_only_llm")

--- a/src/backend/chat/tests/views/chat/conversations/test_conversation_model_routing.py
+++ b/src/backend/chat/tests/views/chat/conversations/test_conversation_model_routing.py
@@ -24,14 +24,6 @@ pytestmark = pytest.mark.django_db(transaction=True)
 FROZEN = "2025-07-25T10:36:35.297675Z"
 
 
-@pytest.fixture(autouse=True)
-def ai_settings(settings):
-    settings.AI_BASE_URL = "https://www.external-ai-service.com/"
-    settings.AI_API_KEY = "test-api-key"
-    settings.AI_MODEL = "test-model"
-    settings.AI_AGENT_INSTRUCTIONS = "You are a helpful test assistant :)"
-
-
 @pytest.fixture(name="health_cache", autouse=True)
 def health_cache_fixture():
     django_cache.clear()
@@ -63,7 +55,6 @@ def routed_llm_configs(settings):
     }
     settings.LLM_DEFAULT_MODEL_HRID = "main-model"
     settings.LLM_FALLBACK_MODEL_HRID_1 = "fallback-1"
-    settings.LLM_FALLBACK_MODEL_HRID_2 = ""
 
 
 @freeze_time(FROZEN)

--- a/src/backend/chat/tests/views/chat/conversations/test_conversation_search_with_document_id.py
+++ b/src/backend/chat/tests/views/chat/conversations/test_conversation_search_with_document_id.py
@@ -29,15 +29,7 @@ pytestmark = pytest.mark.django_db(transaction=True)
 @pytest.fixture(autouse=True)
 def ai_settings(settings):
     """Configure AI service URLs and the Albert backend."""
-    settings.RAG_DOCUMENT_SEARCH_BACKEND = (
-        "chat.agent_rag.document_rag_backends.albert_rag_backend.AlbertRagBackend"
-    )
-    settings.AI_BASE_URL = "https://www.external-ai-service.com/"
-    settings.AI_API_KEY = "test-api-key"
-    settings.AI_MODEL = "test-model"
     settings.AI_AGENT_INSTRUCTIONS = "You are a helpful test assistant :)"
-    settings.ALBERT_API_URL = "https://albert.api.etalab.gouv.fr"
-    settings.ALBERT_API_KEY = "albert-api-key"
     return settings
 
 

--- a/src/backend/chat/tests/views/chat/conversations/test_conversation_search_with_document_id_retry.py
+++ b/src/backend/chat/tests/views/chat/conversations/test_conversation_search_with_document_id_retry.py
@@ -37,15 +37,7 @@ pytestmark = pytest.mark.django_db(transaction=True)
 @pytest.fixture(autouse=True)
 def ai_settings(settings):
     """Configure AI service URLs and the Albert backend."""
-    settings.RAG_DOCUMENT_SEARCH_BACKEND = (
-        "chat.agent_rag.document_rag_backends.albert_rag_backend.AlbertRagBackend"
-    )
-    settings.AI_BASE_URL = "https://www.external-ai-service.com/"
-    settings.AI_API_KEY = "test-api-key"
-    settings.AI_MODEL = "test-model"
     settings.AI_AGENT_INSTRUCTIONS = "You are a helpful test assistant :)"
-    settings.ALBERT_API_URL = "https://albert.api.etalab.gouv.fr"
-    settings.ALBERT_API_KEY = "albert-api-key"
     return settings
 
 

--- a/src/backend/chat/tests/views/chat/conversations/test_conversation_with_document_upload.py
+++ b/src/backend/chat/tests/views/chat/conversations/test_conversation_with_document_upload.py
@@ -92,18 +92,7 @@ def ai_settings(request, settings):
         "Please answer the user's question: {user_prompt}"
     )
 
-    settings.AI_BASE_URL = "https://www.external-ai-service.com/"
-    settings.AI_API_KEY = "test-api-key"
-    settings.AI_MODEL = "test-model"
     settings.AI_AGENT_INSTRUCTIONS = "You are a helpful test assistant :)"
-
-    # Albert API settings
-    settings.ALBERT_API_URL = "https://albert.api.etalab.gouv.fr"
-    settings.ALBERT_API_KEY = "albert-api-key"
-
-    # Find API settings
-    settings.FIND_API_URL = "https://find.api.example.com"
-    settings.FIND_API_KEY = "find-api-key"
 
     return settings
 
@@ -213,14 +202,14 @@ def fixture_mock_document_api():
 
     # Mock document indexing (Find API)
     responses.post(
-        "https://find.api.example.com/api/v1.0/documents/index/",
+        "https://app-find/api/v1.0/documents/index/",
         json={"id": "456", "status": "indexed"},
         status=status.HTTP_200_OK,
     )
 
     # Mock document search (Find API)
     responses.post(
-        "https://find.api.example.com/api/v1.0/documents/search/",
+        "https://app-find/api/v1.0/documents/search/",
         json=[
             {
                 "_source": {
@@ -300,14 +289,14 @@ def fixture_mock_odt_document_api():
 
     # Mock document indexing (Find API)
     responses.post(
-        "https://find.api.example.com/api/v1.0/documents/index/",
+        "https://app-find/api/v1.0/documents/index/",
         json={"id": "456", "status": "indexed"},
         status=status.HTTP_200_OK,
     )
 
     # Mock document search (Find API)
     responses.post(
-        "https://find.api.example.com/api/v1.0/documents/search/",
+        "https://app-find/api/v1.0/documents/search/",
         json=[
             {
                 "_source": {

--- a/src/backend/chat/tests/views/chat/conversations/test_conversation_with_document_url.py
+++ b/src/backend/chat/tests/views/chat/conversations/test_conversation_with_document_url.py
@@ -131,11 +131,6 @@ def _assert_document_instructions(
 def ai_settings(request, settings):
     """Fixture to set AI service URLs for testing."""
     settings.RAG_DOCUMENT_SEARCH_BACKEND = request.param
-    settings.AI_BASE_URL = "https://www.external-ai-service.com/"
-    settings.AI_API_KEY = "test-api-key"
-    settings.FIND_API_URL = "https://app-find"
-    settings.FIND_API_KEY = "find-api-key"
-    settings.AI_MODEL = "test-model"
     settings.AI_AGENT_INSTRUCTIONS = "You are a helpful test assistant :)"
     return settings
 

--- a/src/backend/chat/tests/views/chat/conversations/test_conversation_with_history.py
+++ b/src/backend/chat/tests/views/chat/conversations/test_conversation_with_history.py
@@ -37,12 +37,8 @@ PYAI_V1_17 = "v1.17"
 @pytest.fixture(autouse=True)
 def ai_settings(settings):
     """Fixture to set AI service URLs for testing."""
-    settings.AI_BASE_URL = "https://www.external-ai-service.com/"
-    settings.AI_API_KEY = "test-api-key"
-    settings.AI_MODEL = "test-model"
     settings.AI_AGENT_INSTRUCTIONS = "You are a helpful test assistant :)"
 
-    settings.AUTO_TITLE_AFTER_USER_MESSAGES = None  # disable auto title generation
     return settings
 
 
@@ -742,13 +738,12 @@ def test_post_conversation_tool_call_with_history(
 @freeze_time("2025-07-25T10:36:35.297675Z")
 @respx.mock
 def test_post_conversation_tool_call_fails_with_history(
-    api_client, mock_openai_stream_tool, settings, history_conversation
+    api_client, mock_openai_stream_tool, history_conversation
 ):
     """
     Ensure tool calls are correctly forwarded and streamed back when failing with a
     conversation with history.
     """
-    settings.AI_AGENT_TOOLS = []
 
     url = f"/api/v1.0/chats/{history_conversation.pk}/conversation/?protocol=data"
 

--- a/src/backend/chat/tests/views/chat/conversations/test_conversation_with_image_url.py
+++ b/src/backend/chat/tests/views/chat/conversations/test_conversation_with_image_url.py
@@ -38,9 +38,6 @@ pytestmark = pytest.mark.django_db(transaction=True)
 @pytest.fixture(autouse=True)
 def ai_settings(settings):
     """Fixture to set AI service URLs for testing."""
-    settings.AI_BASE_URL = "https://www.external-ai-service.com/"
-    settings.AI_API_KEY = "test-api-key"
-    settings.AI_MODEL = "test-model"
     settings.AI_AGENT_INSTRUCTIONS = "You are a helpful test assistant :)"
     return settings
 

--- a/src/backend/chat/tests/views/chat/conversations/test_conversation_with_project.py
+++ b/src/backend/chat/tests/views/chat/conversations/test_conversation_with_project.py
@@ -31,9 +31,6 @@ def _get_system_messages(last_respx_call):
 @pytest.fixture(autouse=True)
 def ai_settings(settings):
     """Fixture to set AI service URLs for testing."""
-    settings.AI_BASE_URL = "https://www.external-ai-service.com/"
-    settings.AI_API_KEY = "test-api-key"
-    settings.AI_MODEL = "test-model"
     settings.AI_AGENT_INSTRUCTIONS = "You are a helpful test assistant :)"
 
     return settings

--- a/src/backend/chat/tests/views/chat/conversations/test_conversation_with_project_files.py
+++ b/src/backend/chat/tests/views/chat/conversations/test_conversation_with_project_files.py
@@ -41,16 +41,7 @@ pytestmark = pytest.mark.django_db(transaction=True)
 @pytest.fixture(autouse=True)
 def ai_settings(settings):
     """Albert backend + LLM settings, mirroring the document_upload test fixture."""
-    settings.RAG_DOCUMENT_SEARCH_BACKEND = (
-        "chat.agent_rag.document_rag_backends.albert_rag_backend.AlbertRagBackend"
-    )
-    settings.RAG_DOCUMENT_PARSER = "chat.agent_rag.document_converter.parser.AlbertParser"
-    settings.AI_BASE_URL = "https://www.external-ai-service.com/"
-    settings.AI_API_KEY = "test-api-key"
-    settings.AI_MODEL = "test-model"
     settings.AI_AGENT_INSTRUCTIONS = "You are a helpful test assistant :)"
-    settings.ALBERT_API_URL = "https://albert.api.etalab.gouv.fr"
-    settings.ALBERT_API_KEY = "albert-api-key"
     return settings
 
 
@@ -205,7 +196,6 @@ def _inlineable_llm_config_fixture(settings):
     document to `tool_call_only`. Override with a 4000-token model and a 0.5
     budget ratio so a tiny conversation attachment lands as ACCESS_FULL_CONTEXT.
     """
-    settings.DOCUMENT_CONTEXT_BUDGET_RATIO = 0.5
     settings.DOCUMENT_CONTEXT_SECURITY_BUFFER_TOKENS = 0
     settings.LLM_CONFIGURATIONS = {
         "default-model": LLModel(

--- a/src/backend/chat/tests/views/chat/conversations/test_stop_streaming.py
+++ b/src/backend/chat/tests/views/chat/conversations/test_stop_streaming.py
@@ -13,16 +13,6 @@ from chat.factories import ChatConversationFactory
 pytestmark = pytest.mark.django_db()
 
 
-@pytest.fixture(autouse=True)
-def base_settings(settings):
-    """Set up base settings for the tests."""
-    settings.AI_BASE_URL = "https://api.llm.com/v1/"
-    settings.AI_API_KEY = "test-key"
-    settings.AI_MODEL = "model-123"
-    settings.AI_AGENT_INSTRUCTIONS = "You are a helpful assistant"
-    settings.AI_AGENT_TOOLS = []
-
-
 def test_stop_streaming(api_client):
     """Test that the stop_streaming method is called when the endpoint is called."""
     chat_conversation = factories.ChatConversationFactory()

--- a/src/backend/chat/tests/views/chat/test_delete.py
+++ b/src/backend/chat/tests/views/chat/test_delete.py
@@ -19,11 +19,6 @@ pytestmark = pytest.mark.django_db
 @pytest.fixture(name="albert_settings")
 def fixture_albert_settings(settings):
     """Configure Albert backend so collection cleanup hits a known URL."""
-    settings.RAG_DOCUMENT_SEARCH_BACKEND = (
-        "chat.agent_rag.document_rag_backends.albert_rag_backend.AlbertRagBackend"
-    )
-    settings.ALBERT_API_URL = "https://albert.api.etalab.gouv.fr"
-    settings.ALBERT_API_KEY = "albert-api-key"
     return settings
 
 

--- a/src/backend/chat/tests/views/projects/test_delete.py
+++ b/src/backend/chat/tests/views/projects/test_delete.py
@@ -24,11 +24,6 @@ pytestmark = pytest.mark.django_db
 @pytest.fixture(name="albert_settings")
 def fixture_albert_settings(settings):
     """Configure Albert backend so collection cleanup hits a known URL."""
-    settings.RAG_DOCUMENT_SEARCH_BACKEND = (
-        "chat.agent_rag.document_rag_backends.albert_rag_backend.AlbertRagBackend"
-    )
-    settings.ALBERT_API_URL = "https://albert.api.etalab.gouv.fr"
-    settings.ALBERT_API_KEY = "albert-api-key"
     return settings
 
 

--- a/src/backend/chat/tests/views/test_assistant_health_view.py
+++ b/src/backend/chat/tests/views/test_assistant_health_view.py
@@ -32,8 +32,6 @@ def authenticated_client(client, db):
 @pytest.fixture(autouse=True)
 def patch_llm_settings(settings):
     settings.LLM_DEFAULT_MODEL_HRID = "main-model"
-    settings.LLM_FALLBACK_MODEL_HRID_1 = ""
-    settings.LLM_FALLBACK_MODEL_HRID_2 = ""
     settings.LLM_CONFIGURATIONS = {
         "main-model": _make_model("llama3-8b"),
         "fallback-1": _make_model("mistral-7b"),

--- a/src/backend/conversations/settings.py
+++ b/src/backend/conversations/settings.py
@@ -1416,18 +1416,150 @@ class Test(Base):
 
     os.environ["OPENAI_AGENTS_DISABLE_TRACING"] = "true"
 
-    AI_BASE_URL = None
-    AI_API_KEY = None
-    AI_MODEL = None
+    # -------------------------------------------------------------------------
+    # Deterministic test settings.
+    #
+    # Tests get a dedicated, controlled environment: the ``app-test`` compose
+    # service (docker ``make test``) and pytest-dotenv (host / CI) load
+    # ``env.d/test`` instead of the developer-local ``env.d/development/common``.
+    # With that file gone, every setting Base derives from an environment
+    # variable falls back to Base's coded default, which is already
+    # deterministic. ``env.d/test`` only overrides the handful of settings whose
+    # Base default is unusable in tests (secrets, service credentials, provider
+    # endpoints/models); see that file.
+    #
+    # What stays pinned here is what is genuinely test-specific and NOT env
+    # -backed in Base:
+    #   - infra topology (Postgres, MinIO) describes the network, not behavior:
+    #     it defaults to the docker-compose hostnames but stays env-overridable
+    #     so pytest also runs on the host / in CI (repo-root .env or the CI job
+    #     env point at the published ports);
+    #   - test-only backends and structures (dummy malware backend, DRF/OpenAPI,
+    #     CORS headers, storages);
+    #   - the large AI/RAG prompts kept as short placeholders (the real ones are
+    #     only exercised by tests that override them explicitly).
+    #
+    # chat/tests/test_settings_isolation.py asserts the resulting settings are
+    # deterministic.
+    # -------------------------------------------------------------------------
 
-    # Pin to no role restriction so tests are deterministic regardless of the
-    # developer's local env (which may set OIDC_ALLOWED_ROLES); tests that need
-    # the restriction set it explicitly via override_settings.
-    OIDC_ALLOWED_ROLES = []
+    # -- Infra: docker-compose topology by default, env-overridable ------------
+    # Tests run from two vantage points: inside docker (DB_HOST=postgresql via
+    # the app-test service defaults) and on the host / CI (DB_HOST=localhost via
+    # the repo-root .env or the CI job env).
+    DATABASES = {
+        "default": {
+            "ENGINE": "django.db.backends.postgresql_psycopg2",
+            "NAME": "conversations",
+            "USER": "dinum",
+            "PASSWORD": "pass",
+            "HOST": os.environ.get("DB_HOST", "postgresql"),
+            "PORT": int(os.environ.get("DB_PORT", "5432")),
+        }
+    }
 
-    POSTHOG_KEY = None
+    STORAGES = {
+        "default": {"BACKEND": "storages.backends.s3.S3Storage"},
+        "staticfiles": {"BACKEND": "whitenoise.storage.CompressedManifestStaticFilesStorage"},
+    }
 
-    AUTO_TITLE_AFTER_USER_MESSAGES = None
+    # AWS_S3_ENDPOINT_URL: docker default is the compose MinIO host; the repo
+    # -root .env / CI job env point it at the published port.
+    AWS_S3_ENDPOINT_URL = os.environ.get("AWS_S3_ENDPOINT_URL", "http://minio:9000")
+
+    # -- Attachments: dummy malware backend ------------------------------------
+    MALWARE_DETECTION = {
+        "BACKEND": "lasuite.malware_detection.backends.dummy.DummyBackend",
+        "PARAMETERS": {
+            "callback_path": ("core.file_upload.malware_detection.malware_detection_callback"),
+        },
+    }
+
+    # -- DRF / OpenAPI ---------------------------------------------------------
+    REST_FRAMEWORK = {
+        "DEFAULT_AUTHENTICATION_CLASSES": (
+            "mozilla_django_oidc.contrib.drf.OIDCAuthentication",
+            "rest_framework.authentication.SessionAuthentication",
+        ),
+        "DEFAULT_PARSER_CLASSES": [
+            "rest_framework.parsers.JSONParser",
+            "nested_multipart_parser.drf.DrfNestedParser",
+        ],
+        "DEFAULT_RENDERER_CLASSES": [
+            "rest_framework.renderers.JSONRenderer",
+        ],
+        "EXCEPTION_HANDLER": "core.api.exception_handler",
+        "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
+        "PAGE_SIZE": 20,
+        "DEFAULT_VERSIONING_CLASS": "rest_framework.versioning.URLPathVersioning",
+        "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
+        "DEFAULT_THROTTLE_RATES": {
+            "attachment_upload": "60/minute",
+            "attachment_auth": "60/minute",
+            "file-stream": "60/minute",
+        },
+    }
+
+    SPECTACULAR_SETTINGS = {
+        "TITLE": "Conversations API",
+        "DESCRIPTION": "This is the conversations API schema.",
+        "VERSION": "1.0.0",
+        "SERVE_INCLUDE_SCHEMA": False,
+        "ENABLE_DJANGO_DEPLOY_CHECK": False,
+        "COMPONENT_SPLIT_REQUEST": True,
+        "SWAGGER_UI_DIST": "SIDECAR",
+        "SWAGGER_UI_FAVICON_HREF": "SIDECAR",
+        "REDOC_DIST": "SIDECAR",
+    }
+
+    # -- CORS ------------------------------------------------------------------
+    CORS_ALLOW_HEADERS = [
+        "x-posthog-distinct-id",
+        "x-posthog-session-id",
+    ] + list(default_headers)
+
+    # -- AI / RAG prompt placeholders ------------------------------------------
+    # Kept as short placeholders instead of Base's large production prompts;
+    # tests that assert on prompt content override these explicitly.
+    AI_AGENT_INSTRUCTIONS = "You are a helpful assistant."
+
+    RAG_WEB_SEARCH_PROMPT_UPDATE = (
+        "Answer using the search results:\n{search_results}\nQuestion: {user_prompt}"
+    )
+
+    # -- Logging ---------------------------------------------------------------
+    LOGGING = {
+        "version": 1,
+        "disable_existing_loggers": False,
+        "formatters": {
+            "simple": {
+                "format": "{asctime} {name} {levelname} {message}",
+                "style": "{",
+            },
+        },
+        "handlers": {
+            "console": {
+                "class": "logging.StreamHandler",
+                "formatter": "simple",
+            },
+        },
+        "root": {
+            "handlers": ["console"],
+            "level": "INFO",
+        },
+        "loggers": {
+            "core": {
+                "handlers": ["console"],
+                "level": "INFO",
+                "propagate": False,
+            },
+            "conversations.security": {
+                "handlers": ["console"],
+                "level": "INFO",
+                "propagate": False,
+            },
+        },
+    }
 
     def __init__(self):
         # pylint: disable=invalid-name

--- a/src/backend/core/tests/authentication/test_backends.py
+++ b/src/backend/core/tests/authentication/test_backends.py
@@ -153,7 +153,6 @@ def test_authentication_getter_existing_user_no_fallback_to_email_no_duplicate(
 
     # Set the setting to False
     settings.OIDC_FALLBACK_TO_EMAIL_FOR_IDENTIFICATION = False
-    settings.OIDC_ALLOW_DUPLICATE_EMAILS = False
 
     def get_userinfo_mocked(*args):
         return {"sub": "123", "email": db_user.email}
@@ -186,7 +185,6 @@ def test_authentication_getter_existing_user_no_fallback_to_email_no_duplicate_c
 
     # Set the setting to False
     settings.OIDC_FALLBACK_TO_EMAIL_FOR_IDENTIFICATION = False
-    settings.OIDC_ALLOW_DUPLICATE_EMAILS = False
 
     def get_userinfo_mocked(*args):
         return {"sub": "123", "email": "JOHN.DOE@EXAMPLE.COM"}
@@ -361,7 +359,6 @@ def test_authentication_getter_new_user_with_email(monkeypatch):
     assert models.User.objects.count() == 1
 
 
-@override_settings(OIDC_OP_USER_ENDPOINT="http://oidc.endpoint.test/userinfo")
 @responses.activate
 def test_authentication_get_userinfo_json_response():
     """Test get_userinfo method with a JSON response."""
@@ -385,7 +382,6 @@ def test_authentication_get_userinfo_json_response():
     assert result["email"] == "john.doe@example.com"
 
 
-@override_settings(OIDC_OP_USER_ENDPOINT="http://oidc.endpoint.test/userinfo")
 @responses.activate
 def test_authentication_get_userinfo_token_response(monkeypatch, settings):
     """Test get_userinfo method with a token response."""
@@ -415,7 +411,6 @@ def test_authentication_get_userinfo_token_response(monkeypatch, settings):
     assert result["email"] == "jane.doe@example.com"
 
 
-@override_settings(OIDC_OP_USER_ENDPOINT="http://oidc.endpoint.test/userinfo")
 @responses.activate
 def test_authentication_get_userinfo_invalid_response(settings):
     """
@@ -505,9 +500,6 @@ def test_authentication_session_tokens(django_assert_num_queries, monkeypatch, r
     """
     Test that the session contains oidc_refresh_token and oidc_access_token after authentication.
     """
-    settings.OIDC_OP_TOKEN_ENDPOINT = "http://oidc.endpoint.test/token"
-    settings.OIDC_OP_USER_ENDPOINT = "http://oidc.endpoint.test/userinfo"
-    settings.OIDC_OP_JWKS_ENDPOINT = "http://oidc.endpoint.test/jwks"
     settings.OIDC_STORE_ACCESS_TOKEN = True
     settings.OIDC_STORE_REFRESH_TOKEN = True
     settings.OIDC_STORE_REFRESH_TOKEN_KEY = Fernet.generate_key()
@@ -556,13 +548,9 @@ def test_authentication_user_added_to_brevo(monkeypatch, rf, settings):
     """
     Test that a user is added to the Brevo follow-up list upon authentication.
     """
-    settings.OIDC_OP_TOKEN_ENDPOINT = "http://oidc.endpoint.test/token"
-    settings.OIDC_OP_USER_ENDPOINT = "http://oidc.endpoint.test/userinfo"
-    settings.OIDC_OP_JWKS_ENDPOINT = "http://oidc.endpoint.test/jwks"
 
     settings.BREVO_API_KEY = "test-api-key"
     settings.BREVO_FOLLOWUP_LIST_ID = "follow-up-list-id"
-    settings.ACTIVATION_REQUIRED = False
 
     brevo_create_contact = responses.post(
         "https://api.brevo.com/v3/contacts",
@@ -635,13 +623,8 @@ def test_authentication_user_not_added_to_brevo_without_list_id(monkeypatch, rf,
     """
     Test that no Brevo call is made when BREVO_FOLLOWUP_LIST_ID is not configured.
     """
-    settings.OIDC_OP_TOKEN_ENDPOINT = "http://oidc.endpoint.test/token"
-    settings.OIDC_OP_USER_ENDPOINT = "http://oidc.endpoint.test/userinfo"
-    settings.OIDC_OP_JWKS_ENDPOINT = "http://oidc.endpoint.test/jwks"
 
     settings.BREVO_API_KEY = "test-api-key"
-    settings.BREVO_FOLLOWUP_LIST_ID = None
-    settings.ACTIVATION_REQUIRED = False
 
     brevo_create_contact = responses.post(
         "https://api.brevo.com/v3/contacts",
@@ -690,13 +673,9 @@ def test_authentication_role_denied_user_not_added_to_brevo(monkeypatch, rf, set
     """
     Test that a user denied by the role gate is not added to the Brevo list.
     """
-    settings.OIDC_OP_TOKEN_ENDPOINT = "http://oidc.endpoint.test/token"
-    settings.OIDC_OP_USER_ENDPOINT = "http://oidc.endpoint.test/userinfo"
-    settings.OIDC_OP_JWKS_ENDPOINT = "http://oidc.endpoint.test/jwks"
 
     settings.BREVO_API_KEY = "test-api-key"
     settings.BREVO_FOLLOWUP_LIST_ID = "follow-up-list-id"
-    settings.ACTIVATION_REQUIRED = False
     settings.OIDC_ALLOWED_ROLES = ["agent_public_etat"]
 
     brevo_create_contact = responses.post(
@@ -746,7 +725,6 @@ def test_authentication_role_denied_user_not_added_to_brevo(monkeypatch, rf, set
     assert len(brevo_add_to_list.calls) == 0
 
 
-@override_settings(OIDC_ALLOWED_ROLES=[])
 def test_verify_claims_no_allowed_roles_setting_allows_any_user():
     """With OIDC_ALLOWED_ROLES empty, any user passing essential claims is allowed."""
     klass = OIDCAuthenticationBackend()

--- a/src/backend/core/tests/test_api_config.py
+++ b/src/backend/core/tests/test_api_config.py
@@ -79,7 +79,6 @@ def test_api_config(is_authenticated):
     }
 
 
-@override_settings(FRONTEND_CONTACT_EMAIL=None, FRONTEND_DOCUMENTATION_URL=None)
 def test_api_config_help_links_unset():
     """Documentation URL and contact email are exposed as None when not configured."""
     response = APIClient().get("/api/v1.0/config/")
@@ -243,7 +242,6 @@ async def test_api_config_async(is_authenticated):
 
 
 @override_settings(
-    STATUS_PAGE_URL=None,
     THEME_CUSTOMIZATION_FILE_PATH="",
     RAG_FILES_ACCEPTED_FORMATS=["application/pdf"],
 )

--- a/src/backend/core/tests/test_maintenance.py
+++ b/src/backend/core/tests/test_maintenance.py
@@ -77,7 +77,6 @@ def test_env_var_forces_active_even_if_db_disabled():
     assert is_maintenance_active() is True
 
 
-@override_settings(MAINTENANCE_MODE=False)
 def test_db_only_when_env_off():
     """With env off, the DB singleton state alone drives the flag."""
     config = models.MaintenanceMode.get_solo()

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -91,6 +91,7 @@ dev = [
     "pytest-asyncio==1.4.0",
     "pytest-cov==7.1.0",
     "pytest-django==4.12.0",
+    "pytest-dotenv==0.5.2",
     "pytest==9.0.3",
     "pytest-icdiff==0.9",
     "pytest-xdist==3.8.0",
@@ -179,4 +180,13 @@ addopts = [
 python_files = [
     "test_*.py",
     "tests.py",
+]
+# For host-run pytest and CI (docker uses the app-test service env_file instead),
+# load the dedicated, deterministic test environment. env.d/test carries the
+# behavior settings; the repo-root .env carries host infra topology (DB/S3 ports).
+# Existing process env is never overridden, so the CI job env (localhost/5432)
+# wins over .env's host ports (localhost/15432).
+env_files = [
+    "env.d/test",
+    ".env",
 ]

--- a/src/backend/uv.lock
+++ b/src/backend/uv.lock
@@ -560,6 +560,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-django" },
+    { name = "pytest-dotenv" },
     { name = "pytest-icdiff" },
     { name = "pytest-xdist" },
     { name = "responses" },
@@ -619,6 +620,7 @@ requires-dist = [
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = "==1.4.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = "==7.1.0" },
     { name = "pytest-django", marker = "extra == 'dev'", specifier = "==4.12.0" },
+    { name = "pytest-dotenv", marker = "extra == 'dev'", specifier = "==0.5.2" },
     { name = "pytest-icdiff", marker = "extra == 'dev'", specifier = "==0.9" },
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = "==3.8.0" },
     { name = "python-magic", specifier = "==0.4.27" },
@@ -2779,6 +2781,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/13/2b/db9a193df89e5660137f5428063bcc2ced7ad790003b26974adf5c5ceb3b/pytest_django-4.12.0.tar.gz", hash = "sha256:df94ec819a83c8979c8f6de13d9cdfbe76e8c21d39473cfe2b40c9fc9be3c758", size = 91156, upload-time = "2026-02-14T18:40:49.235Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/83/a5/41d091f697c09609e7ef1d5d61925494e0454ebf51de7de05f0f0a728f1d/pytest_django-4.12.0-py3-none-any.whl", hash = "sha256:3ff300c49f8350ba2953b90297d23bf5f589db69545f56f1ec5f8cff5da83e85", size = 26123, upload-time = "2026-02-14T18:40:47.381Z" },
+]
+
+[[package]]
+name = "pytest-dotenv"
+version = "0.5.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "python-dotenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cd/b0/cafee9c627c1bae228eb07c9977f679b3a7cb111b488307ab9594ba9e4da/pytest-dotenv-0.5.2.tar.gz", hash = "sha256:2dc6c3ac6d8764c71c6d2804e902d0ff810fa19692e95fe138aefc9b1aa73732", size = 3782, upload-time = "2020-06-16T12:38:03.4Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/da/9da67c67b3d0963160e3d2cbc7c38b6fae342670cc8e6d5936644b2cf944/pytest_dotenv-0.5.2-py3-none-any.whl", hash = "sha256:40a2cece120a213898afaa5407673f6bd924b1fa7eafce6bda0e8abffe2f710f", size = 3993, upload-time = "2020-06-16T12:38:01.139Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Purpose

Update test settings for RAG parser so that we can run tests with updating config (common file)


## Proposal

- [x] Pin `RAG_DOCUMENT_PARSER` for tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Test runs now rely on fully pinned, deterministic test configuration (DB/storage/AWS endpoints, API/RAG placeholders, logging, CORS), reducing failures from local environment differences.
  * Improved isolation to prevent developer settings from leaking into tests.
* **Tests**
  * Reduced reliance on per-test settings overrides; updated affected test suites to match the shared deterministic defaults.
  * Added/extended guards to validate settings determinism for the test environment.
* **Chores**
  * Added a dedicated `app-test` run path and streamlined CI/test environment variables using `env.d/test` + `pytest-dotenv`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->