### PR TITLE
🐛(back) align Albert RAG requests with the current API contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to
 
 - ⬆️(dependencies) update pypdf and next
 
+### Fixed
+
+- 🐛(back) align Albert RAG document upload and search with the current API
+
 ## [0.0.20] - 2026-07-23
 
 ### Added

--- a/src/backend/chat/agent_rag/document_rag_backends/albert_rag_backend.py
+++ b/src/backend/chat/agent_rag/document_rag_backends/albert_rag_backend.py
@@ -155,7 +155,7 @@ class AlbertRagBackend(BaseRagBackend):  # pylint: disable=too-many-instance-att
             headers=self._headers,
             files={
                 "file": (f"{name}.md", BytesIO(content.encode("utf-8")), MARKDOWN_MIME_TYPE),
-                "collection": (None, int(self.collection_id)),
+                "collection_id": (None, int(self.collection_id)),
                 "metadata": (None, json.dumps({"document_name": name})),  # undocumented API
             },
             timeout=settings.ALBERT_API_TIMEOUT,
@@ -191,7 +191,7 @@ class AlbertRagBackend(BaseRagBackend):  # pylint: disable=too-many-instance-att
                     "file": (f"{name}.md", BytesIO(content.encode("utf-8")), MARKDOWN_MIME_TYPE),
                 },
                 data={
-                    "collection": int(self.collection_id),
+                    "collection_id": int(self.collection_id),
                     "metadata": json.dumps({"document_name": name}),  # undocumented API
                 },
                 timeout=settings.ALBERT_API_TIMEOUT,
@@ -218,14 +218,14 @@ class AlbertRagBackend(BaseRagBackend):  # pylint: disable=too-many-instance-att
         When `document_id` is provided, it is preferred over `document_name`:
         Albert's `document_ids` filter is collection-aware and unambiguous,
         whereas `metadata_filters: document_name` matches by name across every
