### PR TITLE
✨(chat) add optional plan-first mode

### DIFF
--- a/src/backend/chat/clients/pydantic_ai.py
+++ b/src/backend/chat/clients/pydantic_ai.py
@@ -371,13 +371,21 @@ class AIAgentService:  # pylint: disable=too-many-instance-attributes
     # Public streaming API (unchanged signatures)
     # --------------------------------------------------------------------- #
 
-    def stream_text(self, messages: List[UIMessage], force_web_search: bool = False):
+    def stream_text(
+        self, messages: List[UIMessage], force_web_search: bool = False, force_plan: bool = False
+    ):
         """Return only the assistant text deltas (legacy text mode)."""
-        return convert_async_generator_to_sync(self.stream_text_async(messages, force_web_search))
+        return convert_async_generator_to_sync(
+            self.stream_text_async(messages, force_web_search, force_plan)
+        )
 
-    def stream_data(self, messages: List[UIMessage], force_web_search: bool = False):
+    def stream_data(
+        self, messages: List[UIMessage], force_web_search: bool = False, force_plan: bool = False
+    ):
         """Return Vercel-AI-SDK formatted events."""
-        return convert_async_generator_to_sync(self.stream_data_async(messages, force_web_search))
+        return convert_async_generator_to_sync(
+            self.stream_data_async(messages, force_web_search, force_plan)
+        )
 
     def stop_streaming(self):
         """
@@ -455,7 +463,11 @@ class AIAgentService:  # pylint: disable=too-many-instance-attributes
             )
 
     async def _stream_content(
-        self, messages: List[UIMessage], force_web_search: bool = False, encoder_fn: Callable = None
+        self,
+        messages: List[UIMessage],
+        force_web_search: bool = False,
+        force_plan: bool = False,
+        encoder_fn: Callable = None,
     ):
         """Common streaming logic with configurable encoder."""
         await self._clean()
@@ -475,7 +487,7 @@ class AIAgentService:  # pylint: disable=too-many-instance-attributes
                 )
 
             try:
-                async for event in self._run_agent(messages, force_web_search):
+                async for event in self._run_agent(messages, force_web_search, force_plan):
                     if stream_text := encoder_fn(event):
                         yield stream_text
             except (ModelHTTPError, HTTPValidationError, SDKError) as exc:
@@ -514,18 +526,28 @@ class AIAgentService:  # pylint: disable=too-many-instance-attributes
                 else:
                     raise
 
-    async def stream_text_async(self, messages: List[UIMessage], force_web_search: bool = False):
+    async def stream_text_async(
+        self, messages: List[UIMessage], force_web_search: bool = False, force_plan: bool = False
+    ):
         """Return only the assistant text deltas (legacy text mode)."""
         async for chunk in self._stream_content(
-            messages, force_web_search, encoder_fn=self.event_encoder.encode_text
+            messages,
+            force_web_search,
+            force_plan=force_plan,
+            encoder_fn=self.event_encoder.encode_text,
         ):
             yield chunk
 
-    async def stream_data_async(self, messages: List[UIMessage], force_web_search: bool = False):
+    async def stream_data_async(
+        self, messages: List[UIMessage], force_web_search: bool = False, force_plan: bool = False
+    ):
         """Return Vercel-AI-SDK formatted events."""
 
         async for chunk in self._stream_content(
-            messages, force_web_search, encoder_fn=self.event_encoder.encode
+            messages,
+            force_web_search,
+            force_plan=force_plan,
+            encoder_fn=self.event_encoder.encode,
         ):
             yield chunk
 
@@ -713,6 +735,25 @@ class AIAgentService:  # pylint: disable=too-many-instance-attributes
         def force_web_search_prompt() -> str:
             """Dynamic system prompt function to force web search."""
             return "You must call the web_search tool before answering the user request."
+
+        return True
+
+    def _setup_plan(self, force_plan: bool) -> bool:
+        """Configure plan-first mode if forced."""
+        if not force_plan:
+            return False
+
+        @self.conversation_agent.instructions
+        def force_plan_prompt() -> str:
+            """Dynamic system prompt function to force upfront planning."""
+            return (
+                "Planning mode is enabled for this request. Start by proposing a concise "
+                "numbered plan (maximum 8 steps) tailored to the user's goal. If you plan "
+                "to use tools, tell the user which tools without using explicitly the tools "
+                "names but tell the user the arguments you plan to use. Ask the user "
+                "to confirm or adjust the plan, and do not proceed with any execution until "
+                "the plan is approved. After approval, follow the agreed steps."
+            )
 
         return True
 
@@ -1452,6 +1493,7 @@ class AIAgentService:  # pylint: disable=too-many-instance-attributes
         self,
         messages: List[UIMessage],
         force_web_search: bool = False,
+        force_plan: bool = False,
     ) -> AsyncGenerator[events_v4.Event | events_v5.Event, None]:
         """Run the Pydantic AI agent and stream events."""
         if not messages or messages[-1].role != "user":
@@ -1529,6 +1571,7 @@ class AIAgentService:  # pylint: disable=too-many-instance-attributes
         self._setup_self_documentation_tool()
         self._setup_web_search_tool()
         self._setup_web_search(force_web_search)
+        self._setup_plan(force_plan)
 
         if await self._check_should_enable_rag(conversation_has_own_documents):
             document_context_instruction = await self._build_document_context_instruction()

--- a/src/backend/chat/serializers.py
+++ b/src/backend/chat/serializers.py
@@ -148,6 +148,11 @@ class ChatConversationRequestSerializer(serializers.Serializer):
         default=False,
         help_text="Force web search.",
     )
+    force_plan = serializers.BooleanField(
+        required=False,
+        default=False,
+        help_text="Force the model to propose a plan before answering.",
+    )
     model_hrid = serializers.CharField(
         required=False,
         default=None,

--- a/src/backend/chat/tests/serializers/test_chat_conversation_request_serializer.py
+++ b/src/backend/chat/tests/serializers/test_chat_conversation_request_serializer.py
@@ -37,6 +37,7 @@ def test_chat_conversation_request_serializer_default():
     assert serializer.is_valid()
     assert serializer.validated_data == {
         "force_web_search": False,
+        "force_plan": False,
         "model_hrid": None,
         "protocol": "data",
     }
@@ -90,6 +91,27 @@ def test_chat_conversation_request_serializer_force_web_search_invalid():
     assert not serializer.is_valid()
     assert serializer.errors == {
         "force_web_search": [ErrorDetail(string="Must be a valid boolean.", code="invalid")]
+    }
+
+
+@pytest.mark.parametrize("force_plan", [True, False])
+def test_chat_conversation_request_serializer_force_plan_valid(force_plan):
+    """
+    Test that the serializer accepts valid boolean values for force_plan.
+    """
+    serializer = serializers.ChatConversationRequestSerializer(data={"force_plan": force_plan})
+    assert serializer.is_valid()
+    assert serializer.validated_data["force_plan"] == force_plan
+
+
+def test_chat_conversation_request_serializer_force_plan_invalid():
+    """
+    Test that the serializer rejects non-boolean values for force_plan.
+    """
+    serializer = serializers.ChatConversationRequestSerializer(data={"force_plan": "invalid"})
+    assert not serializer.is_valid()
+    assert serializer.errors == {
+        "force_plan": [ErrorDetail(string="Must be a valid boolean.", code="invalid")]
     }
 
 

--- a/src/backend/chat/views/conversations.py
+++ b/src/backend/chat/views/conversations.py
@@ -227,6 +227,7 @@ class ChatViewSet(  # pylint: disable=too-many-ancestors, abstract-method
         query_params_serializer.is_valid(raise_exception=True)
         protocol = query_params_serializer.validated_data["protocol"]
         force_web_search = query_params_serializer.validated_data["force_web_search"]
+        force_plan = query_params_serializer.validated_data["force_plan"]
         requested_model_hrid = query_params_serializer.validated_data["model_hrid"]
 
         raw_messages = request.data.get("messages")
@@ -329,19 +330,23 @@ class ChatViewSet(  # pylint: disable=too-many-ancestors, abstract-method
             logger.debug("Using ASYNC streaming for chat conversation.")
             if protocol == "data":
                 base_stream = ai_service.stream_data_async(
-                    messages, force_web_search=force_web_search
+                    messages, force_web_search=force_web_search, force_plan=force_plan
                 )
             else:  # Default to 'text' protocol
                 base_stream = ai_service.stream_text_async(
-                    messages, force_web_search=force_web_search
+                    messages, force_web_search=force_web_search, force_plan=force_plan
                 )
             streaming_content = stream_with_keepalive_async(base_stream)
         else:
             logger.debug("Using SYNC streaming for chat conversation.")
             if protocol == "data":
-                base_stream = ai_service.stream_data(messages, force_web_search=force_web_search)
+                base_stream = ai_service.stream_data(
+                    messages, force_web_search=force_web_search, force_plan=force_plan
+                )
             else:  # Default to 'text' protocol
-                base_stream = ai_service.stream_text(messages, force_web_search=force_web_search)
+                base_stream = ai_service.stream_text(
+                    messages, force_web_search=force_web_search, force_plan=force_plan
+                )
 
             streaming_content = stream_with_keepalive_sync(base_stream)
         response = StreamingHttpResponse(

--- a/src/frontend/apps/conversations/src/features/chat/api/useChat.tsx
+++ b/src/frontend/apps/conversations/src/features/chat/api/useChat.tsx
@@ -23,7 +23,7 @@ const fetchAPIAdapter = (input: RequestInfo | URL, init?: RequestInit) => {
 
   const searchParams = new URLSearchParams();
 
-  const { forceWebSearch, selectedModelHrid } =
+  const { forceWebSearch, selectedModelHrid, forcePlanMode } =
     useChatPreferencesStore.getState();
 
   if (forceWebSearch) {
@@ -32,6 +32,10 @@ const fetchAPIAdapter = (input: RequestInfo | URL, init?: RequestInit) => {
 
   if (selectedModelHrid) {
     searchParams.append('model_hrid', selectedModelHrid);
+  }
+
+  if (forcePlanMode) {
+    searchParams.append('force_plan', 'true');
   }
 
   if (searchParams.toString()) {

--- a/src/frontend/apps/conversations/src/features/chat/components/Chat.tsx
+++ b/src/frontend/apps/conversations/src/features/chat/components/Chat.tsx
@@ -89,6 +89,8 @@ export const Chat = ({
   const {
     forceWebSearch,
     toggleForceWebSearch,
+    forcePlanMode,
+    toggleForcePlanMode,
     selectedModelHrid,
     setSelectedModelHrid,
   } = useChatPreferencesStore();
@@ -337,8 +339,46 @@ export const Chat = ({
     }
   };
 
+  const [dismissedPlanForAssistantId, setDismissedPlanForAssistantId] =
+    useState<string | null>(null);
+  const [planAcceptPending, setPlanAcceptPending] = useState(false);
+  const [overlayLockedForUserId, setOverlayLockedForUserId] = useState<
+    string | null
+  >(null);
+  const [planAcceptedOnce, setPlanAcceptedOnce] = useState(false);
+  const lastMessage = messages[messages.length - 1];
+  const lastAssistantId =
+    messages
+      .slice()
+      .reverse()
+      .find((m) => m.role === 'assistant')?.id || null;
+  const lastAssistantIndexForPlan = messages.findLastIndex(
+    (m) => m.role === 'assistant',
+  );
+  const lastUserIndexForPlan = messages.findLastIndex((m) => m.role === 'user');
+  const lastUserId =
+    messages
+      .slice()
+      .reverse()
+      .find((m) => m.role === 'user')?.id || null;
+  const canShowForUser = lastUserId && overlayLockedForUserId !== lastUserId;
+  const showPlanOverlay =
+    forcePlanMode &&
+    lastAssistantId !== null &&
+    lastAssistantIndexForPlan > lastUserIndexForPlan &&
+    dismissedPlanForAssistantId !== lastAssistantId &&
+    canShowForUser &&
+    !planAcceptedOnce;
+
   const toggleWebSearch = () => {
     toggleForceWebSearch();
+  };
+
+  const togglePlanning = () => {
+    toggleForcePlanMode();
+    setPlanAcceptedOnce(false);
+    setDismissedPlanForAssistantId(null);
+    setOverlayLockedForUserId(null);
   };
 
   const handleStop = () => {
@@ -348,6 +388,46 @@ export const Chat = ({
   const handleSubmitWrapper = (event: FormEvent<HTMLFormElement>) => {
     void handleSubmit(event);
   };
+
+  const handlePlanAccept = () => {
+    if (lastAssistantId) {
+      setDismissedPlanForAssistantId(lastAssistantId);
+    }
+    if (lastUserId) {
+      setOverlayLockedForUserId(lastUserId);
+    }
+    setPlanAcceptedOnce(true);
+    handleInputChange({
+      target: { value: t('Plan accepté') },
+    } as ChangeEvent<HTMLTextAreaElement>);
+    // Wait for React to update the input, then submit when status is ready.
+    setPlanAcceptPending(true);
+  };
+
+  useEffect(() => {
+    if (planAcceptPending && status === 'ready') {
+      const form = document.createElement('form');
+      const syntheticFormEvent = {
+        preventDefault: () => {},
+        target: form,
+        currentTarget: form,
+      } as unknown as FormEvent<HTMLFormElement>;
+      void handleSubmitWrapper(syntheticFormEvent);
+      setPlanAcceptPending(false);
+      if (lastAssistantId) {
+        setDismissedPlanForAssistantId(lastAssistantId);
+      }
+    }
+  }, [planAcceptPending, status, lastAssistantId]);
+
+  useEffect(() => {
+    // When a new user message arrives, re-authorize overlay for that turn.
+    if (lastMessage?.role === 'user' && lastUserId) {
+      setOverlayLockedForUserId(null);
+      setDismissedPlanForAssistantId(null);
+      setPlanAcceptPending(false);
+    }
+  }, [lastMessage, lastUserId]);
 
   const handleRetry = () => {
     if (!lastSubmissionRef.current || !setMessages) {
@@ -1057,6 +1137,77 @@ export const Chat = ({
           />
         )}
       </Box>
+      {showPlanOverlay && lastAssistantId && (
+        <Box
+          $css={`
+            position: fixed;
+            left: 50%;
+            transform: translateX(-50%);
+            bottom: ${isMobile ? '110px' : '140px'};
+            display: flex;
+            justify-content: center;
+            pointer-events: none;
+            z-index: 1400;
+          `}
+        >
+          <Box
+            $direction="row"
+            $align="center"
+            $gap="10px"
+            $padding={{ horizontal: 'md', vertical: 'xs' }}
+            $radius="12px"
+            $background="var(--c--contextuals--background--surface--primary)"
+            $css={`
+              border: 1px solid var(--c--contextuals--border--semantic--brand--tertiary);
+              pointer-events: auto;
+              box-shadow: 0 10px 30px rgba(0, 0, 0, 0.12);
+              max-width: 360px;
+              width: fit-content;
+              justify-content: center;
+              margin: 0 auto;
+            `}
+          >
+            <Icon
+              iconName="fact_check"
+              $theme="brand"
+              $variation="secondary"
+              $size="22px"
+            />
+            {!isMobile && (
+              <Text $theme="brand" $variation="secondary" $size="sm">
+                {t('Plan prêt — acceptez pour continuer')}
+              </Text>
+            )}
+            <Box
+              className="c__button--neutral action-chat-button"
+              $direction="row"
+              $align="center"
+              $gap="6px"
+              $padding={{ horizontal: 'sm', vertical: 'xs' }}
+              $css="cursor: pointer;"
+              onClick={handlePlanAccept}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  handlePlanAccept();
+                }
+              }}
+              role="button"
+              tabIndex={0}
+            >
+              <Icon
+                iconName="check"
+                $theme="brand"
+                $variation="secondary"
+                $size="18px"
+              />
+              <Text $theme="brand" $variation="secondary">
+                {t('Accept')}
+              </Text>
+            </Box>
+          </Box>
+        </Box>
+      )}
       <Box
         $css={`
           position: relative;
@@ -1086,6 +1237,8 @@ export const Chat = ({
           onStop={handleStop}
           forceWebSearch={forceWebSearch}
           onToggleWebSearch={toggleWebSearch}
+          planModeEnabled={forcePlanMode}
+          onTogglePlanMode={togglePlanning}
           selectedModel={selectedModel}
           onModelSelect={handleModelSelect}
           isUploadingFiles={isUploadingFiles}

--- a/src/frontend/apps/conversations/src/features/chat/components/InputChat.tsx
+++ b/src/frontend/apps/conversations/src/features/chat/components/InputChat.tsx
@@ -50,6 +50,8 @@ interface InputChatProps {
   containerRef?: React.RefObject<HTMLDivElement | null>;
   forceWebSearch?: boolean;
   onToggleWebSearch?: () => void;
+  planModeEnabled?: boolean;
+  onTogglePlanMode?: () => void;
   onStop?: () => void;
   selectedModel?: LLMModel | null;
   onModelSelect?: (model: LLMModel) => void;
@@ -148,6 +150,8 @@ export const InputChat = ({
   containerRef,
   forceWebSearch = false,
   onToggleWebSearch,
+  planModeEnabled = false,
+  onTogglePlanMode,
   onStop,
   selectedModel,
   onModelSelect,
@@ -410,6 +414,11 @@ export const InputChat = ({
     textareaRef.current?.focus();
   }, [onToggleWebSearch]);
 
+  const handlePlanModeToggle = useCallback(() => {
+    onTogglePlanMode?.();
+    textareaRef.current?.focus();
+  }, [onTogglePlanMode]);
+
   const handleFileChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
       const fileList = e.target.files;
@@ -604,9 +613,13 @@ export const InputChat = ({
                 isUploadingFiles={isUploadingFiles}
                 isMobile={isMobile}
                 forceWebSearch={forceWebSearch}
+                forcePlanMode={planModeEnabled}
                 onAttachClick={handleAttachClick}
                 onWebSearchToggle={
                   onToggleWebSearch ? handleWebSearchToggle : undefined
+                }
+                onPlanModeToggle={
+                  onTogglePlanMode ? handlePlanModeToggle : undefined
                 }
                 onModelSelect={onModelSelect}
                 selectedModel={selectedModel || null}

--- a/src/frontend/apps/conversations/src/features/chat/components/InputChatAction.tsx
+++ b/src/frontend/apps/conversations/src/features/chat/components/InputChatAction.tsx
@@ -18,10 +18,14 @@ interface InputChatActionsProps {
   isMobile: boolean;
   /** Whether web search is forced/active */
   forceWebSearch: boolean;
+  /** Whether plan-first mode is active */
+  forcePlanMode?: boolean;
   /** Handler for attach button click */
   onAttachClick: () => void;
   /** Handler for web search toggle - if undefined, button is hidden */
   onWebSearchToggle?: () => void;
+  /** Handler for plan mode toggle - if undefined, button is hidden */
+  onPlanModeToggle?: () => void;
   /** Handler for model selection - if undefined, selector is hidden */
   onModelSelect?: (model: LLMModel) => void;
   /** Currently selected model */
@@ -53,6 +57,13 @@ const ACTIONS_OPACITY_CSS = 'opacity: 1;';
 
 const ACTIVE_WEB_BUTTON_CSS = `
   .research-web-button {
+    background-color: var(--c--contextuals--background--semantic--brand--secondary) !important;
+    color: var(--c--contextuals--content--semantic--brand--secondary) !important;
+  }
+`;
+
+const ACTIVE_PLAN_BUTTON_CSS = `
+  .plan-mode-button {
     background-color: var(--c--contextuals--background--semantic--brand--secondary) !important;
     color: var(--c--contextuals--content--semantic--brand--secondary) !important;
   }
@@ -90,8 +101,10 @@ export const InputChatActions = memo(
     isUploadingFiles,
     isMobile,
     forceWebSearch,
+    forcePlanMode = false,
     onAttachClick,
     onWebSearchToggle,
+    onPlanModeToggle,
     onModelSelect,
     selectedModel,
     status,
@@ -111,6 +124,10 @@ export const InputChatActions = memo(
       }
       return css;
     }, [isMobile, forceWebSearch]);
+
+    const planModeWrapperCss = useMemo(() => {
+      return forcePlanMode ? ACTIVE_PLAN_BUTTON_CSS : '';
+    }, [forcePlanMode]);
 
     return (
       <Box
@@ -195,6 +212,62 @@ export const InputChatActions = memo(
                       $css={MOBILE_TEXT_CSS}
                     >
                       {t('Web')}
+                    </Text>
+                    <Icon
+                      iconName="close"
+                      $theme="brand"
+                      $variation="secondary"
+                      $size="md"
+                      $css={CLOSE_ICON_CSS}
+                    />
+                  </Box>
+                )}
+              </Button>
+            </Box>
+          )}
+
+          {/* Plan-first toggle button */}
+          {onPlanModeToggle && (
+            <Box $margin={STYLES.webSearchMargin} $css={planModeWrapperCss}>
+              <Button
+                size="nano"
+                color={forcePlanMode ? 'brand' : 'neutral'}
+                variant="tertiary"
+                type="button"
+                disabled={isUploadingFiles}
+                onClick={onPlanModeToggle}
+                aria-label={t('Plan tasks first')}
+                className="c__button--neutral plan-mode-button"
+                icon={
+                  <Icon
+                    iconName="fact_check"
+                    $theme={forcePlanMode ? 'brand' : 'neutral'}
+                    $variation="tertiary"
+                  />
+                }
+              >
+                {!isMobile && (
+                  <Text
+                    $theme={forcePlanMode ? 'brand' : 'neutral'}
+                    $variation="tertiary"
+                  >
+                    {t('Plan first')}
+                  </Text>
+                )}
+                {isMobile && forcePlanMode && (
+                  <Box
+                    $direction="row"
+                    $align="space-between"
+                    $gap="xs"
+                    $css={MOBILE_TEXT_WRAPPER_CSS}
+                  >
+                    <Text
+                      $theme="brand"
+                      $variation="secondary"
+                      $weight="500"
+                      $css={MOBILE_TEXT_CSS}
+                    >
+                      {t('Plan')}
                     </Text>
                     <Icon
                       iconName="close"

--- a/src/frontend/apps/conversations/src/features/chat/components/__tests__/InputChatAction.test.tsx
+++ b/src/frontend/apps/conversations/src/features/chat/components/__tests__/InputChatAction.test.tsx
@@ -214,4 +214,55 @@ describe('InputChatActions', () => {
     expect(screen.getByText('Research on the web')).toBeInTheDocument();
     expect(screen.queryByText('Web')).not.toBeInTheDocument();
   });
+
+  it('should render plan mode button when onPlanModeToggle is provided', () => {
+    render(
+      <InputChatActions
+        {...defaultProps}
+        onPlanModeToggle={jest.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByRole('button', { name: 'Plan tasks first' }),
+    ).toBeInTheDocument();
+  });
+
+  it('should not render plan mode button when onPlanModeToggle is undefined', () => {
+    render(
+      <InputChatActions {...defaultProps} onPlanModeToggle={undefined} />,
+    );
+
+    expect(
+      screen.queryByRole('button', { name: 'Plan tasks first' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('should call onPlanModeToggle when plan mode button is clicked', async () => {
+    const user = userEvent.setup();
+    const onPlanModeToggle = jest.fn();
+    render(
+      <InputChatActions
+        {...defaultProps}
+        onPlanModeToggle={onPlanModeToggle}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Plan tasks first' }));
+
+    expect(onPlanModeToggle).toHaveBeenCalledTimes(1);
+  });
+
+  it('should show "Plan" text on mobile when forcePlanMode is active', () => {
+    render(
+      <InputChatActions
+        {...defaultProps}
+        isMobile={true}
+        forcePlanMode={true}
+        onPlanModeToggle={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByText('Plan')).toBeInTheDocument();
+  });
 });

--- a/src/frontend/apps/conversations/src/features/chat/stores/useChatPreferencesStore.ts
+++ b/src/frontend/apps/conversations/src/features/chat/stores/useChatPreferencesStore.ts
@@ -5,12 +5,14 @@ interface ChatPreferencesState {
   themeModePreference: 'system' | 'light' | 'dark';
   selectedModelHrid: string | null;
   forceWebSearch: boolean;
+  forcePlanMode: boolean;
   isDarkModePreference: boolean;
   isPanelOpen: boolean;
   setSelectedModelHrid: (hrid: string | null) => void;
   setThemeModePreference: (mode: 'system' | 'light' | 'dark') => void;
   toggleDarkModePreferences: () => void;
   toggleForceWebSearch: () => void;
+  toggleForcePlanMode: () => void;
   setPanelOpen: (isOpen: boolean) => void;
   togglePanel: () => void;
 }
@@ -21,6 +23,7 @@ export const useChatPreferencesStore = create<ChatPreferencesState>()(
       themeModePreference: 'system',
       selectedModelHrid: null,
       forceWebSearch: false,
+      forcePlanMode: false,
       isDarkModePreference: false,
       isPanelOpen: false,
       setSelectedModelHrid: (hrid) => set({ selectedModelHrid: hrid }),
@@ -39,6 +42,8 @@ export const useChatPreferencesStore = create<ChatPreferencesState>()(
         }),
       toggleForceWebSearch: () =>
         set((state) => ({ forceWebSearch: !state.forceWebSearch })),
+      toggleForcePlanMode: () =>
+        set((state) => ({ forcePlanMode: !state.forcePlanMode })),
       setPanelOpen: (isOpen) => set({ isPanelOpen: isOpen }),
       togglePanel: () => set((state) => ({ isPanelOpen: !state.isPanelOpen })),
     }),


### PR DESCRIPTION
## Summary
- Add an optional plan-first chat mode: when enabled, the model proposes a short numbered plan and waits for approval before executing.
- Wire a `force_plan` query param end-to-end (serializer → chat view → agent instructions), following the same pattern as `force_web_search`.
- Add a Plan toggle in the chat input and an Accept overlay so users can approve the plan and continue.

<img width="819" height="225" alt="Capture d’écran 2026-07-23 à 15 42 16" src="https://github.com/user-attachments/assets/5543743a-cf9d-4a4d-bf10-3db9312aff6d" />
<img width="774" height="953" alt="Capture d’écran 2026-07-23 à 15 42 31" src="https://github.com/user-attachments/assets/4a2103cc-170a-49c3-ad2f-c0638837906b" />


## Test plan
- [ ] Toggle **Plan first** on, send a multi-step request → assistant replies with a numbered plan and does not call tools yet
- [ ] Click **Accept** → follow-up message is sent and the assistant executes the plan
- [ ] Toggle plan mode off → normal chat behavior (no plan prompt / no overlay)
- [ ] Confirm `force_plan=true` is present on the conversation request when plan mode is enabled
- [ ] Run serializer tests for `force_plan` (valid true/false + invalid)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an optional Plan mode for chat conversations.
  - Users can toggle Plan mode before sending a message.
  - The assistant proposes a short, numbered plan and waits for approval before taking action.
  - Added an approval overlay with an **Accept** action, including keyboard support.
  - Plan mode works with both text and data streaming responses.

- **Tests**
  - Added coverage for Plan mode validation, toggling, display, and user interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->