### PR TITLE
⚡️(back) add users to the Brevo follow-up list only at signup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,15 +10,19 @@ and this project adheres to
 
 ### Added
 
-- ✨(back) list conversation files on the admin conversation page
 - ✨(conversation) summarize messages
 
 ### Changed
 
-- ⬆️(dependencies) update pypdf and next
+- ⚡️(back) add users to the Brevo follow-up list only at signup
+- ✨(back) list conversation files on the admin conversation page
 - ⚡️(back) speed up the admin conversation list page
 
 ## [0.0.21] - 2026-07-28
+
+### Changed
+
+- ⬆️(dependencies) update pypdf and next
 
 ### Fixed
 

--- a/src/backend/core/authentication/backends.py
+++ b/src/backend/core/authentication/backends.py
@@ -121,11 +121,15 @@ class OIDCAuthenticationBackend(LaSuiteOIDCAuthenticationBackend):
             }
         )
 
-    def authenticate(self, request, **kwargs):
-        """Authenticate user and add they to Brevo list if activation not required."""
-        user = super().authenticate(request, **kwargs)
+    def post_get_or_create_user(self, user, claims, is_new_user):
+        """Add the user to the Brevo follow-up list if activation is not required.
 
-        if user and not settings.ACTIVATION_REQUIRED and settings.BREVO_FOLLOWUP_LIST_ID:
+        Only on signup: adding a contact already in the list is a no-op for Brevo, so
+        doing it on every login only costs an HTTP round-trip in the login path.
+
+        A failure is logged and never retried (as in every other Brevo call site).
+        The follow-up list is a marketing aid: recovering a missed contact is a
+        re-import, not something worth persisting per-user state for.
+        """
+        if is_new_user and not settings.ACTIVATION_REQUIRED and settings.BREVO_FOLLOWUP_LIST_ID:
             add_user_to_brevo_list([user.email], settings.BREVO_FOLLOWUP_LIST_ID)
-
-        return user

--- a/src/backend/core/brevo.py
+++ b/src/backend/core/brevo.py
@@ -9,6 +9,12 @@ import requests
 
 logger = logging.getLogger(__name__)
 
