### PR TITLE
💬(back) use a generic localised timestamped title for docs exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to
 - ⬆️(dependencies) update dependencies and pin CVE-affected packages
 - ♻️(front) consolidate input chat banners into a reusable component
 - ⬆️(dependencies) drop unused pydantic-ai extras
+- 💬(back) use a generic localised timestamped title for Docs exports
 
 ### Fixed
 

--- a/src/backend/chat/tests/views/chat/conversations/test_edit_in_docs.py
+++ b/src/backend/chat/tests/views/chat/conversations/test_edit_in_docs.py
@@ -1,5 +1,6 @@
 """Tests for the edit_in_docs view action."""
 
+import re
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -11,7 +12,6 @@ from core.factories import UserFactory
 from chat.ai_sdk_types import TextUIPart, UIMessage
 from chat.factories import ChatConversationFactory
 from chat.views.edit_in_docs import (
-    TITLE_MAX_LENGTH,
     _build_doc_title,
     conditional_refresh_oidc_token,
 )
@@ -363,43 +363,18 @@ def test_edit_in_docs_maps_docs_http_errors(
 
 
 # ---------------------------------------------------------------------------
-# Title heuristic (_build_doc_title)
+# Title (_build_doc_title)
 # ---------------------------------------------------------------------------
-@pytest.mark.parametrize(
-    ("content", "expected"),
-    [
-        # 1. first markdown header wins
-        ("# Hello World\n\nbody text", "Hello World"),
-        ("## Comparison of approaches\nbody", "Comparison of approaches"),
-        # header wins even when it is not the first line
-        ("intro line\n\n## Real Header\nbody", "Real Header"),
-        # 2. no header -> first non-empty line, markers stripped
-        ("Just a plain first line\nmore", "Just a plain first line"),
-        ("- bullet item here\nmore", "bullet item here"),
-        ("1. first ordered item\nmore", "first ordered item"),
-        ("> quoted line\nx", "quoted line"),
-        ("**Bold lead**\nrest", "Bold lead"),
-        # leading blank lines are skipped
-        ("\n\n   \nActual content\n", "Actual content"),
-        # 3. fallback when there is nothing usable
-        ("", "Assistant response"),
-        ("\n\n   \n", "Assistant response"),
-    ],
-)
-def test_build_doc_title(content, expected):
-    """The title heuristic prefers a header, else the first cleaned line, else a default."""
-    assert _build_doc_title(content) == expected
+def test_build_doc_title_is_generic_and_timestamped():
+    """The title follows the "[L'Assistant] New document MM/DD/YYYY HH:MM" template.
 
-
-def test_build_doc_title_truncates_on_word_boundary():
-    """A long title is truncated to TITLE_MAX_LENGTH on a word boundary with an ellipsis."""
-    long_header = "# " + " ".join(["word"] * 30)  # well over 60 chars
-
-    title = _build_doc_title(long_header)
-
-    assert title.endswith("…")
-    assert len(title) <= TITLE_MAX_LENGTH + 1  # +1 for the ellipsis char
-    assert not title.rstrip("…").endswith("wor")  # no mid-word cut
+    The date format string is itself translatable (French flips to DD/MM/YYYY);
+    under the test locale (English) the source format applies.
+    """
+    assert re.fullmatch(
+        r"\[L'Assistant\] New document \d{2}/\d{2}/\d{4} \d{2}:\d{2}",
+        _build_doc_title(),
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/src/backend/chat/views/edit_in_docs.py
+++ b/src/backend/chat/views/edit_in_docs.py
@@ -6,10 +6,11 @@ stays readable.
 """
 
 import logging
-import re
 from urllib.parse import urljoin
 
 from django.conf import settings
+from django.utils import formats, timezone
+from django.utils.translation import gettext as _
 
 import requests as http_requests
 from rest_framework import decorators, status
@@ -22,46 +23,18 @@ from chat.views.helpers import conditional_refresh_oidc_token
 
 logger = logging.getLogger(__name__)
 
-TITLE_MAX_LENGTH = 60
 
-_HEADER_RE = re.compile(r"^#{1,6}\s+(.*)")
-# Leading whitespace, blockquote (>), bullet (-, *) and ordered-list (1.) markers.
-_LEADING_MARKERS_RE = re.compile(r"^[\s>*\-]*(?:\d+\.\s+)?")
-
-
-def _truncate_title(text):
-    """Trim a title to TITLE_MAX_LENGTH characters on a word boundary."""
-    text = text.strip()
-    if len(text) <= TITLE_MAX_LENGTH:
-        return text
-    truncated = text[:TITLE_MAX_LENGTH].rsplit(" ", 1)[0].rstrip()
-    return f"{truncated or text[:TITLE_MAX_LENGTH].rstrip()}…"
-
-
-def _build_doc_title(content):
-    """Derive a document title from the assistant's markdown.
-
-    1. the first markdown header (``#`` … ``######``) in document order;
-    2. else the first non-empty line, stripped of leading markdown markers;
-    3. else a generic default.
-
-    The result is truncated to TITLE_MAX_LENGTH on a word boundary.
+def _build_doc_title():
+    """Build a generic timestamped document title, e.g.
+    "[L'Assistant] New document 07/22/2026 14:30" (localised via gettext,
+    including the date format itself).
     """
-    lines = content.splitlines()
-
-    for line in lines:
-        match = _HEADER_RE.match(line.strip())
-        if match and match.group(1).strip():
-            return _truncate_title(match.group(1))
-
-    for line in lines:
-        if not line.strip():
-            continue
-        cleaned = _LEADING_MARKERS_RE.sub("", line.strip()).strip("* ").strip()
-        if cleaned:
-            return _truncate_title(cleaned)
-
-    return "Assistant response"
+    # Translators: Django date-format string
+    # (https://docs.djangoproject.com/en/stable/ref/templates/builtins/#date),
+    # e.g. French uses "d/m/Y H:i" for the day-first order.
+    date_format = _("m/d/Y H:i")
+    formatted_date = formats.date_format(timezone.now(), date_format, use_l10n=False)
+    return _("[L'Assistant] New document %(date)s") % {"date": formatted_date}
 
 
 def _docs_http_error_response(exc):
@@ -162,7 +135,7 @@ class EditInDocsMixin:
         if not content:
             raise ValidationError({"message_id": "Message has no text content."})
 
-        title = _build_doc_title(content)
+        title = _build_doc_title()
 
         docs_client = DocsClient()
         try:


### PR DESCRIPTION
## Purpose

Documents created through the "Edit in Docs" action were titled by guessing a heading from the message content, which produced inconsistent and sometimes meaningless titles. Give exported documents a predictable, recognizable name instead.

## Proposal

- [x] Title exported documents with the product name and a creation timestamp instead of deriving a title from the message content
- [x] Make the title translatable, including the date format so each locale keeps its usual day/month ordering
- [x] Update the tests accordingly



https://github.com/orgs/suitenumerique/projects/13/views/3?filterQuery=&pane=issue&itemId=217069626&issue=suitenumerique%7Cconversations%7C612

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->




## Summary by CodeRabbit

* **Changed**
  * Docs exports now use a generic, localized title with the format “[L'Assistant] New document MM/DD/YYYY HH:MM.”
  * Titles no longer depend on or truncate assistant-generated content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->