### PR TITLE
Camand/tools display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to
 
 - ♻️(back) split chat views and replace hardcoded strings with constants
 - 💄(front) change 404 illustration
+- 💄(front) tool calls display
 
 ### Fixed
 

--- a/src/frontend/apps/conversations/src/components/Loader.tsx
+++ b/src/frontend/apps/conversations/src/components/Loader.tsx
@@ -3,14 +3,18 @@ import dynamic from 'next/dynamic';
 const Lottie = dynamic(() => import('lottie-react'), { ssr: false });
 import searchingAnimation from '@/assets/lotties/searching';
 
-export function Loader() {
+interface LoaderProps {
+  size?: number;
+}
+
+export function Loader({ size = 24 }: LoaderProps) {
   return (
     <div role="status">
       <Lottie
         animationData={searchingAnimation}
         loop
         autoplay
-        style={{ width: 24, height: 24 }}
+        style={{ width: size, height: size }}
       />
     </div>
   );

--- a/src/frontend/apps/conversations/src/features/chat/components/MessageItem.tsx
+++ b/src/frontend/apps/conversations/src/features/chat/components/MessageItem.tsx
@@ -3,7 +3,7 @@ import { Button } from '@gouvfr-lasuite/cunningham-react';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { Box, Icon, Loader, Text } from '@/components';
+import { Box, Icon, Text } from '@/components';
 import { AttachmentList } from '@/features/chat/components/AttachmentList';
 import { FeedbackButtons } from '@/features/chat/components/FeedbackButtons';
 import {
@@ -11,7 +11,8 @@ import {
   RawTextBlock,
 } from '@/features/chat/components/MessageBlock';
 import { SourceItemList } from '@/features/chat/components/SourceItemList';
-import { ToolInvocationItem } from '@/features/chat/components/ToolInvocationItem';
+import { ToolInvocationItem, isVisibleToolInvocation } from '@/features/chat/components/ToolInvocationItem';
+import { ToolInvocationTimeline } from '@/features/chat/components/ToolInvocationTimeline';
 
 // Memoized blocks list to prevent parent re-renders from causing block remounts
 const BlocksList = React.memo(
@@ -236,21 +237,10 @@ const MessageItemComponent: React.FC<MessageItemProps> = ({
     );
   }, [message.parts]);
 
-  const hasNonDocumentParsingTool = React.useMemo(() => {
-    return toolInvocationParts.some(
-      (part) =>
-        part.toolInvocation.toolName !== 'document_parsing' &&
-        part.toolInvocation.toolName !== 'conversation_resume',
+  const visibleToolInvocationParts = React.useMemo(() => {
+    return toolInvocationParts.filter((part) =>
+      isVisibleToolInvocation(part.toolInvocation),
     );
-  }, [toolInvocationParts]);
-
-  const activeToolInvocation = React.useMemo(() => {
-    const tool = toolInvocationParts.find(
-      (part) =>
-        part.toolInvocation.toolName !== 'document_parsing' &&
-        part.toolInvocation.toolName !== 'conversation_resume',
-    );
-    return tool?.toolInvocation;
   }, [toolInvocationParts]);
 
   // Memoize the streaming content split to avoid recreating components in JSX
@@ -335,6 +325,19 @@ const MessageItemComponent: React.FC<MessageItemProps> = ({
               : undefined
           }
         >
+          {message.role === 'assistant' && visibleToolInvocationParts.length > 0 && (
+            <ToolInvocationTimeline>
+              {visibleToolInvocationParts.map((part, partIndex) =>
+                isLastAssistantMessage ? (
+                  <ToolInvocationItem
+                    key={`tool-invocation-${partIndex}`}
+                    toolInvocation={part.toolInvocation}
+                  />
+                ) : null,
+              )}
+            </ToolInvocationTimeline>
+          )}
+
           {/* Message content */}
           {message.content && (
             <Box
@@ -366,43 +369,6 @@ const MessageItemComponent: React.FC<MessageItemProps> = ({
               )}
             </Box>
           )}
-
-          <Box $direction="column" $gap="2">
-            {isCurrentlyStreaming &&
-              isLastAssistantMessage &&
-              status === 'streaming' &&
-              hasNonDocumentParsingTool && (
-                <Box
-                  $direction="row"
-                  $align="center"
-                  $gap="6px"
-                  $width="100%"
-                  $maxWidth="var(--chat-content-max-width, 750px)"
-                  $margin={{
-                    all: 'auto',
-                    top: 'base',
-                    bottom: 'md',
-                  }}
-                >
-                  <Loader />
-                  <Text $variation="600" $size="md">
-                    {activeToolInvocation?.toolName === 'summarize'
-                      ? t('Summarizing...')
-                      : t('Search...')}
-                  </Text>
-                </Box>
-              )}
-            {toolInvocationParts.map((part, partIndex) =>
-              isLastAssistantMessage ? (
-                <ToolInvocationItem
-                  key={`tool-invocation-${partIndex}`}
-                  toolInvocation={part.toolInvocation}
-                  status={status}
-                  hideSearchLoader={true}
-                />
-              ) : null,
-            )}
-          </Box>
 
           {message.role === 'assistant' &&
             !(isLastAssistantMessage && status === 'streaming') && (

--- a/src/frontend/apps/conversations/src/features/chat/components/ToolCard.tsx
+++ b/src/frontend/apps/conversations/src/features/chat/components/ToolCard.tsx
@@ -1,0 +1,160 @@
+import { ToolInvocation } from '@ai-sdk/ui-utils';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { Box, Icon, Loader, Text } from '@/components';
+
+import {
+  getToolCardStatus,
+  getToolDisplayInfo,
+  getToolExpandedOutputPreview,
+  getToolReadableContent,
+  ToolCardStatus,
+} from './toolCardUtils';
+
+const CARD_CSS = `
+  width: fit-content;
+  max-width: 100%;
+`;
+
+const HEADER_BUTTON_CSS = `
+  width: fit-content;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  text-align: left;
+  padding: 0;
+`;
+
+const DETAIL_TEXT_CSS = `
+  line-height: 1.45;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+`;
+
+const STATUS_COLORS: Record<Exclude<ToolCardStatus, 'running'>, string> = {
+  completed: 'var(--c--contextuals--content--semantic--success--primary)',
+  error: 'var(--c--contextuals--content--semantic--error--primary)',
+};
+
+interface ToolCardProps {
+  toolInvocation: ToolInvocation;
+}
+
+const StatusIndicator = ({ status }: { status: ToolCardStatus }) => {
+  if (status === 'running') {
+    return <Loader size={14} />;
+  }
+
+  return (
+    <Icon
+      iconName={status === 'completed' ? 'check_circle' : 'error'}
+      $size="14px"
+      $css={`color: ${STATUS_COLORS[status]};`}
+      aria-hidden="true"
+    />
+  );
+};
+
+export const ToolCard: React.FC<ToolCardProps> = ({ toolInvocation }) => {
+  const { t } = useTranslation();
+  const [expanded, setExpanded] = React.useState(false);
+  const status = getToolCardStatus(toolInvocation);
+  const displayInfo = getToolDisplayInfo(toolInvocation.toolName);
+  const output =
+    toolInvocation.state === 'result' ? toolInvocation.result : undefined;
+  const readableContent = getToolReadableContent(
+    toolInvocation.toolName,
+    toolInvocation.args,
+    output,
+    t,
+  );
+  const expandedOutputPreview = getToolExpandedOutputPreview(
+    toolInvocation.toolName,
+    output,
+    t,
+  );
+
+  const hasDetails = Boolean(
+    readableContent.inputPreview ||
+      readableContent.outputPreview ||
+      readableContent.errorPreview ||
+      expandedOutputPreview,
+  );
+
+  return (
+    <Box
+      data-testid={`tool-card-${toolInvocation.toolCallId}`}
+      $css={CARD_CSS}
+      $margin={{ top: '4px', bottom: '4px' }}
+    >
+      <Box
+        as="button"
+        type="button"
+        aria-expanded={expanded}
+        aria-label={t('Toggle tool details')}
+        onClick={() => hasDetails && setExpanded((current) => !current)}
+        $css={HEADER_BUTTON_CSS}
+        $cursor={hasDetails ? 'pointer' : 'default'}
+      >
+        <Box $direction="row" $align="center" $gap="6px" $minWidth="0">
+          <StatusIndicator status={status} />
+          <Text
+            $size="xs"
+            $weight="600"
+            $theme="greyscale"
+            $variation="700"
+            $css="line-height: 1.3; white-space: nowrap;"
+          >
+            {displayInfo.label}
+          </Text>
+          {hasDetails && (
+            <Icon
+              iconName={expanded ? 'expand_less' : 'expand_more'}
+              $size="16px"
+              $theme="greyscale"
+              $variation="550"
+              aria-hidden="true"
+            />
+          )}
+        </Box>
+      </Box>
+
+      {expanded && hasDetails && (
+        <Box
+          $direction="column"
+          $gap="6px"
+          $padding={{ left: '20px', top: '4px', bottom: '4px' }}
+        >
+          {readableContent.inputPreview && (
+            <Box $direction="column" $gap="2px">
+              <Text $size="xs" $weight="600" $theme="greyscale" $variation="600">
+                {readableContent.inputLabel}
+              </Text>
+              <Text $size="xs" $theme="greyscale" $variation="700" $css={DETAIL_TEXT_CSS}>
+                {readableContent.inputPreview}
+              </Text>
+            </Box>
+          )}
+
+          {readableContent.errorPreview && (
+            <Text $size="xs" $theme="error" $variation="primary" $css={DETAIL_TEXT_CSS}>
+              {readableContent.errorPreview}
+            </Text>
+          )}
+
+          {expandedOutputPreview && !readableContent.errorPreview && (
+            <Box $direction="column" $gap="2px">
+              <Text $size="xs" $weight="600" $theme="greyscale" $variation="600">
+                {t('Preview')}
+              </Text>
+              <Text $size="xs" $theme="greyscale" $variation="700" $css={DETAIL_TEXT_CSS}>
+                {expandedOutputPreview}
+              </Text>
+            </Box>
+          )}
+        </Box>
+      )}
+    </Box>
+  );
+};

--- a/src/frontend/apps/conversations/src/features/chat/components/ToolInvocationItem.tsx
+++ b/src/frontend/apps/conversations/src/features/chat/components/ToolInvocationItem.tsx
@@ -2,11 +2,13 @@ import { ToolInvocation } from '@ai-sdk/ui-utils';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { Box, Loader, Text } from '@/components';
+import { Box, Text } from '@/components';
 
 import ChatBubblesIllustration from '../assets/chat-bubbles-illustration.svg';
 
 import { DocumentParsingErrorBox } from './DocumentParsingErrorBox';
+import { ToolCard } from './ToolCard';
+import { getDocumentParsingSummary } from './toolCardUtils';
 
 const ConversationResumeLoader = ({ t }: { t: (key: string) => string }) => {
   return (
@@ -45,14 +47,33 @@ const ConversationResumeLoader = ({ t }: { t: (key: string) => string }) => {
 
 interface ToolInvocationItemProps {
   toolInvocation: ToolInvocation;
-  status?: string;
-  hideSearchLoader?: boolean;
 }
+
+export const isVisibleToolInvocation = (
+  toolInvocation: ToolInvocation,
+): boolean => {
+  if (toolInvocation.toolName === 'conversation_resume') {
+    return toolInvocation.state !== 'result';
+  }
+
+  if (toolInvocation.toolName === 'document_parsing') {
+    if (toolInvocation.state === 'partial-call') {
+      return false;
+    }
+
+    if (toolInvocation.state === 'result') {
+      const result = toolInvocation.result as { state?: string };
+      return result?.state === 'error';
+    }
+
+    return true;
+  }
+
+  return true;
+};
 
 export const ToolInvocationItem: React.FC<ToolInvocationItemProps> = ({
   toolInvocation,
-  status,
-  hideSearchLoader = false,
 }) => {
   const { t } = useTranslation();
 
@@ -82,55 +103,19 @@ export const ToolInvocationItem: React.FC<ToolInvocationItemProps> = ({
       return null;
     }
 
-    const documents: unknown = (toolInvocation.args as { documents: unknown })
-      ?.documents;
-    const documentIdentifiers: string[] =
-      Array.isArray(documents) &&
-      documents.every(
-        (doc): doc is { identifier: string } =>
-          typeof doc === 'object' && doc !== null && 'identifier' in doc,
-      )
-        ? documents.map((doc) => doc.identifier)
-        : [];
+    const documentSummary = getDocumentParsingSummary(toolInvocation.args);
+    const toolInvocationWithSummary = documentSummary
+      ? {
+          ...toolInvocation,
+          args: {
+            ...toolInvocation.args,
+            documents: documentSummary,
+          },
+        }
+      : toolInvocation;
 
-    return (
-      <Box
-        $direction="row"
-        $align="center"
-        $gap="6px"
-        key={toolInvocation.toolCallId}
-        $width="100%"
-        $maxWidth="750px"
-        $margin={{ all: 'auto', top: 'base', bottom: 'md' }}
-      >
-        <Loader />
-        <Text $variation="600" $size="md">
-          {t('Extracting documents: {{documents}} ...', {
-            documents: documentIdentifiers.join(', '),
-          })}
-        </Text>
-      </Box>
-    );
+    return <ToolCard toolInvocation={toolInvocationWithSummary} />;
   }
 
-  return (
-    <>
-      {status === 'streaming' && !hideSearchLoader && (
-        <Box
-          $direction="row"
-          $align="center"
-          $gap="6px"
-          key={toolInvocation.toolCallId}
-          $width="100%"
-          $maxWidth="750px"
-          $margin={{ all: 'auto', top: 'base', bottom: 'md' }}
-        >
-          <Loader />
-          <Text $variation="600" $size="md">
-            {t('Search...')}
-          </Text>
-        </Box>
-      )}
-    </>
-  );
+  return <ToolCard toolInvocation={toolInvocation} />;
 };

--- a/src/frontend/apps/conversations/src/features/chat/components/ToolInvocationTimeline.tsx
+++ b/src/frontend/apps/conversations/src/features/chat/components/ToolInvocationTimeline.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+
+import { Box } from '@/components';
+
+const CONNECTOR_CSS = `
+  width: 2px;
+  height: 10px;
+  margin-left: 6px;
+  border-radius: 1px;
+  background: var(--c--contextuals--border--semantic--neutral--tertiary);
+`;
+
+interface ToolInvocationTimelineProps {
+  children: React.ReactNode;
+}
+
+export const ToolInvocationTimeline: React.FC<ToolInvocationTimelineProps> = ({
+  children,
+}) => {
+  const items = React.Children.toArray(children).filter(Boolean);
+
+  if (items.length <= 1) {
+    return (
+      <Box $direction="column" $gap="4px">
+        {items}
+      </Box>
+    );
+  }
+
+  return (
+    <Box
+      $direction="column"
+      data-testid="tool-invocation-timeline"
+      aria-label="Tool execution timeline"
+    >
+      {items.map((item, index) => (
+        <React.Fragment key={index}>
+          {index > 0 && <Box aria-hidden="true" $css={CONNECTOR_CSS} />}
+          <Box $position="relative">{item}</Box>
+        </React.Fragment>
+      ))}
+    </Box>
+  );
+};

--- a/src/frontend/apps/conversations/src/features/chat/components/__tests__/ToolCard.test.tsx
+++ b/src/frontend/apps/conversations/src/features/chat/components/__tests__/ToolCard.test.tsx
@@ -1,0 +1,123 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { ToolCard } from '../ToolCard';
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+jest.mock('@/components', () => ({
+  Box: ({
+    children,
+    as: Component = 'div',
+    ...props
+  }: {
+    children?: React.ReactNode;
+    as?: React.ElementType;
+    [key: string]: unknown;
+  }) => {
+    const Tag = Component;
+    return <Tag {...props}>{children}</Tag>;
+  },
+  Icon: ({ iconName }: { iconName: string }) => (
+    <span data-testid={`icon-${iconName}`} />
+  ),
+  Loader: () => <div role="status" data-testid="assistant-loader" />,
+  Text: ({ children }: { children?: React.ReactNode }) => (
+    <span>{children}</span>
+  ),
+}));
+
+describe('ToolCard', () => {
+  it('shows only the tool name and loading state when collapsed', () => {
+    render(
+      <ToolCard
+        toolInvocation={{
+          toolCallId: 'call-1',
+          toolName: 'web_search',
+          state: 'call',
+          args: { query: 'latest news' },
+        }}
+      />,
+    );
+
+    expect(screen.getByText('Web search')).toBeInTheDocument();
+    expect(screen.queryByText(/Searching the web/)).not.toBeInTheDocument();
+    expect(screen.queryByText('Request')).not.toBeInTheDocument();
+    expect(screen.getByTestId('assistant-loader')).toBeInTheDocument();
+  });
+
+  it('shows only the tool name and success state when collapsed', () => {
+    render(
+      <ToolCard
+        toolInvocation={{
+          toolCallId: 'call-3',
+          toolName: 'summarize',
+          state: 'result',
+          args: { instructions: 'In 2 paragraphs' },
+          result: 'This is a short summary for the user.',
+        }}
+      />,
+    );
+
+    expect(screen.getByText('Summarize')).toBeInTheDocument();
+    expect(
+      screen.queryByText(/This is a short summary for the user./),
+    ).not.toBeInTheDocument();
+    expect(screen.getByTestId('icon-check_circle')).toBeInTheDocument();
+  });
+
+  it('shows readable details only when expanded', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <ToolCard
+        toolInvocation={{
+          toolCallId: 'call-2',
+          toolName: 'web_search',
+          state: 'result',
+          args: { query: 'latest news' },
+          result: {
+            '0': { title: 'Result 1', url: 'https://example.com/1' },
+            '1': { title: 'Result 2', url: 'https://example.com/2' },
+          },
+        }}
+      />,
+    );
+
+    expect(screen.queryByText('Preview')).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Toggle tool details' }));
+
+    expect(screen.getByText('Request')).toBeInTheDocument();
+    expect(screen.getByText('Query: latest news')).toBeInTheDocument();
+    expect(screen.getByText('Preview')).toBeInTheDocument();
+    expect(screen.getByText(/Result 1/)).toBeInTheDocument();
+    expect(screen.queryByText(/"title"/)).not.toBeInTheDocument();
+  });
+
+  it('shows error details only when expanded', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <ToolCard
+        toolInvocation={{
+          toolCallId: 'call-4',
+          toolName: 'web_search',
+          state: 'result',
+          args: { query: 'fail' },
+          result: { state: 'error', error: 'Provider unavailable' },
+        }}
+      />,
+    );
+
+    expect(screen.getByText('Web search')).toBeInTheDocument();
+    expect(screen.queryByText(/Provider unavailable/)).not.toBeInTheDocument();
+    expect(screen.getByTestId('icon-error')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Toggle tool details' }));
+
+    expect(screen.getByText('Provider unavailable')).toBeInTheDocument();
+  });
+});

--- a/src/frontend/apps/conversations/src/features/chat/components/__tests__/ToolInvocationTimeline.test.tsx
+++ b/src/frontend/apps/conversations/src/features/chat/components/__tests__/ToolInvocationTimeline.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from '@testing-library/react';
+
+import { ToolInvocationTimeline } from '../ToolInvocationTimeline';
+import { ToolCard } from '../ToolCard';
+
+jest.mock('../ToolCard', () => ({
+  ToolCard: ({ toolInvocation }: { toolInvocation: { toolCallId: string } }) => (
+    <div data-testid={`tool-card-${toolInvocation.toolCallId}`} />
+  ),
+}));
+
+jest.mock('@/components', () => ({
+  Box: ({
+    children,
+    ...props
+  }: {
+    children?: React.ReactNode;
+    [key: string]: unknown;
+  }) => <div {...props}>{children}</div>,
+}));
+
+describe('ToolInvocationTimeline', () => {
+  it('does not render a connector for a single tool', () => {
+    render(
+      <ToolInvocationTimeline>
+        <ToolCard
+          toolInvocation={{
+            toolCallId: 'call-1',
+            toolName: 'web_search',
+            state: 'call',
+            args: {},
+          }}
+        />
+      </ToolInvocationTimeline>,
+    );
+
+    expect(screen.queryByTestId('tool-invocation-timeline')).not.toBeInTheDocument();
+    expect(screen.getByTestId('tool-card-call-1')).toBeInTheDocument();
+  });
+
+  it('renders vertical connectors between multiple tools', () => {
+    const { container } = render(
+      <ToolInvocationTimeline>
+        <ToolCard
+          toolInvocation={{
+            toolCallId: 'call-1',
+            toolName: 'web_search',
+            state: 'result',
+            args: {},
+            result: {},
+          }}
+        />
+        <ToolCard
+          toolInvocation={{
+            toolCallId: 'call-2',
+            toolName: 'summarize',
+            state: 'call',
+            args: {},
+          }}
+        />
+      </ToolInvocationTimeline>,
+    );
+
+    expect(screen.getByTestId('tool-invocation-timeline')).toBeInTheDocument();
+    expect(container.querySelectorAll('[aria-hidden="true"]')).toHaveLength(1);
+  });
+});

--- a/src/frontend/apps/conversations/src/features/chat/components/__tests__/toolCardUtils.test.ts
+++ b/src/frontend/apps/conversations/src/features/chat/components/__tests__/toolCardUtils.test.ts
@@ -1,0 +1,66 @@
+import {
+  getDocumentParsingSummary,
+  getToolCardStatus,
+  getToolErrorFromResult,
+  getToolReadableContent,
+  truncateText,
+} from '../toolCardUtils';
+
+describe('toolCardUtils', () => {
+  it('truncates long text with an ellipsis', () => {
+    expect(truncateText('abcdefghij', 6)).toBe('abcde…');
+  });
+
+  it('detects tool errors from result payloads', () => {
+    expect(
+      getToolErrorFromResult({ state: 'error', error: 'Boom' }),
+    ).toBe('Boom');
+    expect(getToolErrorFromResult({ ok: true })).toBeUndefined();
+  });
+
+  it('maps invocation states to card statuses', () => {
+    expect(
+      getToolCardStatus({
+        toolCallId: '1',
+        toolName: 'web_search',
+        state: 'call',
+        args: {},
+      }),
+    ).toBe('running');
+
+    expect(
+      getToolCardStatus({
+        toolCallId: '2',
+        toolName: 'web_search',
+        state: 'result',
+        args: {},
+        result: { ok: true },
+      }),
+    ).toBe('completed');
+  });
+
+  it('formats web search content without JSON', () => {
+    const content = getToolReadableContent(
+      'web_search',
+      { query: 'climate news' },
+      {
+        '0': { title: 'Article A', url: 'https://example.com/a' },
+        '1': { title: 'Article B', url: 'https://example.com/b' },
+      },
+      (key, options) =>
+        key.replace('{{count}}', String(options?.count ?? '')),
+    );
+
+    expect(content.inputPreview).toBe('Query: climate news');
+    expect(content.outputPreview).toContain('2 results');
+    expect(content.outputPreview).toContain('Article A');
+  });
+
+  it('extracts document parsing identifiers from args', () => {
+    expect(
+      getDocumentParsingSummary({
+        documents: [{ identifier: 'doc-a.pdf' }, { identifier: 'doc-b.pdf' }],
+      }),
+    ).toBe('doc-a.pdf, doc-b.pdf');
+  });
+});

--- a/src/frontend/apps/conversations/src/features/chat/components/toolCardUtils.ts
+++ b/src/frontend/apps/conversations/src/features/chat/components/toolCardUtils.ts
@@ -1,0 +1,353 @@
+import { ToolInvocation } from '@ai-sdk/ui-utils';
+
+export type ToolCardStatus = 'running' | 'completed' | 'error';
+
+interface ToolDisplayInfo {
+  label: string;
+  icon: string;
+}
+
+const TOOL_DISPLAY_INFO: Record<string, ToolDisplayInfo> = {
+  web_search: { label: 'Web search', icon: 'search' },
+  summarize: { label: 'Summarize', icon: 'summarize' },
+  summarize_project: { label: 'Summarize project', icon: 'summarize' },
+  document_parsing: { label: 'Document parsing', icon: 'description' },
+  document_search_rag: { label: 'Document search', icon: 'find_in_page' },
+  conversation_resume: { label: 'Conversation resume', icon: 'history' },
+  get_current_weather: { label: 'Weather', icon: 'cloud' },
+  self_documentation: { label: 'Assistant info', icon: 'info' },
+};
+
+const PREVIEW_MAX_LENGTH = 120;
+const EXPANDED_PREVIEW_MAX_LENGTH = 280;
+
+const formatToolName = (toolName: string): string =>
+  toolName
+    .split('_')
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+
+export const truncateText = (text: string, maxLength: number): string => {
+  const normalized = text.replace(/\s+/g, ' ').trim();
+  if (normalized.length <= maxLength) {
+    return normalized;
+  }
+
+  return `${normalized.slice(0, maxLength - 1).trimEnd()}…`;
+};
+
+export const getToolDisplayInfo = (toolName: string): ToolDisplayInfo => {
+  return (
+    TOOL_DISPLAY_INFO[toolName] ?? {
+      label: formatToolName(toolName),
+      icon: 'build',
+    }
+  );
+};
+
+export const getToolRunningLabel = (
+  toolName: string,
+  t: (key: string, options?: Record<string, unknown>) => string,
+): string => {
+  if (toolName === 'summarize' || toolName === 'summarize_project') {
+    return t('Summarizing...');
+  }
+
+  if (toolName === 'document_parsing') {
+    return t('Extracting documents...');
+  }
+
+  if (toolName === 'web_search') {
+    return t('Searching the web...');
+  }
+
+  if (toolName === 'document_search_rag') {
+    return t('Searching documents...');
+  }
+
+  return t('Running...');
+};
+
+export const getToolErrorFromResult = (result: unknown): string | undefined => {
+  if (!result || typeof result !== 'object') {
+    return undefined;
+  }
+
+  const payload = result as { state?: string; error?: string; kind?: string };
+
+  if (payload.state !== 'error') {
+    return undefined;
+  }
+
+  return payload.error || payload.kind || 'Tool execution failed';
+};
+
+export const getToolCardStatus = (
+  toolInvocation: ToolInvocation,
+): ToolCardStatus => {
+  if (
+    toolInvocation.state === 'partial-call' ||
+    toolInvocation.state === 'call'
+  ) {
+    return 'running';
+  }
+
+  if (getToolErrorFromResult(toolInvocation.result)) {
+    return 'error';
+  }
+
+  return 'completed';
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const readStringField = (
+  source: Record<string, unknown>,
+  keys: string[],
+): string | undefined => {
+  for (const key of keys) {
+    const value = source[key];
+    if (typeof value === 'string' && value.trim()) {
+      return value.trim();
+    }
+  }
+
+  return undefined;
+};
+
+const extractWebSearchResults = (
+  output: unknown,
+): Array<{ title?: string; url?: string }> => {
+  if (!isRecord(output)) {
+    return [];
+  }
+
+  return Object.values(output)
+    .filter(isRecord)
+    .map((entry) => ({
+      title: readStringField(entry, ['title']),
+      url: readStringField(entry, ['url']),
+    }))
+    .filter((entry) => entry.title || entry.url);
+};
+
+const formatWebSearchOutputPreview = (
+  output: unknown,
+  t: (key: string, options?: Record<string, unknown>) => string,
+  maxLength: number,
+): string | undefined => {
+  const results = extractWebSearchResults(output);
+  if (results.length === 0) {
+    return undefined;
+  }
+
+  const titles = results
+    .map((result) => result.title || result.url)
+    .filter((value): value is string => Boolean(value));
+
+  if (titles.length === 0) {
+    return t('{{count}} results found', { count: results.length });
+  }
+
+  const lead = t('{{count}} results', { count: results.length });
+  return truncateText(`${lead}: ${titles.slice(0, 2).join(', ')}`, maxLength);
+};
+
+const formatSummarizeOutputPreview = (
+  output: unknown,
+  maxLength: number,
+): string | undefined => {
+  if (typeof output === 'string' && output.trim()) {
+    return truncateText(output, maxLength);
+  }
+
+  if (!isRecord(output)) {
+    return undefined;
+  }
+
+  const summary = readStringField(output, ['summary', 'return_value', 'text']);
+  return summary ? truncateText(summary, maxLength) : undefined;
+};
+
+const formatGenericOutputPreview = (
+  output: unknown,
+  maxLength: number,
+): string | undefined => {
+  if (typeof output === 'string' && output.trim()) {
+    return truncateText(output, maxLength);
+  }
+
+  if (typeof output === 'number' || typeof output === 'boolean') {
+    return String(output);
+  }
+
+  if (!isRecord(output)) {
+    return undefined;
+  }
+
+  const directValue = readStringField(output, [
+    'summary',
+    'message',
+    'text',
+    'title',
+    'query',
+    'result',
+  ]);
+  if (directValue) {
+    return truncateText(directValue, maxLength);
+  }
+
+  if (Array.isArray(output.results)) {
+    return truncateText(
+      `${output.results.length} results`,
+      maxLength,
+    );
+  }
+
+  const keys = Object.keys(output);
+  if (keys.length === 0) {
+    return undefined;
+  }
+
+  return truncateText(`${keys.length} items`, maxLength);
+};
+
+export interface ToolReadableContent {
+  inputLabel?: string;
+  inputPreview?: string;
+  outputPreview?: string;
+  headerPreview?: string;
+  errorPreview?: string;
+}
+
+export const getToolReadableContent = (
+  toolName: string,
+  args: ToolInvocation['args'],
+  output: unknown,
+  t: (key: string, options?: Record<string, unknown>) => string,
+  maxLength = PREVIEW_MAX_LENGTH,
+): ToolReadableContent => {
+  const errorPreview = getToolErrorFromResult(output);
+  if (errorPreview) {
+    return {
+      headerPreview: truncateText(errorPreview, maxLength),
+      errorPreview: truncateText(errorPreview, EXPANDED_PREVIEW_MAX_LENGTH),
+    };
+  }
+
+  const argsRecord = isRecord(args) ? args : undefined;
+  let inputPreview: string | undefined;
+  let outputPreview: string | undefined;
+
+  if (toolName === 'web_search') {
+    const query = argsRecord ? readStringField(argsRecord, ['query']) : undefined;
+    inputPreview = query
+      ? t('Query: {{query}}', { query: truncateText(query, maxLength) })
+      : undefined;
+    outputPreview = formatWebSearchOutputPreview(output, t, maxLength);
+  } else if (
+    toolName === 'summarize' ||
+    toolName === 'summarize_project'
+  ) {
+    const instructions = argsRecord
+      ? readStringField(argsRecord, ['instructions'])
+      : undefined;
+    const documentId = argsRecord
+      ? readStringField(argsRecord, ['document_id'])
+      : undefined;
+
+    if (instructions) {
+      inputPreview = t('Instructions: {{instructions}}', {
+        instructions: truncateText(instructions, maxLength),
+      });
+    } else if (documentId) {
+      inputPreview = t('Document: {{document}}', {
+        document: truncateText(documentId, maxLength),
+      });
+    }
+
+    outputPreview = formatSummarizeOutputPreview(output, maxLength);
+  } else if (toolName === 'document_parsing') {
+    const documents = argsRecord?.documents;
+    if (typeof documents === 'string' && documents.trim()) {
+      inputPreview = t('Documents: {{documents}}', {
+        documents: truncateText(documents, maxLength),
+      });
+    }
+  } else if (toolName === 'document_search_rag') {
+    const query = argsRecord ? readStringField(argsRecord, ['query']) : undefined;
+    inputPreview = query
+      ? t('Query: {{query}}', { query: truncateText(query, maxLength) })
+      : undefined;
+    outputPreview = formatGenericOutputPreview(output, maxLength);
+  } else {
+    const query = argsRecord ? readStringField(argsRecord, ['query']) : undefined;
+    if (query) {
+      inputPreview = t('Query: {{query}}', { query: truncateText(query, maxLength) });
+    }
+
+    outputPreview = formatGenericOutputPreview(output, maxLength);
+  }
+
+  const headerPreview =
+    outputPreview ||
+    inputPreview ||
+    (toolName === 'document_parsing' ? undefined : t('Completed'));
+
+  return {
+    inputLabel:
+      toolName === 'web_search' || toolName === 'document_search_rag'
+        ? t('Request')
+        : toolName === 'summarize' || toolName === 'summarize_project'
+          ? t('Context')
+          : t('Details'),
+    inputPreview,
+    outputPreview: outputPreview
+      ? truncateText(outputPreview, EXPANDED_PREVIEW_MAX_LENGTH)
+      : undefined,
+    headerPreview,
+  };
+};
+
+export const getDocumentParsingSummary = (
+  args: ToolInvocation['args'],
+): string | undefined => {
+  const documents: unknown = args?.documents;
+
+  if (
+    !Array.isArray(documents) ||
+    !documents.every(
+      (doc): doc is { identifier: string } =>
+        typeof doc === 'object' && doc !== null && 'identifier' in doc,
+    )
+  ) {
+    return undefined;
+  }
+
+  return documents.map((doc) => doc.identifier).join(', ');
+};
+
+export const getToolExpandedOutputPreview = (
+  toolName: string,
+  output: unknown,
+  t: (key: string, options?: Record<string, unknown>) => string,
+): string | undefined => {
+  if (toolName === 'web_search') {
+    const results = extractWebSearchResults(output);
+    if (results.length === 0) {
+      return undefined;
+    }
+
+    return results
+      .slice(0, 3)
+      .map((result, index) => {
+        const label = result.title || result.url || t('Result {{index}}', { index: index + 1 });
+        return `• ${label}`;
+      })
+      .join('\n');
+  }
+
+  return getToolReadableContent(toolName, undefined, output, t, EXPANDED_PREVIEW_MAX_LENGTH)
+    .outputPreview;
+};


### PR DESCRIPTION
## Purpose

Make tool calls in the chat clearer and less noisy: compact expandable cards with readable status, instead of a generic "Search..." / "Summarizing..." loader while tools run.

## Proposal

- [x] Add `ToolCard` with collapsed header (tool name + status) and expandable input/output/error details
- [x] Add `ToolInvocationTimeline` to stack multiple tool calls with a visual connector
- [x] Centralize tool labels, status, and readable previews in `toolCardUtils`
- [x] Show the animated assistant `Loader` while a tool is running
- [x] Keep special cases for `conversation_resume` and `document_parsing` errors
- [x] Add unit tests for `ToolCard`, `ToolInvocationTimeline`, and `toolCardUtils`

<img width="760" height="327" alt="Capture d’écran 2026-07-09 à 16 44 25" src="https://github.com/user-attachments/assets/acb1397c-3e7f-45b7-ba65-2e4e28716bd8" />
