### PR TITLE
🐛(back) remove the md extension from docs export titles

### DIFF
--- a/src/backend/chat/docs_client.py
+++ b/src/backend/chat/docs_client.py
@@ -38,8 +38,10 @@ class DocsClient:
         access_token = self.get_access_token(session)
         file = BytesIO(content.encode("utf-8"))
         # Strip path separators and control characters so the title is a safe filename.
+        # No .md extension: Docs reuses the filename as the document title and the
+        # content type already declares markdown.
         safe_title = re.sub(r"[/\\\x00-\x1f]", " ", title).strip() or "document"
-        file.name = f"{safe_title}.md"
+        file.name = safe_title
         response = requests.post(
             urljoin(self.api_url, "documents/"),
             headers={"Authorization": f"Bearer {access_token}"},

--- a/src/backend/chat/tests/test_docs_client.py
+++ b/src/backend/chat/tests/test_docs_client.py
@@ -111,7 +111,10 @@ def test_create_document_sends_bearer_token(docs_client):
 
 
 def test_create_document_sends_markdown_file(docs_client):
-    """create_document uploads the content as a .md file with text/markdown MIME type."""
+    """create_document uploads the content with text/markdown MIME type.
+
+    The filename carries no .md extension: Docs reuses it as the document title.
+    """
     session = {"oidc_access_token": "tok"}
     fake_response = MagicMock()
     fake_response.json.return_value = {"id": "doc-abc"}
@@ -122,7 +125,7 @@ def test_create_document_sends_markdown_file(docs_client):
     files = mock_post.call_args.kwargs["files"]
     assert "file" in files
     filename, fileobj, mimetype = files["file"]
-    assert filename == "My Doc.md"
+    assert filename == "My Doc"
     assert mimetype == "text/markdown"
     assert fileobj.read() == b"# Hello"
 

--- a/src/backend/chat/tests/views/chat/conversations/test_edit_in_docs.py
+++ b/src/backend/chat/tests/views/chat/conversations/test_edit_in_docs.py
@@ -1,7 +1,8 @@
 """Tests for the edit_in_docs view action."""
 
-import re
 from unittest.mock import MagicMock, patch
+
+from django.utils import formats, timezone
 
 import pytest
 import requests
@@ -366,14 +367,15 @@ def test_edit_in_docs_maps_docs_http_errors(
 # Title (_build_doc_title)
 # ---------------------------------------------------------------------------
 def test_build_doc_title_is_generic_and_timestamped():
-    """The title follows the "[L'Assistant] New document MM/DD/YYYY HH:MM" template.
+    """The title is the generic template plus the locale's SHORT_DATETIME_FORMAT date."""
+    # Format the date on both sides of the call so a minute rollover cannot flake.
+    before = formats.date_format(timezone.now(), "SHORT_DATETIME_FORMAT")
+    title = _build_doc_title()
+    after = formats.date_format(timezone.now(), "SHORT_DATETIME_FORMAT")
 
-    The date format string is itself translatable (French flips to DD/MM/YYYY);
-    under the test locale (English) the source format applies.
-    """
-    assert re.fullmatch(
-        r"\[L'Assistant\] New document \d{2}/\d{2}/\d{4} \d{2}:\d{2}",
-        _build_doc_title(),
+    assert title in (
+        f"[L'Assistant] New document {before}",
+        f"[L'Assistant] New document {after}",
     )
 
 

--- a/src/backend/chat/views/edit_in_docs.py
+++ b/src/backend/chat/views/edit_in_docs.py
@@ -26,14 +26,12 @@ logger = logging.getLogger(__name__)
 
 def _build_doc_title():
     """Build a generic timestamped document title, e.g.
-    "[L'Assistant] New document 07/22/2026 14:30" (localised via gettext,
-    including the date format itself).
+    "[L'Assistant] New document 07/22/2026 2:30 p.m.".
+
+    The wording is localised via gettext; the date uses Django's per-locale
+    SHORT_DATETIME_FORMAT, so no translation entry is needed for the format.
     """
-    # Translators: Django date-format string
-    # (https://docs.djangoproject.com/en/stable/ref/templates/builtins/#date),
-    # e.g. French uses "d/m/Y H:i" for the day-first order.
-    date_format = _("m/d/Y H:i")
-    formatted_date = formats.date_format(timezone.now(), date_format, use_l10n=False)
+    formatted_date = formats.date_format(timezone.now(), "SHORT_DATETIME_FORMAT")
     return _("[L'Assistant] New document %(date)s") % {"date": formatted_date}
 
 


### PR DESCRIPTION
PR description

## Purpose

Documents exported to Docs were titled with a trailing md extension, because the upload filename is reused by Docs as the document title. Give exported documents a clean title.

## Proposal

- [x] Drop the file extension from the uploaded document so the title shows    only the product name and timestamp
- [x] Update the corresponding test