### PR TITLE
💄(front) use "L'Assistant" as the default product name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,11 @@ and this project adheres to
 - 🔧(dependencies) bump backend to Python 3.14 and update pinned dependencies
 - ⬆️(dependencies) update front and mail dependencies
 - ♻️(front) source the home documentation link from config
+- 💄(front) use "L'Assistant" as the default product name
 
 ### Fixed
 
 - 🐛(front) keep the app open when using the contact link
->>>>>>> 0064d5f (🐛(front) fix contact link target and home doc link)
 
 ## [0.0.18] - 2026-06-12
 

--- a/src/frontend/apps/conversations/src/core/settings.ts
+++ b/src/frontend/apps/conversations/src/core/settings.ts
@@ -1,1 +1,2 @@
-export const productName = process.env.NEXT_PUBLIC_PRODUCT_NAME || 'Assistant';
+export const productName =
+  process.env.NEXT_PUBLIC_PRODUCT_NAME || "L'Assistant";


### PR DESCRIPTION

## Purpose

The default product name shown when no environment override is configured did  not match the intended branding for the French-language deployment.

## Proposal

Update the fallback product name so the application presents the correct default  title when the product-name environment variable is not set.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default app/product name shown to users to **“L'Assistant”** when no custom name is configured.
  * Kept the existing contact-link behavior unchanged (the app remains open).
* **Documentation**
  * Updated the changelog under the unreleased fixes to reflect the new default product name, alongside the existing contact-link entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->