### PR TITLE
♻️(front) extract reusable input chat banner component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,15 +25,16 @@ and this project adheres to
 - ✨(back) process project files asynchronously with indexing state
 - ⚡️(back) process conversation files asynchronously off the request worker
 - ⬆️(dependencies) update dependencies and pin CVE-affected packages
-
-### Removed
-
-- 🔥(back) remove the Find RAG backend and its FIND_API_* settings
+- ♻️(front) consolidate input chat banners into a reusable component
 
 ### Fixed
 
 - 🐛(front) prevent app crash for users without a full name or email
 - 🐛(front) refresh the conversation title in the collapsed left panel
+
+### Removed
+
+- 🔥(back) remove the Find RAG backend and its FIND_API_* settings
 
 ## [0.0.19] - 2026-06-24
 

--- a/src/backend/chat/tests/views/chat/conversations/test_conversation_with_project_files.py
+++ b/src/backend/chat/tests/views/chat/conversations/test_conversation_with_project_files.py
@@ -293,28 +293,19 @@ def test_post_conversation_inlines_convo_doc_while_project_doc_stays_rag_only(
     assert "The conversation note says hello." in docs_by_title["note.md"]["content"]
 
 
-@pytest.mark.parametrize(
-    ("upload_state", "index_state"),
-    [
-        (AttachmentStatus.ANALYZING, AttachmentIndexState.NOT_INDEXED),
-        (AttachmentStatus.READY, AttachmentIndexState.INDEXING),
-    ],
-)
-def test_post_conversation_blocked_while_project_file_in_flight(
-    api_client, upload_state, index_state
-):
-    """A project file whose scan or indexing is still running blocks the message with 409.
+def test_post_conversation_blocked_while_project_file_scanning(api_client):
+    """A project file still being malware-scanned blocks the message with 409.
 
-    The backstop must catch both in-flight states: a file mid-scan (ANALYZING,
-    not yet handed to the indexer) and a file mid-indexing (INDEXING). Answering
-    before either settles would silently ignore the file's content.
+    The scan is the only in-flight state that blocks: its content must not reach
+    the model before the scan clears it. Indexing does not block (see
+    `test_post_conversation_not_blocked_while_project_file_indexing`).
     """
     project = ChatProjectFactory(collection_id="22")
     ChatProjectAttachmentFactory(
         project=project,
         content_type="text/plain",
-        upload_state=upload_state,
-        index_state=index_state,
+        upload_state=AttachmentStatus.ANALYZING,
+        index_state=AttachmentIndexState.NOT_INDEXED,
     )
     conversation = ChatConversationFactory(owner=project.owner, project=project)
     api_client.force_authenticate(user=conversation.owner)
@@ -327,6 +318,49 @@ def test_post_conversation_blocked_while_project_file_in_flight(
 
     assert response.status_code == status.HTTP_409_CONFLICT
     assert response.json() == {"error": "project_files_indexing"}
+
+
+@respx.mock
+@freeze_time("2025-07-25T10:36:35.297675Z")
+def test_post_conversation_not_blocked_by_stale_scanning_file(
+    api_client,
+    settings,
+    hello_conversation_data,
+    mock_ai_agent_service,
+):
+    """A row stuck in ANALYZING past the window must not deadlock messaging.
+
+    The scan runs off-process and reports back via callback. If it exhausts its
+    retries or the worker dies, the callback never fires and the row stays
+    ANALYZING forever, which would block every message in the project for good.
+    Once `updated_at` is older than the cutoff the gate stops blocking on it.
+    """
+    project = ChatProjectFactory(collection_id=None)
+    attachment = ChatProjectAttachmentFactory(
+        project=project,
+        content_type="text/plain",
+        upload_state=AttachmentStatus.ANALYZING,
+        index_state=AttachmentIndexState.NOT_INDEXED,
+    )
+    # `updated_at` is auto_now, so bypass it with .update() to age the row past
+    # the cutoff (CELERY_TASK_TIME_LIMIT + 60s margin).
+    stale = timezone.now() - timedelta(seconds=settings.CELERY_TASK_TIME_LIMIT + 120)
+    type(attachment).objects.filter(pk=attachment.pk).update(updated_at=stale)
+
+    conversation = ChatConversationFactory(owner=project.owner, project=project)
+    api_client.force_authenticate(user=conversation.owner)
+
+    def agent_model(_messages: list[ModelMessage], _info: AgentInfo):
+        return ModelResponse(parts=[TextPart(content="Hello there")])
+
+    with mock_ai_agent_service(FunctionModel(function=agent_model)):
+        response = api_client.post(
+            f"/api/v1.0/chats/{conversation.pk}/conversation/",
+            data=hello_conversation_data,
+            format="json",
+        )
+
+    assert response.status_code == status.HTTP_200_OK
 
 
 @respx.mock
@@ -365,29 +399,24 @@ def test_post_conversation_not_blocked_by_terminal_suspicious_file(
 
 @respx.mock
 @freeze_time("2025-07-25T10:36:35.297675Z")
-def test_post_conversation_not_blocked_by_stale_indexing_file(
+def test_post_conversation_not_blocked_while_project_file_indexing(
     api_client,
-    settings,
     hello_conversation_data,
     mock_ai_agent_service,
 ):
-    """A row stuck in INDEXING past the hard-limit window must not deadlock messaging.
+    """A project file mid-indexing must not block messaging.
 
-    If the indexing worker is SIGKILLed / OOM-killed / crashes, the row never
-    leaves INDEXING. Once its `updated_at` is older than CELERY_TASK_TIME_LIMIT
-    plus the margin, the gate stops blocking on it so the project can chat again.
+    Indexing runs as a Celery task and can take a while, so the user is allowed
+    to send anyway (e.g. a quick question unrelated to the documents). The file
+    is simply not searchable yet; the frontend banner says so.
     """
     project = ChatProjectFactory(collection_id=None)
-    attachment = ChatProjectAttachmentFactory(
+    ChatProjectAttachmentFactory(
         project=project,
         content_type="text/plain",
         upload_state=AttachmentStatus.READY,
         index_state=AttachmentIndexState.INDEXING,
     )
-    # `updated_at` is auto_now, so bypass it with .update() to age the row past
-    # the cutoff (CELERY_TASK_TIME_LIMIT + 60s margin).
-    stale = timezone.now() - timedelta(seconds=settings.CELERY_TASK_TIME_LIMIT + 120)
-    type(attachment).objects.filter(pk=attachment.pk).update(updated_at=stale)
 
     conversation = ChatConversationFactory(owner=project.owner, project=project)
     api_client.force_authenticate(user=conversation.owner)

--- a/src/backend/chat/views/conversations.py
+++ b/src/backend/chat/views/conversations.py
@@ -5,7 +5,7 @@ import os
 from datetime import timedelta
 
 from django.conf import settings
-from django.db.models import Exists, OuterRef, Q
+from django.db.models import Exists, OuterRef
 from django.http import StreamingHttpResponse
 from django.utils import timezone
 from django.utils.module_loading import import_string
@@ -25,7 +25,6 @@ from activation_codes.permissions import IsActivatedUser
 from chat import models, serializers
 from chat.clients.pydantic_ai import AIAgentService
 from chat.constants import IMAGE_MIME_PREFIX, SSE_MIME_TYPE
-from chat.enums import AttachmentIndexState
 from chat.keepalive import stream_with_keepalive_async, stream_with_keepalive_sync
 from chat.model_routing import resolve_effective_model_hrid
 from chat.rate_limiting import ChatCooldownThrottle, get_cooldown_remaining
@@ -238,34 +237,33 @@ class ChatViewSet(  # pylint: disable=too-many-ancestors, abstract-method
 
         conversation = self.get_object()
 
-        # Backstop the frontend gate: a project file whose malware scan or RAG
-        # indexing is still running isn't searchable yet, so answering now would
-        # silently ignore it. Refuse the message until both settle (the frontend
-        # blocks send too). Only these in-flight states block; terminal states
-        # (READY, SUSPICIOUS, too-large, FAILED) and a not-yet-uploaded PENDING
-        # row do not, so a rejected or abandoned file can't deadlock the project.
+        # Refuse the message while a project file is still being malware-scanned:
+        # its content must not reach the model before the scan clears it. Only
+        # this in-flight state blocks; terminal states (READY, SUSPICIOUS,
+        # too-large, FAILED) and a not-yet-uploaded PENDING row do not, so a
+        # rejected or abandoned file can't deadlock the project.
         #
-        # An INDEXING row is only counted while fresh: if the indexing worker is
-        # SIGKILLed at CELERY_TASK_TIME_LIMIT (or OOM-killed / crashes), the
-        # final INDEXED/FAILED write never runs and the row stays INDEXING
-        # forever, which would otherwise deadlock messaging for the whole
-        # project. Past the hard-limit window (plus a margin) such a row is
-        # provably dead, so we stop blocking on it. This unblocks messaging only;
-        # recovering the stuck index (mark FAILED / requeue) is separate work.
+        # An ANALYZING row is only counted while fresh. The scan runs off-process
+        # if it exhausts its retries or the worker dies,
+        # the callback never fires and the row stays
+        # ANALYZING forever, permanently blocking every message in the project.
+        # Past the window such a row is provably dead, so we stop blocking on it.
+        # This is safe: the row never reaches READY, and only READY uploads are
+        # fed to the model, so an unscanned file still can't reach it. Marking
+        # the dead row terminal is separate periodic-recovery work.
+        #
+        # Indexing deliberately does NOT block: since indexing runs as a Celery
+        # task it can take a while, and a user may well have a quick question
+        # unrelated to the documents. A still-indexing file is simply not
+        # searchable yet, and the frontend banner says so.
         if (
             conversation.project_id
             and models.ChatConversationAttachment.objects.filter(
                 project_id=conversation.project_id,
-            )
-            .filter(
-                Q(upload_state=AttachmentStatus.ANALYZING)
-                | Q(
-                    index_state=AttachmentIndexState.INDEXING,
-                    updated_at__gte=timezone.now()
-                    - timedelta(seconds=settings.CELERY_TASK_TIME_LIMIT + 60),
-                )
-            )
-            .exists()
+                upload_state=AttachmentStatus.ANALYZING,
+                updated_at__gte=timezone.now()
+                - timedelta(seconds=settings.CELERY_TASK_TIME_LIMIT + 60),
+            ).exists()
         ):
             return Response(
                 {"error": "project_files_indexing"},

--- a/src/frontend/apps/conversations/src/features/attachments/api/useProjectAttachments.tsx
+++ b/src/frontend/apps/conversations/src/features/attachments/api/useProjectAttachments.tsx
@@ -32,7 +32,7 @@ export const useProjectAttachments = (projectId?: string) => {
     queryKey: [KEY_PROJECT_ATTACHMENTS, projectId],
     queryFn: () => getProjectAttachments(projectId as string),
     enabled: !!projectId,
-    // Poll while any file is still indexing so the send gate clears on its own.
+    // Poll while any file is still indexing so the banner clears on its own.
     refetchInterval: (query) =>
       query.state.data?.some((a) => a.index_state === 'indexing')
         ? 3000

--- a/src/frontend/apps/conversations/src/features/chat/components/Chat.tsx
+++ b/src/frontend/apps/conversations/src/features/chat/components/Chat.tsx
@@ -229,9 +229,10 @@ export const Chat = ({
     clearPendingInput,
   } = usePendingChatStore();
 
-  // Gate sending while the active project still has files being indexed: their
-  // content isn't searchable yet, so a message now would get an answer that
-  // ignores them. `useProjectAttachments` polls itself until indexing settles.
+  // Surface a notice while the active project still has files being indexed:
+  // their content isn't searchable yet, so a message sent now gets an answer
+  // that ignores them. Sending stays allowed - the banner states the tradeoff
+  // and the user decides. `useProjectAttachments` polls until indexing settles.
   const activeProjectId =
     conversationProjectId ?? pendingProjectId ?? undefined;
   const { data: projectAttachments } = useProjectAttachments(activeProjectId);
@@ -803,12 +804,6 @@ export const Chat = ({
 
     // Inference-load cooldown: block new messages until the wait elapses.
     if (cooldownUntil && Date.now() < cooldownUntil) {
-      return;
-    }
-
-    // Block while project files are still indexing (matches the backend
-    // backstop); their content isn't searchable yet.
-    if (isIndexingFiles) {
       return;
     }
 

--- a/src/frontend/apps/conversations/src/features/chat/components/InputChat.tsx
+++ b/src/frontend/apps/conversations/src/features/chat/components/InputChat.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@gouvfr-lasuite/cunningham-react';
+import { ArrowSquarepath, FileDelete } from '@gouvfr-lasuite/ui-kit/icons';
 import React, {
   useCallback,
   useEffect,
@@ -16,6 +17,7 @@ import { useAssistantHealth } from '@/features/chat/api/useAssistantHealth';
 import { LLMModel } from '@/features/chat/api/useLLMConfiguration';
 import { ChatErrorType } from '@/features/chat/components/ChatError';
 import { InputChatActions } from '@/features/chat/components/InputChatAction';
+import { InputChatBanner } from '@/features/chat/components/InputChatBanner';
 import { ProjectWelcomeMessage } from '@/features/chat/components/ProjectWelcomeMessage';
 import { SuggestionCarousel } from '@/features/chat/components/SuggestionCarousel';
 import { WelcomeMessage } from '@/features/chat/components/WelcomeMessage';
@@ -96,14 +98,6 @@ const FILE_DROP_CSS = `
                 outline: 2px solid var(--c--contextuals--border--semantic--brand--secondary);
                 box-shadow: 0 0 64px 0 rgba(62, 93, 231, 0.25);
                 `;
-const COOLDOWN_BANNER_CSS = `
-                padding: 8px 16px;
-                border-top-left-radius: 12px;
-                border-top-right-radius: 12px;
-                border-bottom: 1px solid var(--c--contextuals--border--surface--primary);
-                background: var(--c--contextuals--background--semantic--warning--tertiary);
-                text-align: center;
-                `;
 const DRAG_FADE_CSS = `
             top: 0;
             left: 0;
@@ -114,6 +108,10 @@ const DRAG_FADE_CSS = `
             background-color: rgba(255, 255, 255, 0.1);
             pointer-events: all;
           `;
+
+// The ui-kit ArrowSquarepath draws vertical arrows; the design wants them
+// horizontal (top arrow pointing right, bottom arrow pointing left).
+const ROTATE_90_STYLE: React.CSSProperties = { transform: 'rotate(90deg)' };
 
 const TEXTAREA_STYLE: React.CSSProperties = {
   padding: '1rem 1.5rem 0.5rem 1.5rem',
@@ -298,9 +296,10 @@ export const InputChat = ({
     return () => clearInterval(interval);
   }, [cooldownUntil]);
 
-  // During a cooldown or while project files are indexing, the textarea stays
-  // enabled so the user can still draft a message; only sending is blocked (see
-  // handleTextareaKeyDown + the send button below, and the submit guard in Chat).
+  // During a cooldown the textarea stays enabled so the user can still draft a
+  // message; only sending is blocked (see handleTextareaKeyDown + the send
+  // button below). Indexing no longer blocks sending: the banner warns that
+  // still-indexing files are ignored, and the user decides whether to wait.
   const isInputDisabled =
     !INPUT_ENABLED_STATUSES.includes(
       status as (typeof INPUT_ENABLED_STATUSES)[number],
@@ -348,13 +347,12 @@ export const InputChat = ({
         if (isInputDisabled) return;
         if (status === 'streaming' || status === 'submitted') return;
         if (cooldownRemaining > 0) return;
-        if (isIndexingFiles) return;
         const textarea = e.target as HTMLTextAreaElement;
         textarea.style.height = '0';
         e.currentTarget.form?.requestSubmit?.();
       }
     },
-    [isInputDisabled, status, cooldownRemaining, isIndexingFiles],
+    [isInputDisabled, status, cooldownRemaining],
   );
 
   const handleFormSubmit = useCallback(
@@ -479,6 +477,46 @@ export const InputChat = ({
 
         <form onSubmit={handleFormSubmit} style={STYLES.form}>
           <Box $padding={formPadding}>
+            {isIndexingFiles && (
+              <InputChatBanner
+                variant="neutral"
+                icon={<Loader />}
+                text={t(
+                  'Files related to this project are being indexed and will be ignored.',
+                )}
+              />
+            )}
+            {failedIndexingCount > 0 && !isIndexingFiles && (
+              <InputChatBanner
+                variant="error"
+                icon={<FileDelete size={18} />}
+                text={t(
+                  '{{number}} project file(s) failed to index and are not searchable.',
+                  { number: failedIndexingCount },
+                )}
+                action={
+                  <Button
+                    size="nano"
+                    color="error"
+                    variant="tertiary"
+                    icon={<ArrowSquarepath size={18} style={ROTATE_90_STYLE} />}
+                    onClick={onRetryFailedIndexing}
+                    disabled={isRetryingIndexing || !onRetryFailedIndexing}
+                  >
+                    {t('Retry')}
+                  </Button>
+                }
+              />
+            )}
+            {cooldownRemaining > 0 && (
+              <InputChatBanner
+                icon={<WarningFilledIcon width={20} height={20} />}
+                text={t(
+                  'The model is under heavy load. You can send a new message in {{seconds}}s.',
+                  { seconds: cooldownRemaining },
+                )}
+              />
+            )}
             <Box
               $flex={1}
               $radius="12px"
@@ -510,80 +548,6 @@ export const InputChat = ({
                       {t('To add a file to the conversation, drop it here.')}
                     </Text>
                   </Box>
-                </Box>
-              )}
-              {isIndexingFiles && (
-                <Box
-                  role="status"
-                  $align="center"
-                  $direction="row"
-                  $justify="center"
-                  $gap="8px"
-                  $css={COOLDOWN_BANNER_CSS}
-                >
-                  <Loader />
-                  <Text
-                    $weight="700"
-                    $size="sm"
-                    $color="var(--c--contextuals--content--semantic--warning--primary)"
-                  >
-                    {t(
-                      'Processing project files. You can send a message once indexing is done.',
-                    )}
-                  </Text>
-                </Box>
-              )}
-              {failedIndexingCount > 0 && !isIndexingFiles && (
-                <Box
-                  role="status"
-                  $align="center"
-                  $direction="row"
-                  $justify="center"
-                  $gap="8px"
-                  $css={COOLDOWN_BANNER_CSS}
-                >
-                  <WarningFilledIcon width={20} height={20} />
-                  <Text
-                    $weight="700"
-                    $size="sm"
-                    $color="var(--c--contextuals--content--semantic--warning--primary)"
-                  >
-                    {t(
-                      '{{number}} project file(s) failed to index and are not searchable.',
-                      { number: failedIndexingCount },
-                    )}
-                  </Text>
-                  <Button
-                    size="nano"
-                    color="neutral"
-                    variant="bordered"
-                    onClick={onRetryFailedIndexing}
-                    disabled={isRetryingIndexing || !onRetryFailedIndexing}
-                  >
-                    {t('Retry')}
-                  </Button>
-                </Box>
-              )}
-              {cooldownRemaining > 0 && (
-                <Box
-                  role="status"
-                  $align="center"
-                  $direction="row"
-                  $justify="center"
-                  $gap="8px"
-                  $css={COOLDOWN_BANNER_CSS}
-                >
-                  <WarningFilledIcon width={20} height={20} />
-                  <Text
-                    $weight="700"
-                    $size="sm"
-                    $color="var(--c--contextuals--content--semantic--warning--primary)"
-                  >
-                    {t(
-                      'The model is under heavy load. You can send a new message in {{seconds}}s.',
-                      { seconds: cooldownRemaining },
-                    )}
-                  </Text>
                 </Box>
               )}
               <textarea
@@ -648,7 +612,7 @@ export const InputChat = ({
                 selectedModel={selectedModel || null}
                 status={status}
                 inputHasContent={Boolean(input?.trim())}
-                sendDisabled={cooldownRemaining > 0 || isIndexingFiles}
+                sendDisabled={cooldownRemaining > 0}
                 onStop={onStop}
               />
             </Box>

--- a/src/frontend/apps/conversations/src/features/chat/components/InputChatBanner.tsx
+++ b/src/frontend/apps/conversations/src/features/chat/components/InputChatBanner.tsx
@@ -1,0 +1,73 @@
+import { ReactNode } from 'react';
+
+import { Box, Text } from '@/components';
+
+// Tab-like strip peeking above the input card: rounded top corners, extra
+// bottom padding and a negative margin so the card overlaps its bottom edge.
+// The variant's content color is set on the root so the icon (currentColor)
+// inherits it, and forced onto the action button so it matches too.
+const bannerCss = (contentColor: string) => `
+  padding: 8px 16px 20px;
+  margin-bottom: -12px;
+  border-top-left-radius: 12px;
+  border-top-right-radius: 12px;
+  text-align: left;
+  color: ${contentColor};
+
+  & .c__button {
+    color: ${contentColor};
+  }
+`;
+
+const VARIANT_COLORS = {
+  error: {
+    background: 'var(--c--contextuals--background--semantic--error--tertiary)',
+    content: 'var(--c--contextuals--content--semantic--error--primary)',
+  },
+  neutral: {
+    background:
+      'var(--c--contextuals--background--semantic--neutral--tertiary)',
+    content: 'var(--c--contextuals--content--semantic--neutral--primary)',
+  },
+  warning: {
+    background:
+      'var(--c--contextuals--background--semantic--warning--tertiary)',
+    content: 'var(--c--contextuals--content--semantic--warning--primary)',
+  },
+} as const;
+
+interface InputChatBannerProps {
+  icon: ReactNode;
+  text: string;
+  action?: ReactNode;
+  variant?: keyof typeof VARIANT_COLORS;
+}
+
+export const InputChatBanner = ({
+  icon,
+  text,
+  action,
+  variant = 'warning',
+}: InputChatBannerProps) => {
+  const colors = VARIANT_COLORS[variant];
+
+  return (
+    <Box
+      role="status"
+      $align="center"
+      $direction="row"
+      $justify="space-between"
+      $gap="8px"
+      $background={colors.background}
+      $css={bannerCss(colors.content)}
+    >
+      <Box $align="center" $direction="row" $gap="8px" $color={colors.content}>
+        {icon}
+        <Text $weight="700" $size="sm" $color={colors.content}>
+          {text}
+        </Text>
+      </Box>
+      {action}
+    </Box>
+  );
+};

--- a/src/frontend/apps/conversations/src/features/chat/components/MessageItem.tsx
+++ b/src/frontend/apps/conversations/src/features/chat/components/MessageItem.tsx
@@ -7,15 +7,15 @@ import { Box, Icon, Loader, Text } from '@/components';
 import { useConfig } from '@/core/config';
 import { AttachmentList } from '@/features/chat/components/AttachmentList';
 import { FeedbackButtons } from '@/features/chat/components/FeedbackButtons';
-import { MessageEnergyIndicator } from '@/features/chat/components/MessageEnergyIndicator';
-import { getMessageCo2Impact } from '@/features/chat/utils/getMessageCo2Impact';
 import {
   CompletedMarkdownBlock,
   RawTextBlock,
 } from '@/features/chat/components/MessageBlock';
+import { MessageEnergyIndicator } from '@/features/chat/components/MessageEnergyIndicator';
 import { MoreActionsButton } from '@/features/chat/components/MoreActionsButton';
 import { SourceItemList } from '@/features/chat/components/SourceItemList';
 import { ToolInvocationItem } from '@/features/chat/components/ToolInvocationItem';
+import { getMessageCo2Impact } from '@/features/chat/utils/getMessageCo2Impact';
 
 // Memoized blocks list to prevent parent re-renders from causing block remounts
 const BlocksList = React.memo(

--- a/src/frontend/apps/conversations/src/features/chat/components/__tests__/InputChatBanner.test.tsx
+++ b/src/frontend/apps/conversations/src/features/chat/components/__tests__/InputChatBanner.test.tsx
@@ -1,0 +1,95 @@
+import { render, screen } from '@testing-library/react';
+
+import { InputChatBanner } from '../InputChatBanner';
+
+/**
+ * jsdom drops `var()` values, so `toHaveStyle` passes for any expected value
+ * and cannot be used for the variant colors. Instead, read the declarations
+ * that styled-components injected for the element's own generated classes.
+ */
+const cssFor = (element: Element): string => {
+  // eslint-disable-next-line testing-library/no-node-access
+  const css = Array.from(document.querySelectorAll('style'))
+    .map((tag) => tag.textContent ?? '')
+    .join('');
+  return Array.from(element.classList)
+    .map((cls) => css.match(new RegExp(`\\.${cls}\\{([^}]*)\\}`))?.[1] ?? '')
+    .join(';');
+};
+
+describe('<InputChatBanner />', () => {
+  it('renders as a status region with the icon and text', () => {
+    render(
+      <InputChatBanner
+        icon={<svg data-testid="banner-icon" />}
+        text="Files are being indexed"
+      />,
+    );
+
+    expect(screen.getByRole('status')).toBeInTheDocument();
+    expect(screen.getByTestId('banner-icon')).toBeInTheDocument();
+    expect(screen.getByText('Files are being indexed')).toBeInTheDocument();
+  });
+
+  it('renders no action by default', () => {
+    render(<InputChatBanner icon={<svg />} text="Indexing" />);
+
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('renders the action when provided', () => {
+    render(
+      <InputChatBanner
+        icon={<svg />}
+        text="Indexing failed"
+        action={<button>Retry</button>}
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
+  });
+
+  it('uses the warning colors by default', () => {
+    render(<InputChatBanner icon={<svg />} text="Heavy load" />);
+
+    const css = cssFor(screen.getByRole('status'));
+    expect(css).toContain(
+      'background:var(--c--contextuals--background--semantic--warning--tertiary)',
+    );
+    expect(css).toContain(
+      'color:var(--c--contextuals--content--semantic--warning--primary)',
+    );
+  });
+
+  it('applies the colors of the given variant', () => {
+    render(
+      <InputChatBanner icon={<svg />} text="Indexing failed" variant="error" />,
+    );
+
+    const css = cssFor(screen.getByRole('status'));
+    expect(css).toContain(
+      'background:var(--c--contextuals--background--semantic--error--tertiary)',
+    );
+    expect(css).toContain(
+      'color:var(--c--contextuals--content--semantic--error--primary)',
+    );
+  });
+
+  it('cascades the variant color to the icon wrapper and the text', () => {
+    render(
+      <InputChatBanner
+        icon={<svg data-testid="banner-icon" />}
+        text="Indexing failed"
+        variant="error"
+      />,
+    );
+
+    const contentColor =
+      'color:var(--c--contextuals--content--semantic--error--primary)';
+    expect(
+      // eslint-disable-next-line testing-library/no-node-access
+      cssFor(screen.getByTestId('banner-icon').parentElement as Element),
+    ).toContain(contentColor);
+    expect(cssFor(screen.getByText('Indexing failed'))).toContain(contentColor);
+  });
+});

--- a/src/frontend/apps/conversations/src/features/chat/utils/__tests__/getMessageCo2Impact.test.ts
+++ b/src/frontend/apps/conversations/src/features/chat/utils/__tests__/getMessageCo2Impact.test.ts
@@ -22,7 +22,7 @@ describe('getMessageCo2Impact', () => {
         id: '1',
         role: 'assistant',
         content: 'Hello',
-      } as Message),
+      }),
     ).toBeUndefined();
   });
 
@@ -33,7 +33,7 @@ describe('getMessageCo2Impact', () => {
         role: 'assistant',
         content: 'Hello',
         annotations: [{ co2_impact: 0 }],
-      } as Message & { annotations: { co2_impact: number }[] }),
+      }),
     ).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Purpose

The chat input showed three separate status banners (file indexing in progress, indexing failures, and model cooldown) built from duplicated inline markup and styling. This made them inconsistent and hard to maintain.

## Proposal

- Introduce a single reusable banner component for the chat input, with neutral, warning, and error variants that drive its colors.
- Render the banners as a tab-like strip above the input card instead of inside it, so they read as attached to the input.
- Give the indexing-failure banner an error appearance and a clearer retry affordance.
- Replace the three duplicated banner blocks in the input with the shared component and add unit tests covering its rendering and variants.

https://github.com/user-attachments/assets/56a864cd-2908-4f32-ad2c-a09bf86c36b9





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added reusable chat input status banners with icons, warning/error styling variants, and optional action buttons.
* **Bug Fixes / Behavior Changes**
  * Chat submissions are no longer blocked by active project file indexing—sending is gated by cooldown only, with banners providing indexing/scanning feedback.
  * Backend “in-flight” blocking now applies only to malware-scanned project files (HTTP 409 with the existing error payload).
* **Tests**
  * Updated backend conversation gating tests and added UI coverage for banner rendering, status semantics, variants, and optional actions.
* **Documentation**
  * Updated the unreleased changelog entries for banner consolidation and section ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->