### PR TITLE
🐳(docker) keep frontend dev cache inside the container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to
 ### Changed
 
 - ♻️(back) split chat views and replace hardcoded strings with constants
+
+### Fixed
+
+- 🐳(docker) keep the frontend dev build cache inside the container
  
 ### Fixed
 

--- a/compose.yml
+++ b/compose.yml
@@ -151,6 +151,9 @@ services:
       - ./src/frontend:/home/frontend
       - /home/frontend/node_modules
       - /home/frontend/apps/conversations/node_modules
+      # Keep .next inside the container. On the macOS bind mount, Turbopack's dev
+      # cache desyncs and forces a manual `rm -rf .next` after restarts.
+      - /home/frontend/apps/conversations/.next
     ports:
       - "3000:3000"
 

--- a/src/frontend/Dockerfile
+++ b/src/frontend/Dockerfile
@@ -29,6 +29,11 @@ FROM frontend-deps AS conversations-dev
 
 WORKDIR /home/frontend/apps/conversations
 
+# Pre-create .next so its (anonymous) volume inherits a writable dir. The container
+# runs as an arbitrary host UID (DOCKER_USER), while the image is built as root, so
+# the dir must be world-writable for `next dev` to create its cache.
+RUN mkdir -p .next && chmod 777 .next
+
 EXPOSE 3000
 
 CMD [ "yarn", "dev"]


### PR DESCRIPTION
## Purpose

The frontend dev server would break after most restarts, requiring a manual wipe of the local build cache before it would serve pages again. This was caused by the dev build cache living on the host bind mount, where the macOS Docker filesystem loses consistency with the container and corrupts the cache across restarts.

## Proposal

- [ ] Keep the frontend dev build cache inside the container instead of on the host bind mount, so it stays consistent across restarts.
- [ ] Ensure the cache directory is writable by the container runtime user, regardless of the host user id used to start the stack.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the frontend development environment so build cache files stay inside the container and remain writable.
  * Reduced issues with stale or out-of-sync dev cache on macOS bind mounts.
  * Avoided the need to manually remove the local build cache after restarting development containers.

* **Chores**
  * Updated the changelog with the latest fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->