### PR TITLE
✨(deindex) handle 404 during deletion as successful de-indexing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [unreleased]
+
+### Fixed
+
+- ✨(back) handle 404 during deletion as successful de-indexing 
 
 ### Changed
 

--- a/src/backend/chat/management/commands/deindex_inactive_collections.py
+++ b/src/backend/chat/management/commands/deindex_inactive_collections.py
@@ -10,6 +10,8 @@ from django.core.management.base import BaseCommand
 from django.utils import timezone
 from django.utils.module_loading import import_string
 
+import requests
+
 from chat.enums import CollectionIndexState
 from chat.models import ChatConversation, ChatConversationAttachment
 
@@ -42,7 +44,20 @@ def _deindex_one(conv, *, backend_cls, threshold):
 
     try:
         backend_cls(collection_id=conv.collection_id).delete_collection()
-    except Exception:  # pylint: disable=broad-except
+    except Exception as exc:  # pylint: disable=broad-except
+        if isinstance(exc, requests.HTTPError):
+            response = exc.response
+            if response is not None and response.status_code == 404:
+                # Collection already gone on the backend — the earlier
+                # .update() calls already cleared our state, so treat it as
+                # a successful de-index.
+                logger.info(
+                    "Collection %s for conversation %s already deleted (404), "
+                    "treating as de-indexed",
+                    conv.collection_id,
+                    conv.pk,
+                )
+                return True
         # Conditional restore: only write back if the row is still NULL so we
         # don't overwrite a collection_id set by a concurrent re-index.
         ChatConversation.objects.filter(pk=conv.pk, collection_id__isnull=True).update(

--- a/src/backend/chat/tests/management/commands/test_deindex_inactive_collections.py
+++ b/src/backend/chat/tests/management/commands/test_deindex_inactive_collections.py
@@ -7,6 +7,7 @@ from django.core.management import call_command
 from django.utils import timezone
 
 import pytest
+import requests
 
 from chat.enums import CollectionIndexState
 from chat.factories import ChatConversationAttachmentFactory, ChatConversationFactory
@@ -152,6 +153,38 @@ def test_rollback_restores_exact_pre_deindex_state(settings):
     att_pending.refresh_from_db()
     assert att_pending.is_indexed is False
     assert att_pending.rag_document_id is None
+
+
+@pytest.mark.django_db(transaction=True)
+def test_treats_404_as_deindexed(settings):
+    """A 404 from delete_collection means the collection is already gone — keep cleared state."""
+    settings.RAG_COLLECTION_INACTIVITY_DAYS = 30
+    conv = ChatConversationFactory(
+        collection_id="albert-gone", index_state=CollectionIndexState.INDEXED
+    )
+    past = timezone.now() - timedelta(days=31)
+    ChatConversation.objects.filter(pk=conv.pk).update(updated_at=past)
+    attachment = ChatConversationAttachmentFactory(
+        conversation=conv, is_indexed=True, rag_document_id="doc-gone"
+    )
+
+    response = MagicMock(status_code=404)
+    error = requests.HTTPError("404 Not Found", response=response)
+    mock_instance = MagicMock()
+    mock_instance.delete_collection.side_effect = error
+    mock_backend_cls = MagicMock(return_value=mock_instance)
+    with patch(
+        "chat.management.commands.deindex_inactive_collections.import_string",
+        return_value=mock_backend_cls,
+    ):
+        call_command("deindex_inactive_collections")
+
+    conv.refresh_from_db()
+    assert conv.collection_id is None
+    assert conv.index_state == CollectionIndexState.DEINDEXED
+    attachment.refresh_from_db()
+    assert attachment.is_indexed is False
+    assert attachment.rag_document_id is None
 
 
 @pytest.mark.django_db(transaction=True)


### PR DESCRIPTION
## Purpose

  The deindex_inactive_collections cron de-indexes RAG collections for inactive conversations by calling delete_collection() on  the RAG backend. Some collections have already been deleted out  of band, so that call returns HTTP 404.

  Previously, _deindex_one treated any exception from delete_collection() as a failure: it restored collection_id /  index_state on the conversation and its attachments, then  returned False. Because the collection_id was never cleared, the  cron picked the same conversation up again on every run and  retried forever against a collection that no longer exists.



##  Proposal

  Treat a 404 as a successful de-index, so these conversations are cleared once and stop being reprocessed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of 404 errors during collection deletion by treating them as successfully de-indexed, avoiding unnecessary error recovery that could leave indexing metadata inconsistent.

* **Documentation**
  * Updated the changelog under **Unreleased → Fixed** to reflect the 404-as-successful-de-indexing behavior.

* **Tests**
  * Added coverage to verify that a 404 deletion failure results in clearing the conversation’s collection reference, marking it de-indexed, and updating related attachment indexing records accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->