+# Brevo answers the "add to list" endpoint with a 400 when it has nothing to add.
+# The message is ambiguous on purpose ("already in list" OR "does not exist"), but we
+# always create the contact right before adding it, so only the first branch can apply:
+# this is an expected no-op, not a failure.
+BREVO_NOTHING_TO_ADD_MESSAGE = "Contact already in list and/or does not exist"
+
 
 def create_contact_in_brevo(email: str) -> bool:
     """
@@ -88,6 +94,10 @@ def add_user_to_brevo_list(emails: List[str], list_id: Optional[str]) -> None:
         return
 
     if response.status_code != 201:
+        if response.status_code == 400 and BREVO_NOTHING_TO_ADD_MESSAGE in response.text:
+            logger.info("Contacts %s already in Brevo list (%s)", emails, list_id)
+            return
+
         logger.error(
             "Error adding contacts to Brevo (%s) %s: (%s) %s",
             list_id,

--- a/src/backend/core/tests/authentication/test_backends.py
+++ b/src/backend/core/tests/authentication/test_backends.py
@@ -605,8 +605,7 @@ def test_authentication_user_added_to_brevo(monkeypatch, rf, settings):
     assert brevo_add_to_list.calls[0].request.headers["api-key"] == "test-api-key"
     assert json.loads(brevo_add_to_list.calls[0].request.body) == {"emails": [user.email]}
 
-    # Now test when activation is required: user should not be added to Brevo list
-    settings.ACTIVATION_REQUIRED = True
+    # A returning user is already in the list: Brevo must not be called again
     klass.authenticate(
         request,
         code="test-code",
@@ -616,6 +615,51 @@ def test_authentication_user_added_to_brevo(monkeypatch, rf, settings):
 
     assert len(brevo_create_contact.calls) == 1  # No new call made
     assert len(brevo_add_to_list.calls) == 1  # No new call made
+
+
+@responses.activate
+def test_post_get_or_create_user_only_syncs_new_users(settings):
+    """Only a freshly created user is pushed to the Brevo follow-up list."""
+
+    settings.BREVO_API_KEY = "test-api-key"
+    settings.BREVO_FOLLOWUP_LIST_ID = "follow-up-list-id"
+    settings.ACTIVATION_REQUIRED = False
+
+    responses.post("https://api.brevo.com/v3/contacts", status=201)
+    brevo_add_to_list = responses.post(
+        "https://api.brevo.com/v3/contacts/lists/follow-up-list-id/contacts/add",
+        status=201,
+    )
+
+    klass = OIDCAuthenticationBackend()
+    user = UserFactory()
+
+    klass.post_get_or_create_user(user, {}, is_new_user=False)
+    assert len(brevo_add_to_list.calls) == 0
+
+    klass.post_get_or_create_user(user, {}, is_new_user=True)
+    assert len(brevo_add_to_list.calls) == 1
+
+
+@responses.activate
+def test_post_get_or_create_user_not_synced_when_activation_required(settings):
+    """A new user is not pushed to the follow-up list while activation is required."""
+
+    settings.BREVO_API_KEY = "test-api-key"
+    settings.BREVO_FOLLOWUP_LIST_ID = "follow-up-list-id"
+    settings.ACTIVATION_REQUIRED = True
+
+    responses.post("https://api.brevo.com/v3/contacts", status=201)
+    brevo_add_to_list = responses.post(
+        "https://api.brevo.com/v3/contacts/lists/follow-up-list-id/contacts/add",
+        status=201,
+    )
+
+    klass = OIDCAuthenticationBackend()
+
+    klass.post_get_or_create_user(UserFactory(), {}, is_new_user=True)
+
+    assert len(brevo_add_to_list.calls) == 0
 
 
 @responses.activate

--- a/src/backend/core/tests/test_brevo.py
+++ b/src/backend/core/tests/test_brevo.py
@@ -1,0 +1,95 @@
+"""Tests for the Brevo API helpers."""
+
+import logging
+
+import responses
+
+from core.brevo import add_user_to_brevo_list
+
+ALREADY_IN_LIST_BODY = {
+    "code": "invalid_parameter",
+    "message": "Contact already in list and/or does not exist",
+}
+
+
+def brevo_logs(caplog):
+    """Return the levels of the records emitted by the Brevo helpers."""
+    return [record.levelno for record in caplog.records if record.name == "core.brevo"]
+
+
+@responses.activate
+def test_add_user_to_brevo_list_success(settings, caplog):
+    """Adding a new contact to a list is not logged."""
+    settings.BREVO_API_KEY = "test-api-key"
+
+    responses.post("https://api.brevo.com/v3/contacts", status=201)
+    add_to_list = responses.post(
+        "https://api.brevo.com/v3/contacts/lists/list-id/contacts/add",
+        status=201,
+    )
+
+    with caplog.at_level(logging.INFO, logger="core.brevo"):
+        add_user_to_brevo_list(["test@example.com"], "list-id")
+
+    assert len(add_to_list.calls) == 1
+    assert brevo_logs(caplog) == []
+
+
+@responses.activate
+def test_add_user_to_brevo_list_already_in_list_is_not_an_error(settings, caplog):
+    """
+    Brevo answers 400 when the contact is already in the list.
+
+    The contact is created right before, so it necessarily exists: this is an expected
+    no-op and must not be logged as an error, otherwise every returning user generates
+    noise in Sentry.
+    """
+    settings.BREVO_API_KEY = "test-api-key"
+
+    responses.post("https://api.brevo.com/v3/contacts", status=204)
+    responses.post(
+        "https://api.brevo.com/v3/contacts/lists/list-id/contacts/add",
+        json=ALREADY_IN_LIST_BODY,
+        status=400,
+    )
+
+    with caplog.at_level(logging.INFO, logger="core.brevo"):
+        add_user_to_brevo_list(["test@example.com"], "list-id")
+
+    assert brevo_logs(caplog) == [logging.INFO]
+
+
+@responses.activate
+def test_add_user_to_brevo_list_genuine_failure_still_logs_an_error(settings, caplog):
+    """Any other Brevo failure is still reported as an error."""
+    settings.BREVO_API_KEY = "test-api-key"
+
+    responses.post("https://api.brevo.com/v3/contacts", status=204)
+    responses.post(
+        "https://api.brevo.com/v3/contacts/lists/list-id/contacts/add",
+        json={"code": "unauthorized", "message": "Key not found"},
+        status=401,
+    )
+
+    with caplog.at_level(logging.INFO, logger="core.brevo"):
+        add_user_to_brevo_list(["test@example.com"], "list-id")
+
+    assert brevo_logs(caplog) == [logging.ERROR]
+
+
+@responses.activate
+def test_add_user_to_brevo_list_other_400_still_logs_an_error(settings, caplog):
+    """A 400 that is not the 'already in list' one is still an error."""
+    settings.BREVO_API_KEY = "test-api-key"
+
+    responses.post("https://api.brevo.com/v3/contacts", status=204)
+    responses.post(
+        "https://api.brevo.com/v3/contacts/lists/list-id/contacts/add",
+        json={"code": "invalid_parameter", "message": "Invalid list id"},
+        status=400,
+    )
+
+    with caplog.at_level(logging.INFO, logger="core.brevo"):
+        add_user_to_brevo_list(["test@example.com"], "list-id")
+
+    assert brevo_logs(caplog) == [logging.ERROR]


### PR DESCRIPTION
## Purpose

Every login pushed the authenticated user to the Brevo follow-up list again.
Brevo rejects a contact that is already in a list, and that rejection was recorded at error level, so each returning user generated a Sentry event.
The result was a large volume of noise that hid real Brevo failures, plus two blocking HTTP calls added to the login path for no benefit.

## Proposal

- [x] Treat the rejection returned when a contact is already in the list as an   expected outcome and log it at info level. The contact is created just      before being added, so this response cannot mean anything else. Genuine      failures such as bad credentials, server errors and timeouts are still      reported as errors and still reach Sentry.
- [x] Push a user to the follow-up list only when the account is created,      using the dedicathentication backend,instead      of on every authetill applies, and the      behaviour when activation is required is unchanged.               
 - [x] Add tests covering the downgraded case, the failures that must remain      errors, and the fact that only new accounts are pushed.


Two points worth putting in the PR conversation, since reviewers will ask:

- The log match is on the response text, so if Brevo reworded that message the errors would return rather than being silently swallowed. That is the safe direction to fail.
- Syncing only at signup means there is no retry if the call fails, and no catch-up for accounts created while activation was required that later become eligible. Accounts that have logged in since the feature shipped are already in the list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Brevo follow-up enrollment now occurs only for newly created accounts during signup when applicable.
  * Returning users are no longer re-added to the follow-up list during login.
  * Accounts already present in the follow-up list are handled as successful no-ops without errors.

* **Bug Fixes**
  * Genuine mailing-list failures and unrelated errors continue to be reported appropriately.

* **Documentation**
  * Updated the unreleased changelog with these behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->