-        collection in `collections` (which fails when conversation and project
+        collection in `collection_ids` (which fails when conversation and project
         each carry a doc with the same filename).
         """
         payload: dict = {
-            "collections": self.get_all_collection_ids(),  # might raise RuntimeError
-            "prompt": query,
+            "collection_ids": self.get_all_collection_ids(),  # might raise RuntimeError
+            "query": query,
             "score_threshold": 0.6,
-            "k": results_count,
+            "limit": results_count,
         }
         if document_id:
             payload["document_ids"] = [int(document_id)]

--- a/src/backend/chat/tests/agent_rag/document_rag_backends/test_albert_rag_backend.py
+++ b/src/backend/chat/tests/agent_rag/document_rag_backends/test_albert_rag_backend.py
@@ -68,8 +68,8 @@ def test_search_without_filter_does_not_send_metadata_filters(albert_backend):
     assert len(responses.calls) == 1
     payload = json.loads(responses.calls[0].request.body)
     assert "metadata_filters" not in payload
-    assert payload["prompt"] == "any query"
-    assert payload["collections"] == [123]
+    assert payload["query"] == "any query"
+    assert payload["collection_ids"] == [123]
 
 
 @responses.activate

--- a/src/backend/chat/tests/tools/test_document_generic_search_rag.py
+++ b/src/backend/chat/tests/tools/test_document_generic_search_rag.py
@@ -280,15 +280,15 @@ def test_document_search_rag_tool_execution(settings):
 
     assert len(search_mock.calls) == 2
     assert json.loads(search_mock.calls[0].request.content) == {
-        "collections": [100, 101, 102],
-        "k": 4,
-        "prompt": "a",
+        "collection_ids": [100, 101, 102],
+        "limit": 4,
+        "query": "a",
         "score_threshold": 0.6,
     }
     assert json.loads(search_mock.calls[1].request.content) == {
-        "collections": [200],
-        "k": 4,
-        "prompt": "a",
+        "collection_ids": [200],
+        "limit": 4,
+        "query": "a",
         "score_threshold": 0.6,
     }
 
@@ -349,9 +349,9 @@ async def test_add_document_rag_search_tool_function_call(settings):
     assert result.metadata == {"sources": {"doc1.txt"}}
     assert len(search_mock.calls) == 1
     assert json.loads(search_mock.calls[0].request.content) == {
-        "collections": [100, 101, 102],
-        "k": 4,
-        "prompt": "Find information about French laws.",
+        "collection_ids": [100, 101, 102],
+        "limit": 4,
+        "query": "Find information about French laws.",
         "score_threshold": 0.6,
     }
 

--- a/src/backend/chat/tests/tools/test_document_search_rag.py
+++ b/src/backend/chat/tests/tools/test_document_search_rag.py
@@ -293,7 +293,7 @@ async def test_search_uses_only_conversation_collection_when_no_project(albert_s
     await _tool_function()(_run_context(conversation, user), query="q")
 
     payload = json.loads(route.calls[0].request.content)
-    assert payload["collections"] == [11]
+    assert payload["collection_ids"] == [11]
 
 
 @pytest.mark.asyncio
@@ -312,7 +312,7 @@ async def test_search_includes_project_collection_when_set(albert_settings):
 
     payload = json.loads(route.calls[0].request.content)
     # Both collection ids land in the search payload (Albert casts to int).
-    assert sorted(payload["collections"]) == [11, 22]
+    assert sorted(payload["collection_ids"]) == [11, 22]
 
 
 @pytest.mark.asyncio
@@ -330,7 +330,7 @@ async def test_search_skips_project_collection_when_project_has_none(albert_sett
     await _tool_function()(_run_context(conversation, user), query="q")
 
     payload = json.loads(route.calls[0].request.content)
-    assert payload["collections"] == [11]
+    assert payload["collection_ids"] == [11]
 
 
 @pytest.mark.asyncio
@@ -348,7 +348,7 @@ async def test_search_uses_only_project_collection_when_conversation_has_none(al
     await _tool_function()(_run_context(conversation, user), query="q")
 
     payload = json.loads(route.calls[0].request.content)
-    assert payload["collections"] == [22]
+    assert payload["collection_ids"] == [22]
 
 
 @sync_to_async
@@ -423,7 +423,7 @@ async def test_document_id_resolves_against_project_attachments(albert_settings)
 
     payload = json.loads(route.calls[0].request.content)
     assert payload["document_ids"] == [555]
-    assert sorted(payload["collections"]) == [11, 22]
+    assert sorted(payload["collection_ids"]) == [11, 22]
 
 
 @pytest.mark.asyncio

--- a/src/backend/chat/tests/views/chat/conversations/test_conversation_search_with_document_id.py
+++ b/src/backend/chat/tests/views/chat/conversations/test_conversation_search_with_document_id.py
@@ -143,4 +143,4 @@ def test_post_conversation_search_with_document_id_filters_albert_request(
     payload = json.loads(albert_search_route.calls[0].request.content)
     assert payload["document_ids"] == [202]
     assert "metadata_filters" not in payload
-    assert payload["prompt"] == "what is in the document?"
+    assert payload["query"] == "what is in the document?"

--- a/src/backend/chat/tests/views/chat/conversations/test_conversation_with_project_files.py
+++ b/src/backend/chat/tests/views/chat/conversations/test_conversation_with_project_files.py
@@ -123,8 +123,8 @@ def test_post_conversation_searches_project_collection(
 
     assert search_mock.call_count == 1
     payload = json.loads(search_mock.calls[0].request.content)
-    assert payload["collections"] == [22]
-    assert payload["prompt"] == "What does the project doc say?"
+    assert payload["collection_ids"] == [22]
+    assert payload["query"] == "What does the project doc say?"
 
 
 @respx.mock
@@ -172,7 +172,7 @@ def test_post_conversation_searches_both_collections_when_conversation_has_own(
     response_text = b"".join(response.streaming_content).decode("utf-8")
     assert search_mock.call_count > 0, f"search not called. response: {response_text!r}"
     payload = json.loads(search_mock.calls[0].request.content)
-    assert sorted(payload["collections"]) == [11, 22]
+    assert sorted(payload["collection_ids"]) == [11, 22]
 
 
 @pytest.fixture(name="inlineable_llm_config")
@@ -277,7 +277,7 @@ def test_post_conversation_inlines_convo_doc_while_project_doc_stays_rag_only(
     # Project doc still searched via the RAG tool against project collection.
     assert search_mock.call_count == 1
     payload = json.loads(search_mock.calls[0].request.content)
-    assert payload["collections"] == [22]
+    assert payload["collection_ids"] == [22]
 
     # Convo doc reached the system prompt as inlined full context.
     assert captured_instructions, "agent_model never received instructions"


### PR DESCRIPTION
## Purpose

Uploading documents to the Albert API fails with a 422 validation error, which
breaks RAG indexing for conversation and project attachments. The Albert API
renamed several request arguments on its document and search endpoints, and our
client still sends the previous names. The search endpoint is affected the same
way, so document search is broken too.

## Proposal

- [x] Update the document upload requests to match the current API contract
- [x] Update the document search payload to match the current API contract
- [x] Update the tests that assert the outgoing request payloads

https://github.com/orgs/suitenumerique/projects/13/views/3?filterQuery=&pane=issue&itemId=219719320&issue=suitenumerique%7Cconversations%7C636


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated Albert RAG document uploads and searches to work with the current API.
  - Improved collection filtering and search request handling while preserving existing result limits and relevance thresholds.

- **Tests**
  - Updated coverage to verify the revised document upload and search behavior across synchronous and asynchronous workflows.

- **Documentation**
  - Added an unreleased changelog entry describing the fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->