### PR TITLE
🐛(back) add back the md extension for docs export

### DIFF
--- a/src/backend/chat/docs_client.py
+++ b/src/backend/chat/docs_client.py
@@ -38,10 +38,8 @@ class DocsClient:
         access_token = self.get_access_token(session)
         file = BytesIO(content.encode("utf-8"))
         # Strip path separators and control characters so the title is a safe filename.
-        # No .md extension: Docs reuses the filename as the document title and the
-        # content type already declares markdown.
         safe_title = re.sub(r"[/\\\x00-\x1f]", " ", title).strip() or "document"
-        file.name = safe_title
+        file.name = f"{safe_title}.md"
         response = requests.post(
             urljoin(self.api_url, "documents/"),
             headers={"Authorization": f"Bearer {access_token}"},

--- a/src/backend/chat/tests/test_docs_client.py
+++ b/src/backend/chat/tests/test_docs_client.py
@@ -111,10 +111,7 @@ def test_create_document_sends_bearer_token(docs_client):
 
 
 def test_create_document_sends_markdown_file(docs_client):
-    """create_document uploads the content with text/markdown MIME type.
-
-    The filename carries no .md extension: Docs reuses it as the document title.
-    """
+    """create_document uploads the content as a .md file with text/markdown MIME type."""
     session = {"oidc_access_token": "tok"}
     fake_response = MagicMock()
     fake_response.json.return_value = {"id": "doc-abc"}
@@ -125,7 +122,7 @@ def test_create_document_sends_markdown_file(docs_client):
     files = mock_post.call_args.kwargs["files"]
     assert "file" in files
     filename, fileobj, mimetype = files["file"]
-    assert filename == "My Doc"
+    assert filename == "My Doc.md"
     assert mimetype == "text/markdown"
     assert fileobj.read() == b"# Hello"
 


### PR DESCRIPTION
Revert previous commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Markdown documents uploaded through the chat experience now use filenames with the `.md` extension.
  * Uploads continue to use the correct Markdown content type for improved file recognition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->