### PR TITLE
- 🐛(co2) fix and enhance co2 impact widget

### DIFF
--- a/src/backend/chat/clients/pydantic_ai.py
+++ b/src/backend/chat/clients/pydantic_ai.py
@@ -1401,6 +1401,10 @@ class AIAgentService:  # pylint: disable=too-many-instance-attributes
         # conversation's cumulative total.
         request_tokens = int(usage["promptTokens"]) + int(usage["completionTokens"])
 
+        # Per-message CO2 impact, captured before _prepare_update_conversation
+        # folds the conversation's cumulative total into usage["co2_impact"].
+        message_co2_impact = usage["co2_impact"]
+
         await sync_to_async(self._prepare_update_conversation)(
             final_output=new_messages,
             usage=usage,
@@ -1430,6 +1434,10 @@ class AIAgentService:  # pylint: disable=too-many-instance-attributes
                 ]
             )
         self._update_langfuse_trace(run_output)
+        # Stream the same CO2 annotation _prepare_update_conversation persisted,
+        # so the live message matches what a reload hydrates from the database.
+        if message_co2_impact:
+            yield events_v4.MessageAnnotationPart(annotations=[{"co2_impact": message_co2_impact}])
         # Vercel finish message
         yield events_v4.FinishMessagePart(
             finish_reason=events_v4.FinishReason.STOP,

--- a/src/backend/chat/tests/views/chat/conversations/test_conversations_with_co2_impact.py
+++ b/src/backend/chat/tests/views/chat/conversations/test_conversations_with_co2_impact.py
@@ -17,6 +17,11 @@ pytestmark = pytest.mark.django_db(transaction=True)
 EXPECTED_CO2_IMPACT = 1e-05
 
 
+def _extract_annotation_events(response_content: str) -> list:
+    """Parse `8:` (message annotation) events from a data-stream response body."""
+    return [json.loads(line[2:]) for line in response_content.splitlines() if line.startswith("8:")]
+
+
 @pytest.fixture(name="albert_settings", autouse=True)
 def albert_settings_fixture(settings):
     """Configure Django settings to use the Albert LLM provider."""
@@ -117,6 +122,10 @@ def test_albert_co2_impact_appears_in_annotations_and_stream(
     response_content = b"".join(response.streaming_content).decode("utf-8")
     assert response_content
     assert mock_openai_stream_multi_calls.called
+    # The CO2 annotation is streamed so the live message shows it without a reload
+    assert _extract_annotation_events(response_content) == [
+        [{"co2_impact": pytest.approx(EXPECTED_CO2_IMPACT)}]
+    ]
     chat_conversation.refresh_from_db()
 
     # Verify the assistant message carries the CO2 annotation in the DB
@@ -153,6 +162,10 @@ def test_albert_co2_impact_appears_in_annotations_and_stream(
 
     second_response_content = b"".join(second_response.streaming_content).decode("utf-8")
     assert second_response_content
+    # The streamed annotation carries this turn's impact, not the cumulative total
+    assert _extract_annotation_events(second_response_content) == [
+        [{"co2_impact": pytest.approx(EXPECTED_CO2_IMPACT)}]
+    ]
     # Verify CO2 annotation appears on the new assistant message
     chat_conversation.refresh_from_db()
     assert chat_conversation.messages[3].annotations == [
@@ -234,7 +247,10 @@ def test_albert_co2_impact_preserved_when_second_request_has_no_co2(
         ]
     }
     second_response = api_client.post(url, second_data, format="json")
-    assert b"".join(second_response.streaming_content).decode("utf-8")
+    second_response_content = b"".join(second_response.streaming_content).decode("utf-8")
+    assert second_response_content
+    # No CO2 from the API means no annotation event in the stream either
+    assert _extract_annotation_events(second_response_content) == []
     chat_conversation.refresh_from_db()
 
     # New assistant message should have no CO2 annotation (none returned by API)

--- a/src/frontend/apps/conversations/src/features/chat/components/MessageEnergyIndicator.tsx
+++ b/src/frontend/apps/conversations/src/features/chat/components/MessageEnergyIndicator.tsx
@@ -21,9 +21,12 @@ import {
 } from '../utils/impactCo2';
 
 const formatCo2Impact = (kgCo2eq: number): string => {
-  return `${(kgCo2eq * 1000).toLocaleString(undefined, {
-    maximumFractionDigits: 2,
-  })} g CO₂eq`;
+  const grams = kgCo2eq * 1000;
+  // Below 1 g, fixed fraction digits would round to "0"; keep 2 significant
+  // digits instead so low impacts stay visible (e.g. "0.0012 g CO₂eq").
+  const format: Intl.NumberFormatOptions =
+    grams < 1 ? { maximumSignificantDigits: 2 } : { maximumFractionDigits: 2 };
+  return `${grams.toLocaleString(undefined, format)} g CO₂eq`;
 };
 
 interface MessageEnergyIndicatorProps {
@@ -37,7 +40,6 @@ export const MessageEnergyIndicator = ({
   const { isMobile } = useResponsiveStore();
   const theme = useCunninghamTheme((state) => state.theme);
   const modal = useModal();
-
   const impactLabel = t('This request: {{co2}}', {
     co2: formatCo2Impact(co2ImpactKg),
   });

--- a/src/frontend/apps/conversations/src/features/chat/components/__tests__/MessageEnergyIndicator.test.tsx
+++ b/src/frontend/apps/conversations/src/features/chat/components/__tests__/MessageEnergyIndicator.test.tsx
@@ -66,7 +66,8 @@ describe('MessageEnergyIndicator', () => {
 
     const dialog = await screen.findByRole('dialog');
     expect(
-      within(dialog).getByText('This request: {{co2}}:0.02 g CO₂eq'),
+      // Decimal separator depends on the host locale (dot in CI, comma on fr)
+      within(dialog).getByText(/^This request: \{\{co2\}\}:0[.,]022 g CO₂eq$/),
     ).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /Know more/i })).toHaveAttribute(
       'href',

--- a/src/frontend/apps/conversations/src/features/chat/utils/__tests__/impactCo2.test.ts
+++ b/src/frontend/apps/conversations/src/features/chat/utils/__tests__/impactCo2.test.ts
@@ -6,6 +6,7 @@ import {
 } from '../impactCo2';
 
 const TEST_CO2_IMPACT_KG = 0.00002191613089507352;
+const ENCODED_COMPARISONS = 'rechercheweb%2Cemail%2Ccafe%2Cvisioconference';
 
 describe('impactCo2', () => {
   it('formats kg CO₂eq as a gram value for impactco2', () => {
@@ -16,7 +17,7 @@ describe('impactCo2', () => {
 
   it('builds the comparateur URL with value and comparisons', () => {
     expect(buildImpactCo2ComparateurUrl(TEST_CO2_IMPACT_KG)).toBe(
-      'https://impactco2.fr/outils/comparateur?value=0.021916130895073518&comparisons=ordinateurfixeparticulier%2Chotel%2Cdisquedur%2Cgalettefromage',
+      `https://impactco2.fr/outils/comparateur?value=0.021916130895073518&comparisons=${ENCODED_COMPARISONS}`,
     );
   });
 
@@ -28,7 +29,8 @@ describe('impactCo2', () => {
         theme: 'night',
       }),
     ).toBe(
-      '?value=0.021916130895073518&comparisons=ordinateurfixeparticulier%2Chotel%2Cdisquedur%2Cgalettefromage&language=fr&theme=night',
+      // The widget takes the value in kg, unlike the comparateur URL (grams)
+      `?value=0.00002191613089507352&comparisons=${ENCODED_COMPARISONS}&language=fr&theme=night`,
     );
   });
 
@@ -47,7 +49,9 @@ describe('impactCo2', () => {
     expect(script?.getAttribute('data-type')).toBe(
       'comparateur/etiquette-animee',
     );
-    expect(script?.getAttribute('data-search')).toContain('value=0.0219161');
+    expect(script?.getAttribute('data-search')).toContain(
+      'value=0.00002191613',
+    );
     expect(script?.getAttribute('data-search')).toContain('language=en');
     expect(script?.getAttribute('data-search')).toContain('theme=default');
   });

--- a/src/frontend/apps/conversations/src/features/chat/utils/getMessageCo2Impact.ts
+++ b/src/frontend/apps/conversations/src/features/chat/utils/getMessageCo2Impact.ts
@@ -5,6 +5,7 @@ type Co2Annotation = { co2_impact?: number };
 export const getMessageCo2Impact = (message: Message): number | undefined => {
   const annotations = (message as Message & { annotations?: Co2Annotation[] })
     .annotations;
+
   const impact = annotations
     ?.map((annotation) => annotation as Co2Annotation)
     .find(

--- a/src/frontend/apps/conversations/src/features/chat/utils/impactCo2.ts
+++ b/src/frontend/apps/conversations/src/features/chat/utils/impactCo2.ts
@@ -1,15 +1,17 @@
-export const IMPACT_CO2_COMPARISONS =
-  'ordinateurfixeparticulier,hotel,disquedur,galettefromage';
+export const IMPACT_CO2_COMPARISONS = 'rechercheweb,email,cafe,visioconference';
 
 export const IMPACT_CO2_SCRIPT_URL = 'https://impactco2.fr/iframe.js';
 export const IMPACT_CO2_WIDGET_TYPE = 'comparateur/etiquette-animee';
 
-/** impactco2 widgets expect the impact as a gram value (numeric string). */
-export const formatImpactCo2Value = (co2ImpactKg: number): string =>
-  (co2ImpactKg * 1000).toLocaleString('en-US', {
+const formatNumericValue = (value: number): string =>
+  value.toLocaleString('en-US', {
     maximumFractionDigits: 20,
     useGrouping: false,
   });
+
+/** The impactco2 comparateur page expects the impact as a gram value (numeric string). */
+export const formatImpactCo2Value = (co2ImpactKg: number): string =>
+  formatNumericValue(co2ImpactKg * 1000);
 
 export const buildImpactCo2ComparateurUrl = (co2ImpactKg: number): string => {
   const params = new URLSearchParams({
@@ -30,7 +32,8 @@ export const buildImpactCo2WidgetDataSearch = ({
   theme: 'default' | 'night';
 }): string => {
   const params = new URLSearchParams({
-    value: formatImpactCo2Value(co2ImpactKg),
+    // Unlike the comparateur page, the iframe widget expects the value in kg
+    value: formatNumericValue(co2ImpactKg),
     comparisons: IMPACT_CO2_COMPARISONS,
     language,
     theme,


### PR DESCRIPTION
## Purpose

The carbon impact indicator on assistant messages only appeared after reloading the page, because the impact was saved in the database but never sent over the live response stream. In addition, the impactco2 widget received values in the wrong unit, and very small impacts were displayed as zero.

## Proposal

- [ ] Send the carbon impact with the streamed response so the indicator appears as soon as the answer completes
- [ ] Send the value in the unit expected by the impactco2 widget, while keeping the existing unit for the comparateur page link
- [ ] Keep small impacts visible in the tooltip instead of rounding them down to zero
- [ ] Refresh the comparison items shown by the widget
- [ ] Cover the streamed impact and the unit change with backend and frontend tests


https://github.com/orgs/suitenumerique/projects/13/views/3?filterQuery=&pane=issue&itemId=217064845&issue=suitenumerique%7Cconversations%7C611

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CO₂ impact annotations now appear in real time as messages stream, matching the values shown after reload.
* **Improvements**
  * Very small CO₂ impacts are displayed more accurately instead of rounding to zero.
  * CO₂ values sent to embedded widgets now use the expected unit and format.
  * Decimal separators are handled consistently across locales.
* **Bug Fixes**
  * Messages without CO₂ data no longer display an empty impact annotation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->