### PR TITLE
✨(front) icon status link styling

### DIFF
--- a/src/frontend/apps/conversations/src/features/chat/components/ChatError.tsx
+++ b/src/frontend/apps/conversations/src/features/chat/components/ChatError.tsx
@@ -59,8 +59,14 @@ export const ChatError = ({
               target="_blank"
               rel="noopener noreferrer"
               aria-label={t('Check service status')}
+              style={{
+                color:
+                  'var(--c--contextuals--content--semantic--greyscale--700)',
+                display: 'inline-flex',
+                textDecoration: 'none',
+              }}
             >
-              <Icon iconName="info" $size="1.375rem" $color="greyscale" />
+              <Icon iconName="info" $size="1.375rem" $withThemeInherited />
             </a>
           )}
         </Box>


### PR DESCRIPTION
Make status Icon it readable in Dark and Light mode
<img width="634" height="133" alt="Screenshot 2026-06-24 at 10 36 34" src="https://github.com/user-attachments/assets/cb7d5782-6486-4468-8fb6-44e1c8a75969" />
<img width="609" height="145" alt="Screenshot 2026-06-24 at 10 36 22" src="https://github.com/user-attachments/assets/d2236439-353a-40b6-ae0f-cf1c9c6c4402" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the appearance of the provider status link in chat error messages, with cleaner inline layout and consistent theme-based styling.
  * Updated the error info icon to better match the surrounding theme colors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->