### PR TITLE
🐛(front) refresh conversation title in the collapsed left panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to
 ### Fixed
 
 - 🐛(front) prevent app crash for users without a full name or email
+- 🐛(front) refresh the conversation title in the collapsed left panel
 
 ## [0.0.19] - 2026-06-24
 

--- a/src/frontend/apps/conversations/src/features/chat/api/__tests__/useRenameConversation.test.tsx
+++ b/src/frontend/apps/conversations/src/features/chat/api/__tests__/useRenameConversation.test.tsx
@@ -1,0 +1,73 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import fetchMock from 'fetch-mock';
+import { PropsWithChildren } from 'react';
+
+import { KEY_CONVERSATION } from '../useConversation';
+import { KEY_LIST_CONVERSATION } from '../useConversations';
+import { useRenameConversation } from '../useRenameConversation';
+
+const API_BASE = 'http://test.jest/api/v1.0/';
+const CONVERSATION_ID = 'conv-123';
+
+describe('useRenameConversation', () => {
+  let queryClient: QueryClient;
+
+  const wrapper = ({ children }: PropsWithChildren) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+
+  beforeEach(() => {
+    fetchMock.restore();
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+  });
+
+  it('invalidates the conversation and list queries on success', async () => {
+    fetchMock.put(`${API_BASE}chats/${CONVERSATION_ID}/`, 200);
+    queryClient.setQueryData([KEY_CONVERSATION, CONVERSATION_ID], {
+      id: CONVERSATION_ID,
+      title: 'Original Title',
+    });
+    queryClient.setQueryData([KEY_LIST_CONVERSATION], []);
+
+    const { result } = renderHook(() => useRenameConversation(), { wrapper });
+    result.current.mutate({
+      conversationId: CONVERSATION_ID,
+      title: 'Updated Title',
+    });
+
+    // The collapsed left panel reads the title from the single-conversation
+    // query, so it stays stale unless that key is invalidated too.
+    await waitFor(() => {
+      expect(
+        queryClient.getQueryState([KEY_CONVERSATION, CONVERSATION_ID])
+          ?.isInvalidated,
+      ).toBe(true);
+    });
+    expect(
+      queryClient.getQueryState([KEY_LIST_CONVERSATION])?.isInvalidated,
+    ).toBe(true);
+  });
+
+  it('leaves other conversations untouched', async () => {
+    fetchMock.put(`${API_BASE}chats/${CONVERSATION_ID}/`, 200);
+    queryClient.setQueryData([KEY_CONVERSATION, 'other-conv'], {
+      id: 'other-conv',
+      title: 'Other Title',
+    });
+
+    const { result } = renderHook(() => useRenameConversation(), { wrapper });
+    result.current.mutate({
+      conversationId: CONVERSATION_ID,
+      title: 'Updated Title',
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(
+      queryClient.getQueryState([KEY_CONVERSATION, 'other-conv'])
+        ?.isInvalidated,
+    ).toBe(false);
+  });
+});

--- a/src/frontend/apps/conversations/src/features/chat/api/useChat.tsx
+++ b/src/frontend/apps/conversations/src/features/chat/api/useChat.tsx
@@ -4,6 +4,7 @@ import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useEffect, useRef, useState } from 'react';
 
 import { fetchAPI } from '@/api';
+import { KEY_CONVERSATION } from '@/features/chat/api/useConversation';
 import { KEY_LIST_CONVERSATION } from '@/features/chat/api/useConversations';
 import { KEY_LIST_PROJECT } from '@/features/chat/api/useProjects';
 import { useChatPreferencesStore } from '@/features/chat/stores/useChatPreferencesStore';
@@ -217,6 +218,9 @@ export function useChat(options: Omit<UseChatOptions, 'fetch'>) {
         });
         void queryClient.invalidateQueries({
           queryKey: [KEY_LIST_PROJECT],
+        });
+        void queryClient.invalidateQueries({
+          queryKey: [KEY_CONVERSATION, item.conversationId],
         });
       } else if (isCooldownEvent(item)) {
         setCooldownUntil(Date.now() + item.seconds * 1000);

--- a/src/frontend/apps/conversations/src/features/chat/api/useRenameConversation.tsx
+++ b/src/frontend/apps/conversations/src/features/chat/api/useRenameConversation.tsx
@@ -6,6 +6,7 @@ import {
 
 import { APIError, errorCauses, fetchAPI } from '@/api';
 
+import { KEY_CONVERSATION } from './useConversation';
 import { KEY_LIST_CONVERSATION } from './useConversations';
 import { KEY_LIST_PROJECT } from './useProjects';
 
@@ -52,6 +53,9 @@ export const useRenameConversation = (
       });
       void queryClient.invalidateQueries({
         queryKey: [KEY_LIST_PROJECT],
+      });
+      void queryClient.invalidateQueries({
+        queryKey: [KEY_CONVERSATION, variables.conversationId],
       });
       if (options?.onSuccess) {
         void options.onSuccess(data, variables, onMutateResult, context);


### PR DESCRIPTION
## Purpose

When a conversation title changes, the collapsed left panel keeps displaying the previous title. It only catches up after a page reload, or after navigating to another conversation and back. The expanded left panel was already correct, so the two views disagreed. Both automatically generated titles and manually edited ones were affected.


https://github.com/user-attachments/assets/a6b31b31-debb-47ba-9426-308dded044d3


https://github.com/orgs/suitenumerique/projects/13/views/3?filterQuery=&pane=issue&itemId=204380894&issue=suitenumerique%7Cconversations%7C570