### PR TITLE
✨(fix) update User interface to allow null full_name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to
 
 - ♻️(back) split chat views and replace hardcoded strings with constants
  
+### Fixed
+
+- 🐛(front) prevent app crash for users without a full name or email
+
 ## [0.0.19] - 2026-06-24
 
 ### Changed

--- a/src/frontend/apps/conversations/src/features/auth/api/types.ts
+++ b/src/frontend/apps/conversations/src/features/auth/api/types.ts
@@ -9,9 +9,9 @@
  */
 export interface User {
   id: string;
-  email: string;
-  full_name: string;
-  short_name: string;
+  email: string | null;
+  full_name: string | null;
+  short_name: string | null;
   language?: string;
   allow_smart_web_search: boolean;
   allow_conversation_analytics: boolean;

--- a/src/frontend/apps/conversations/src/features/auth/components/ActivationPage.tsx
+++ b/src/frontend/apps/conversations/src/features/auth/components/ActivationPage.tsx
@@ -22,6 +22,7 @@ import FichiersIcon from '../assets/fichiers.svg';
 import TchapIcon from '../assets/tchap.svg';
 import VisioIcon from '../assets/visio.svg';
 import { useAuth } from '../hooks';
+import { getUserEmail } from '../utils';
 
 export const ActivationPage = () => {
   const { t } = useTranslation();
@@ -359,7 +360,7 @@ export const ActivationPage = () => {
                   ? t(
                       "We'll email you at {{email}} when the public beta opens.",
                       {
-                        email: user.email,
+                        email: getUserEmail(user),
                       },
                     )
                   : t("We'll email you when the public beta opens.") // should not happen

--- a/src/frontend/apps/conversations/src/features/auth/components/UserInfo.tsx
+++ b/src/frontend/apps/conversations/src/features/auth/components/UserInfo.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { LanguagePicker } from '@/features/language';
 
 import { useAuth } from '../hooks';
-import { gotoLogin, gotoLogout } from '../utils';
+import { getUserEmail, getUserFullName, gotoLogin, gotoLogout } from '../utils';
 
 export const UserInfo = () => {
   const { t } = useTranslation();
@@ -25,7 +25,10 @@ export const UserInfo = () => {
 
   return (
     <UserMenu
-      user={{ email: user.email, full_name: user.full_name }}
+      user={{
+        email: getUserEmail(user),
+        full_name: getUserFullName(user, t('User')),
+      }}
       logout={gotoLogout}
       actions={<LanguagePicker />}
       termOfServiceUrl="https://docs.numerique.gouv.fr/docs/7b118d32-7f3c-4226-a3d0-92d2f33c5f0a/"

--- a/src/frontend/apps/conversations/src/features/auth/utils.ts
+++ b/src/frontend/apps/conversations/src/features/auth/utils.ts
@@ -1,4 +1,12 @@
+import { User } from './api/types';
 import { LOGIN_URL, LOGOUT_URL, PATH_AUTH_LOCAL_STORAGE } from './conf';
+
+/** Safe email for display, since the API may return a null email. */
+export const getUserEmail = (user: User) => user.email ?? '';
+
+/** Best available display name, falling back through email/short name to a default. */
+export const getUserFullName = (user: User, fallback: string) =>
+  user.full_name || user.email || user.short_name || fallback;
 
 export const getAuthUrl = () => {
   const path_auth = localStorage.getItem(PATH_AUTH_LOCAL_STORAGE);


### PR DESCRIPTION
# Purpose

  The app crashes on load with TypeError: can't access property "split", t is null whenever the logged-in user has a null  full_name — for example a superuser created via make superuser  without --full-name.

  The UserAvatar component from @gouvfr-lasuite/ui-kit (rendered   inside UserMenu) derives its initials by calling .split(' ') on   full_name with no null guard, so any account with an unset  full_name cannot use the app.

  The root cause is twofold: we passed full_name straight through  without a fallback, and our User type declared full_name: string  (non-nullable), which hid the problem from TypeScript even though the API can return null.

  Proposal

  - [x] UserInfo.tsx — pass user.full_name ?? user.email to   UserMenu so a non-empty string is always supplied; when   full_name is null the avatar falls back to the email's first letter
  - [x] auth/api/types.ts — change full_name: string → full_name:   string | null so the type matches the API and the nullish  fallback is type-meaningful (and not flagged as redundant by   @typescript-eslint/no-unnecessary-condition)
  - [x] Verified full_name has a single consumer in the frontend,   so the type widening is safe and surgical

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented app crashes for users missing a full name or email.
  * Improved sign-in/menu profile display by adding safe fallbacks for missing email and name values.
  * Updated notification email rendering to handle missing email using a safe default.
* **Chores**
  * Refreshed the unreleased changelog entry formatting and included the latest fix note.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->