### PR TITLE
⚡️(front) throttle chat stream re-renders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- ⚡️(front) throttle chat stream updates to stop excessive re-renders
+
 ## [0.0.20] - 2026-07-23
 
 ### Added

--- a/src/frontend/apps/conversations/src/core/config/ConfigProvider.tsx
+++ b/src/frontend/apps/conversations/src/core/config/ConfigProvider.tsx
@@ -14,6 +14,7 @@ import { MaintenancePage } from '@/features/maintenance';
 import { useAnalytics } from '@/libs';
 import { PostHogAnalytic } from '@/services';
 import { useSentryStore } from '@/stores/useSentryStore';
+import { trackRender } from '@/utils';
 
 import { useConfig } from './api/useConfig';
 
@@ -28,6 +29,13 @@ export const ConfigProvider = ({ children }: PropsWithChildren) => {
   const { i18n } = useTranslation();
   const hasSyncedInitialLanguage = useRef(false);
   const lastSyncedUserLanguage = useRef<string | null>(null);
+
+  // TEMPORARY: render-loop diagnostic, remove with utils/debugRenderLoop.
+  trackRender('ConfigProvider', {
+    hasConf: !!conf,
+    hasUser: !!user,
+    language: i18n.resolvedLanguage,
+  });
 
   useEffect(() => {
     if (!conf || hasSyncedInitialLanguage.current) {

--- a/src/frontend/apps/conversations/src/features/auth/components/Auth.tsx
+++ b/src/frontend/apps/conversations/src/features/auth/components/Auth.tsx
@@ -3,6 +3,7 @@ import { PropsWithChildren } from 'react';
 
 import { Box, Loader } from '@/components';
 import { useConfig } from '@/core';
+import { trackRender } from '@/utils';
 
 import { useActivationStatus } from '../api/useActivationStatus';
 import { HOME_URL } from '../conf';
@@ -17,6 +18,22 @@ export const Auth = ({ children }: PropsWithChildren) => {
   const { data: config, isLoading: isConfigLoading } = useConfig();
   const { data: activationStatus, isLoading: isActivationLoading } =
     useActivationStatus();
+
+  // TEMPORARY: this component redirects from its render body, so every input
+  // it branches on is worth seeing when it loops.
+  trackRender('Auth', {
+    pathname,
+    authenticated,
+    pathAllowed,
+    isLoading,
+    isFetchedAfterMount,
+    isConfigLoading,
+    isActivationLoading,
+    silentLoginEnabled: config?.FRONTEND_SILENT_LOGIN_ENABLED,
+    homepageEnabled: config?.FRONTEND_HOMEPAGE_FEATURE_ENABLED,
+    activationRequired: config?.ACTIVATION_REQUIRED,
+    isActivated: activationStatus?.is_activated,
+  });
 
   if (isLoading && !isFetchedAfterMount) {
     return (

--- a/src/frontend/apps/conversations/src/features/chat/api/useChat.tsx
+++ b/src/frontend/apps/conversations/src/features/chat/api/useChat.tsx
@@ -8,6 +8,7 @@ import { KEY_CONVERSATION } from '@/features/chat/api/useConversation';
 import { KEY_LIST_CONVERSATION } from '@/features/chat/api/useConversations';
 import { KEY_LIST_PROJECT } from '@/features/chat/api/useProjects';
 import { useChatPreferencesStore } from '@/features/chat/stores/useChatPreferencesStore';
+import { debugSample } from '@/utils';
 
 const fetchAPIAdapter = (input: RequestInfo | URL, init?: RequestInit) => {
   let url: string;
@@ -166,6 +167,12 @@ export function stampImagesSkippedOnLatestUserMessage(
   return next;
 }
 
+// Without this the SDK calls SWR's `mutate` once per stream chunk
+// (`throttle(fn, undefined)` returns `fn` untouched), so a fast response
+// re-renders the whole chat tree ~100 times a second. 50ms caps the refresh at
+// 20fps, which still reads as continuous typing.
+const STREAM_THROTTLE_MS = 50;
+
 export function useChat(options: Omit<UseChatOptions, 'fetch'>) {
   const queryClient = useQueryClient();
   const { onFinish: onFinishOption, ...restOptions } = options;
@@ -173,6 +180,7 @@ export function useChat(options: Omit<UseChatOptions, 'fetch'>) {
   const result = useAiSdkChat({
     ...restOptions,
     maxSteps: 3,
+    experimental_throttle: STREAM_THROTTLE_MS,
     fetch: fetchAPIAdapter,
     onFinish: (message, finishOptions) => {
       if (message.annotations?.length) {
@@ -194,6 +202,12 @@ export function useChat(options: Omit<UseChatOptions, 'fetch'>) {
       onFinishOption?.(message, finishOptions);
     },
   });
+
+  // TEMPORARY: render-loop diagnostic. Renders that continue past a `ready`
+  // status are a real loop; renders that stop with it were just the stream.
+  useEffect(() => {
+    debugSample('useChat status', { status: result.status });
+  }, [result.status]);
 
   // Epoch ms until which the user must wait before sending a new message.
   const [cooldownUntil, setCooldownUntil] = useState<number | null>(null);

--- a/src/frontend/apps/conversations/src/features/chat/components/Chat.tsx
+++ b/src/frontend/apps/conversations/src/features/chat/components/Chat.tsx
@@ -45,6 +45,7 @@ import {
 } from '@/features/chat/components/reindexErrorMessages';
 import { useClipboard } from '@/hook';
 import { useResponsiveStore } from '@/stores';
+import { trackRender } from '@/utils';
 
 import { useSourceMetadataCache } from '../hooks';
 import { useAprilFools } from '../hooks/useAprilFools';
@@ -763,6 +764,52 @@ export const Chat = ({
   }, [conversationId]);
 
   const showImagesBanner = imagesSkipped && !imagesBannerDismissed;
+
+  // TEMPORARY: render-loop diagnostic, remove with utils/debugRenderLoop.
+  // Every hook output this component reads, so the diff names what churns.
+  trackRender('Chat', {
+    initialConversationId,
+    conversationId,
+    messages,
+    setMessages,
+    status,
+    data,
+    input,
+    cooldownUntil,
+    initialConversationMessages,
+    llmConfig,
+    selectedModel,
+    selectedModelHrid,
+    config,
+    t,
+    files,
+    isUploadingFiles,
+    conversationProjectId,
+    projectAttachments,
+    failedIndexingIds,
+    chatErrorModal,
+    chatErrorType,
+    imagesSkipped,
+    imagesBannerDismissed,
+    isSourceOpen,
+    streamingMessageHeight,
+    isReadingInstructions,
+    contextTrimmed,
+    shouldAutoSubmit,
+    shouldRetry,
+    hasInitialized,
+    pendingFirstMessage,
+    pendingInput,
+    pendingFiles,
+    pendingProjectId,
+    hasProjectInstructions,
+    forceWebSearch,
+    isMobile,
+    aprilFoolsActive: aprilFools.isActive,
+    aprilFoolsText: aprilFools.displayedText,
+    isErrorAttachment,
+    errorAttachment,
+  });
 
   useEffect(() => {
     if (

--- a/src/frontend/apps/conversations/src/features/chat/components/InputChat.tsx
+++ b/src/frontend/apps/conversations/src/features/chat/components/InputChat.tsx
@@ -24,6 +24,7 @@ import { WelcomeMessage } from '@/features/chat/components/WelcomeMessage';
 import { useFileDragDrop } from '@/features/chat/hooks/useFileDragDrop';
 import { useFileUrls } from '@/features/chat/hooks/useFileUrls';
 import { useResponsiveStore } from '@/stores';
+import { trackRender } from '@/utils';
 
 import FilesIcon from '../assets/files.svg';
 
@@ -456,6 +457,41 @@ export const InputChat = ({
       };
     });
   }, [files, fileUrlMap]);
+
+  // TEMPORARY: render-loop diagnostic, remove with utils/debugRenderLoop.
+  trackRender('InputChat', {
+    messagesLength,
+    input,
+    status,
+    files,
+    setFiles,
+    handleInputChange,
+    handleSubmit,
+    onScrollToBottom,
+    containerRef,
+    forceWebSearch,
+    onToggleWebSearch,
+    onStop,
+    selectedModel,
+    onModelSelect,
+    isUploadingFiles,
+    isIndexingFiles,
+    failedIndexingCount,
+    onRetryFailedIndexing,
+    isRetryingIndexing,
+    errorType,
+    cooldownUntil,
+    cooldownRemaining,
+    conf,
+    assistantHealth,
+    isDragActive,
+    fileUrlMap,
+    attachments,
+    isDesktop,
+    isMobile,
+    t,
+    showToast,
+  });
 
   return (
     <>

--- a/src/frontend/apps/conversations/src/features/left-panel/components/left-panel/LeftPanel.tsx
+++ b/src/frontend/apps/conversations/src/features/left-panel/components/left-panel/LeftPanel.tsx
@@ -9,6 +9,7 @@ import { LaGaufre } from '@/features/header/components/LaGaufre';
 import { OnboardingButton } from '@/features/onboarding';
 import { SettingsButton } from '@/features/settings';
 import { useResponsiveStore } from '@/stores';
+import { trackRender } from '@/utils';
 
 import { LeftPanelContent } from './LeftPanelContent';
 import { LeftPanelHeader } from './LeftPanelHeader';
@@ -32,6 +33,9 @@ export const LeftPanel = () => {
   const showLaGaufre =
     (componentTokens as Record<string, unknown>)['la-gaufre'] === true;
   const { setPanelOpen, isPanelOpen } = useChatPreferencesStore();
+
+  // TEMPORARY: render-loop diagnostic, remove with utils/debugRenderLoop.
+  trackRender('LeftPanel', { isDesktop, isPanelOpen });
 
   useEffect(() => {
     setPanelOpen(isDesktop ? true : false);

--- a/src/frontend/apps/conversations/src/layouts/MainLayout.tsx
+++ b/src/frontend/apps/conversations/src/layouts/MainLayout.tsx
@@ -10,6 +10,7 @@ import { Header } from '@/features/header';
 import { LeftPanel } from '@/features/left-panel';
 import { MAIN_LAYOUT_ID } from '@/layouts/conf';
 import { useResponsiveStore } from '@/stores';
+import { trackRender } from '@/utils';
 
 type MainLayoutProps = {
   backgroundColor?: 'white' | 'grey';
@@ -23,6 +24,9 @@ export function MainLayout({
   const { isPanelOpen } = useChatPreferencesStore();
   const { data: config } = useConfig();
   const { data: assistantHealth } = useAssistantHealth();
+
+  // TEMPORARY: render-loop diagnostic, remove with utils/debugRenderLoop.
+  trackRender('MainLayout', { isDesktop, isPanelOpen });
 
   return (
     <Box className="--docs--main-layout">

--- a/src/frontend/apps/conversations/src/pages/_app.tsx
+++ b/src/frontend/apps/conversations/src/pages/_app.tsx
@@ -7,8 +7,13 @@ import { AppProvider, productName } from '@/core/';
 import { useCunninghamTheme } from '@/cunningham';
 import '@/i18n/initI18n';
 import { NextPageWithLayout } from '@/types/next';
+import { installRenderLoopCapture } from '@/utils';
 
 import './globals.css';
+
+// TEMPORARY: names the component behind the "Maximum update depth exceeded"
+// errors. Remove together with the trackRender() call sites.
+installRenderLoopCapture();
 
 type AppPropsWithLayout = AppProps & {
   Component: NextPageWithLayout;

--- a/src/frontend/apps/conversations/src/utils/debugRenderLoop.ts
+++ b/src/frontend/apps/conversations/src/utils/debugRenderLoop.ts
@@ -1,0 +1,244 @@
+import * as Sentry from '@sentry/nextjs';
+
+/**
+ * TEMPORARY diagnostic for the "Maximum update depth exceeded" errors seen in
+ * production.
+ *
+ * `trackRender` is called from the always-mounted components. React aborts a
+ * runaway update cycle at 50 nested updates, so a component crossing
+ * WARN_THRESHOLD renders inside WINDOW_MS is already looping: we attach that to
+ * the Sentry scope, so the React error that follows a few milliseconds later
+ * carries the name of the component that caused it.
+ *
+ * The console stays silent unless `localStorage['debug-render-loop']` is set:
+ * streaming legitimately re-renders ~20x/s, and the diff payload holds message
+ * content, which has no business in an end user's console. Only counts and
+ * changed key *names* ever reach Sentry.
+ *
+ *   localStorage['debug-render-loop'] = 'on'       // loop reports
+ *   localStorage['debug-render-loop'] = 'verbose'  // plus every single render
+ *
+ * Remove this module and its call sites once the loop is fixed.
+ */
+
+const WINDOW_MS = 1000;
+const WARN_THRESHOLD = 25;
+
+// Once a component passes this many renders in the window it is misbehaving,
+// so start reporting which of its values changed identity between renders.
+const DIFF_THRESHOLD = 5;
+const DIFF_LOGS_PER_WINDOW = 12;
+
+interface RenderCounter {
+  count: number;
+  windowStart: number;
+  warned: boolean;
+  diffLogs: number;
+  lastContext?: Record<string, unknown>;
+  previousValues?: Record<string, unknown>;
+  lastChangedKeys?: string[];
+}
+
+const counters = new Map<string, RenderCounter>();
+
+/**
+ * Keys whose identity differs from the previous render. An empty list means the
+ * re-render came from a parent, a context, or a store - not from this
+ * component's own values.
+ */
+const changedKeys = (
+  previous: Record<string, unknown>,
+  current: Record<string, unknown>,
+) =>
+  Object.keys(current).filter((key) => !Object.is(previous[key], current[key]));
+
+const debugLevel = () => {
+  try {
+    return localStorage.getItem('debug-render-loop');
+  } catch {
+    // localStorage unavailable (privacy mode, sandboxed iframe) - stay quiet.
+    return null;
+  }
+};
+
+/** Console output is opt-in; Sentry reporting is not gated by this. */
+const isConsoleEnabled = () => debugLevel() !== null;
+const isVerbose = () => debugLevel() === 'verbose';
+
+/**
+ * Components still inside their current window, busiest first. Carries only
+ * counts and changed key *names* - never the values, which hold message
+ * content and would otherwise reach Sentry.
+ */
+const snapshot = () => {
+  const now = Date.now();
+  return Array.from(counters.entries())
+    .filter(([, counter]) => now - counter.windowStart <= WINDOW_MS)
+    .sort(([, a], [, b]) => b.count - a.count)
+    .map(([name, counter]) => ({
+      component: name,
+      renders: counter.count,
+      elapsedMs: now - counter.windowStart,
+      changedKeys: counter.lastChangedKeys ?? [],
+    }));
+};
+
+/**
+ * Count one render of `name`. Pass every hook output the component depends on
+ * as `context`: once the render rate goes abnormal, the keys whose identity
+ * changed between renders are logged, which is what names the culprit.
+ */
+export const trackRender = (
+  name: string,
+  context?: Record<string, unknown>,
+) => {
+  const now = Date.now();
+  let counter = counters.get(name);
+
+  if (!counter || now - counter.windowStart > WINDOW_MS) {
+    counter = { count: 0, windowStart: now, warned: false, diffLogs: 0 };
+    counters.set(name, counter);
+  }
+
+  counter.count += 1;
+  const previousValues = counter.previousValues;
+  counter.previousValues = context;
+  counter.lastContext = context;
+
+  if (isVerbose()) {
+    console.log(`[render-loop] ${name} #${counter.count}`, context ?? '');
+  }
+
+  // Computed even when the console is silent: the key names ride along to
+  // Sentry, and they are what identifies the culprit there.
+  if (context && previousValues && counter.count >= DIFF_THRESHOLD) {
+    const changed = changedKeys(previousValues, context);
+    counter.lastChangedKeys = changed;
+
+    if (isConsoleEnabled() && counter.diffLogs < DIFF_LOGS_PER_WINDOW) {
+      counter.diffLogs += 1;
+      console.log(
+        `[render-loop] ${name} #${counter.count} changed: ${changed.join(', ') || '(nothing of its own)'}`,
+        changed.reduce<Record<string, unknown>>((acc, key) => {
+          acc[key] = { from: previousValues[key], to: context[key] };
+          return acc;
+        }, {}),
+      );
+    }
+  }
+
+  if (counter.count < WARN_THRESHOLD || counter.warned) {
+    return;
+  }
+  counter.warned = true;
+
+  const renders = counter.count;
+  const elapsedMs = now - counter.windowStart;
+
+  // Values stay in the developer's own console; only names travel to Sentry.
+  if (isConsoleEnabled()) {
+    console.warn(
+      `[render-loop] ${name} rendered ${renders} times in ${elapsedMs}ms`,
+      { component: name, renders, elapsedMs, context, busiest: snapshot() },
+    );
+  }
+
+  // Attached to the scope rather than captured as its own event: the React
+  // error arrives moments later and we want it to carry this payload.
+  const report = { component: name, renders, elapsedMs, busiest: snapshot() };
+  Sentry.setContext('render_loop', report);
+  Sentry.addBreadcrumb({
+    category: 'render-loop',
+    level: 'warning',
+    message: `${name} rendered ${renders}x in ${elapsedMs}ms`,
+    data: report,
+  });
+};
+
+const SAMPLES_PER_WINDOW = 8;
+const sampleBudgets = new Map<string, { windowStart: number; logs: number }>();
+
+/** Rate-limited, opt-in log for call sites that fire on every render. */
+export const debugSample = (
+  label: string,
+  payload: Record<string, unknown>,
+) => {
+  if (!isConsoleEnabled()) {
+    return;
+  }
+
+  const now = Date.now();
+  let budget = sampleBudgets.get(label);
+
+  if (!budget || now - budget.windowStart > WINDOW_MS) {
+    budget = { windowStart: now, logs: 0 };
+    sampleBudgets.set(label, budget);
+  }
+
+  if (budget.logs >= SAMPLES_PER_WINDOW) {
+    return;
+  }
+  budget.logs += 1;
+  console.log(`[render-loop] ${label}`, payload);
+};
+
+const REACT_LOOP_MESSAGES = [
+  'Maximum update depth exceeded',
+  'while rendering a different component',
+  // Production React reports errors by code: #185 is the update-depth limit.
+  'Minified React error #185',
+];
+
+const isReactLoopMessage = (message: string) =>
+  REACT_LOOP_MESSAGES.some((needle) => message.includes(needle));
+
+let installed = false;
+
+/**
+ * Record the render tally whenever React reports a runaway update, so the
+ * Sentry event names the component that was spinning even though the throw
+ * itself comes from inside react-dom and never mentions it.
+ */
+export const installRenderLoopCapture = () => {
+  if (installed || typeof window === 'undefined') {
+    return;
+  }
+  installed = true;
+
+  const report = (source: string, message: string) => {
+    const busiest = snapshot();
+    Sentry.setContext('render_loop_error', { source, message, busiest });
+    if (isConsoleEnabled()) {
+      console.warn(
+        `[render-loop] React reported "${message}" via ${source}. Busiest components:`,
+        busiest,
+      );
+    }
+  };
+
+  // React throws the update-depth error rather than logging it, so this is the
+  // hook that fires in a production build.
+  window.addEventListener('error', (event) => {
+    const message =
+      event.message ||
+      (event.error instanceof Error ? event.error.message : '');
+    if (isReactLoopMessage(message)) {
+      report('window.onerror', message);
+    }
+  });
+
+  // Development builds log the companion warnings instead of throwing. Patching
+  // console.error is intrusive, so only do it when debugging is switched on.
+  if (!isConsoleEnabled()) {
+    return;
+  }
+
+  const originalError = console.error;
+  console.error = (...args: unknown[]) => {
+    const message = args.filter((arg) => typeof arg === 'string').join(' ');
+    if (isReactLoopMessage(message)) {
+      report('console.error', message);
+    }
+    originalError(...args);
+  };
+};

--- a/src/frontend/apps/conversations/src/utils/index.ts
+++ b/src/frontend/apps/conversations/src/utils/index.ts
@@ -1,4 +1,5 @@
 export * from './date';
+export * from './debugRenderLoop';
 export * from './userAgent';
 export * from './string';
 export * from './styleBuilder';


### PR DESCRIPTION
## Purpose

Chat responses were re-rendering the entire conversation view once per streamed chunk, roughly a hundred times per second on a long answer. This burned a large  amount of main thread work on every message, and is the suspected cause of the maximum update depth exceeded errors reported from production.

## Proposal

- [ ] Throttle streaming updates so the conversation view refreshes at a steady   rate rather than once per chunk. Measured on a long generated answer, renders   dropped by roughly five times and the burst now ends with the stream.
- [ ] Add a temporary render diagnostic that counts renders per second for the   permanently mounted components and records which values changed between   renders. On a runaway loop it attaches that tally to the error report, because   the React error itself never names the component responsible.
- [ ] Keep diagnostic console output behind a local storage flag so ordinary   users see nothing, and send only  component names and counts to error  reporting, never conversation content.
- [ ] Remove the diagnostic once the production errors are confirmed gone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Chat stream updates are now throttled to reduce excessive re-renders and improve responsiveness during streaming.
  - Improved detection and reporting of React render-loop errors, helping identify potential causes of update-depth failures.

- **Diagnostics**
  - Added enhanced runtime diagnostics for chat, authentication, configuration, layout, and navigation rendering behavior.
  - Added targeted logging for chat stream status and render activity to support troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->