### PR TITLE
⬆️(back) migrate to pydantic-ai 2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to
 
 - 💄(settings) move analytics settings to general
 
+## Changed
+
+- ⬆️(back) migrate to pydantic-ai 2.x
+
 ### Removed
 
 - 🔥(back) remove the unused Albert web search manager and its tool

--- a/src/backend/chat/agents/base.py
+++ b/src/backend/chat/agents/base.py
@@ -17,62 +17,6 @@ from chat.tools import get_pydantic_tools_by_name
 logger = logging.getLogger(__name__)
 
 
-def _patch_mistral_streaming_map_content():
-    """Monkey-patch pydantic_ai.models.mistral._map_content to handle citations.
-
-    The original _map_content raises exceptions when responses contain
-    citation/reference data, which happens anytime we use web search or
-    other RAG tools (https://docs.mistral.ai/capabilities/citations/).
-    We replace it with a safe version that extracts text and thinking
-    chunks while ignoring unsupported data types.
-
-    ⚠ WARNING: this is a monkey patch and may break if the original function
-    changes in future versions of pydantic_ai. Current version: v1.0.18
-    """
-    # pylint: disable=import-outside-toplevel,protected-access
-    import pydantic_ai.models.mistral as mistral_models  # noqa: PLC0415
-    from mistralai.client.models import TextChunk as MistralTextChunk  # noqa: PLC0415
-    from mistralai.client.models import ThinkChunk as MistralThinkChunk  # noqa: PLC0415
-    from mistralai.client.types.basemodel import Unset as MistralUnset  # noqa: PLC0415
-
-    if getattr(mistral_models, "__safe_map_patched__", False):
-        return
-
-    def _safe_map_content(content):
-        text: str | None = None
-        thinking: list[str] = []
-
-        if isinstance(content, MistralUnset) or not content:
-            return None, []
-
-        if isinstance(content, list):
-            for chunk in content:
-                if isinstance(chunk, MistralTextChunk):
-                    text = (text or "") + chunk.text
-                elif isinstance(chunk, MistralThinkChunk):
-                    for thought in chunk.thinking:
-                        if thought.type == "text":  # pragma: no branch
-                            thinking.append(thought.text)
-                else:
-                    logger.info(  # pragma: no cover
-                        "Other data types like (Image, Reference) are not yet supported,  got %s",
-                        type(chunk),
-                    )
-        elif isinstance(content, str):
-            text = content
-
-        # Note: Check len to handle potential mismatch between function calls and
-        # responses from the API.
-        # (`msg: not the same number of function class and responses`)
-        if text == "":  # pragma: no cover
-            text = None
-
-        return text, thinking
-
-    mistral_models._map_content = _safe_map_content  # noqa: SLF001
-    mistral_models.__safe_map_patched__ = True
-
-
 def _patch_openai_streaming_list_content():
     """Monkey-patch OpenAIStreamedResponse._map_text_delta to normalize list content.
 
@@ -85,7 +29,7 @@ def _patch_openai_streaming_list_content():
     We normalize list content to str before delegating to the original method.
 
     ⚠ WARNING: this is a monkey patch and may break if the original function
-    changes in future versions of pydantic_ai. Current version: v1.77.0
+    changes in future versions of pydantic_ai. Current version: v2.22.0
     """
     # pylint: disable=import-outside-toplevel,protected-access
     import pydantic_ai.models.openai as openai_models  # noqa: PLC0415
@@ -131,8 +75,6 @@ def prepare_custom_model(configuration: "chat.llm_configuration.LLModel"):
         case "mistral":
             import pydantic_ai.models.mistral as mistral_models  # noqa: PLC0415
             from pydantic_ai.providers.mistral import MistralProvider  # noqa: PLC0415
-
-            _patch_mistral_streaming_map_content()
 
             return mistral_models.MistralModel(
                 model_name=configuration.model_name,

--- a/src/backend/chat/clients/pydantic_ai.py
+++ b/src/backend/chat/clients/pydantic_ai.py
@@ -344,6 +344,12 @@ class AIAgentService:  # pylint: disable=too-many-instance-attributes
                     settings=InstrumentationSettings(
                         include_binary_content=self._store_analytics,
                         include_content=self._store_analytics,
+                        # Pin the OpenTelemetry schema pydantic-ai emitted before 2.x
+                        # (default is now version 5 with `gen_ai.aggregated_usage.*`
+                        # attribute names). Keeps existing Langfuse dashboards working;
+                        # moving to the newer schema is a separate, deliberate change.
+                        version=2,
+                        use_aggregated_usage_attribute_names=False,
                     )
                 )
             )
@@ -624,9 +630,9 @@ class AIAgentService:  # pylint: disable=too-many-instance-attributes
 
         model = self.conversation_agent.model
         if isinstance(model, Model):
-            model_supports_thinking = model.profile.supports_thinking
+            model_supports_thinking = model.profile.get("supports_thinking")
         else:
-            model_supports_thinking = infer_model_profile(model).supports_thinking
+            model_supports_thinking = infer_model_profile(model).get("supports_thinking")
         if not model_supports_thinking:
             history = _strip_thinking_parts(history)
 

--- a/src/backend/chat/mcp_servers.py
+++ b/src/backend/chat/mcp_servers.py
@@ -1,6 +1,6 @@
 """MCP servers configuration: will be replaced by models."""
 
-from pydantic_ai.mcp import MCPServerStreamableHTTP
+from pydantic_ai.mcp import MCPToolset
 
 MCP_SERVERS = {
     "mcpServers": {
@@ -15,6 +15,6 @@ MCP_SERVERS = {
 def get_mcp_servers():
     """Retrieve MCP servers configuration."""
     return [
-        MCPServerStreamableHTTP(**server_config)
+        MCPToolset(server_config["url"], headers=server_config.get("headers"))
         for _name, server_config in MCP_SERVERS["mcpServers"].items()
     ]

--- a/src/backend/chat/tests/agents/test_albert_models.py
+++ b/src/backend/chat/tests/agents/test_albert_models.py
@@ -123,7 +123,7 @@ def test_albert_chat_model_uses_albert_streamed_response_cls():
     """AlbertOpenAIChatModel._streamed_response_cls returns AlbertOpenAIStreamedResponse."""
     model = AlbertOpenAIChatModel(
         model_name="test-model",
-        profile="test-profile",
+        profile=None,
         provider=AlbertOpenAIProvider(
             base_url="https://test-albert-api.com",
             api_key="test-api-key",

--- a/src/backend/chat/tests/agents/test_base_agent.py
+++ b/src/backend/chat/tests/agents/test_base_agent.py
@@ -5,8 +5,9 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
+from mistralai.client.models import ReferenceChunk, TextChunk, ThinkChunk
 from pydantic_ai.capabilities import Hooks
-from pydantic_ai.models.mistral import MistralModel
+from pydantic_ai.models.mistral import MistralModel, _map_content
 from pydantic_ai.models.openai import OpenAIChatModel, OpenAIStreamedResponse
 
 from chat.agents.base import BaseAgent
@@ -117,9 +118,24 @@ def test_custom_model_mistral(settings):
 
     assert isinstance(agent._model, MistralModel)
 
-    import pydantic_ai.models.mistral as mistral_models  # noqa: PLC0415 # pylint: disable=import-outside-toplevel
 
-    assert mistral_models.__safe_map_patched__ is True  # pylint: disable=protected-access
+def test_mistral_map_content_handles_citation_chunks():
+    """pydantic-ai tolerates the reference chunks Mistral emits alongside citations.
+
+    Mistral returns citation/reference data whenever web search or a RAG tool is used
+    (https://docs.mistral.ai/capabilities/citations/). Older pydantic-ai versions raised
+    on those chunks, which we worked around with a monkey patch on `_map_content`;
+    upstream handles them since 2.x, so the patch is gone and this test guards the
+    behavior we depend on.
+    """
+    content = [
+        TextChunk(text="Hello "),
+        ReferenceChunk(reference_ids=[1, 2]),
+        ThinkChunk(thinking=[TextChunk(text="pondering")]),
+        TextChunk(text="world"),
+    ]
+
+    assert _map_content(content) == ("Hello world", ["pondering"])
 
 
 def test_custom_model_mistral_neutral_sampling_defaults(settings):
@@ -183,9 +199,9 @@ def test_custom_model_openai_profile(settings):
     agent = BaseAgent(model_hrid="openai-model")
 
     assert isinstance(agent._model, OpenAIChatModel)
-    assert agent._model.profile.supports_tools is True
-    assert agent._model.profile.supports_json_schema_output is False
-    assert agent._model.profile.supports_json_object_output is True
+    assert agent._model.profile["supports_tools"] is True
+    assert agent._model.profile["supports_json_schema_output"] is False
+    assert agent._model.profile["supports_json_object_output"] is True
 
 
 def test_custom_model_albert(settings):

--- a/src/backend/chat/tests/clients/pydantic_ai/fixtures/pydantic_ai_v1_message_history.json
+++ b/src/backend/chat/tests/clients/pydantic_ai/fixtures/pydantic_ai_v1_message_history.json
@@ -1,0 +1,473 @@
+{
+  "text_only": [
+    {
+      "parts": [
+        {
+          "content": "Bonjour",
+          "timestamp": "2026-03-14T09:15:00Z",
+          "part_kind": "user-prompt"
+        }
+      ],
+      "timestamp": "2026-03-14T09:15:00Z",
+      "instructions": "You are a helpful assistant.",
+      "kind": "request",
+      "run_id": null,
+      "conversation_id": null,
+      "metadata": null
+    },
+    {
+      "parts": [
+        {
+          "content": "Bonjour !",
+          "id": null,
+          "provider_name": null,
+          "provider_details": null,
+          "part_kind": "text"
+        }
+      ],
+      "usage": {
+        "input_tokens": 120,
+        "cache_write_tokens": 0,
+        "cache_read_tokens": 0,
+        "output_tokens": 42,
+        "input_audio_tokens": 0,
+        "cache_audio_read_tokens": 0,
+        "output_audio_tokens": 0,
+        "details": {
+          "co2_impact_factor_20": 730
+        }
+      },
+      "model_name": "albert-large",
+      "timestamp": "2026-03-14T09:15:00Z",
+      "kind": "response",
+      "provider_name": "albert_openai",
+      "provider_url": null,
+      "provider_details": null,
+      "provider_response_id": "chatcmpl-1",
+      "finish_reason": "stop",
+      "run_id": null,
+      "conversation_id": null,
+      "metadata": null,
+      "state": "complete"
+    }
+  ],
+  "tool_call_with_sources_metadata": [
+    {
+      "parts": [
+        {
+          "content": "Que dit le rapport ?",
+          "timestamp": "2026-03-14T09:15:00Z",
+          "part_kind": "user-prompt"
+        }
+      ],
+      "timestamp": "2026-03-14T09:15:00Z",
+      "instructions": "You are a helpful assistant.",
+      "kind": "request",
+      "run_id": null,
+      "conversation_id": null,
+      "metadata": null
+    },
+    {
+      "parts": [
+        {
+          "tool_name": "document_search_rag",
+          "args": {
+            "query": "rapport"
+          },
+          "tool_call_id": "call_abc123",
+          "tool_kind": null,
+          "id": null,
+          "provider_name": null,
+          "provider_details": null,
+          "part_kind": "tool-call"
+        }
+      ],
+      "usage": {
+        "input_tokens": 120,
+        "cache_write_tokens": 0,
+        "cache_read_tokens": 0,
+        "output_tokens": 42,
+        "input_audio_tokens": 0,
+        "cache_audio_read_tokens": 0,
+        "output_audio_tokens": 0,
+        "details": {
+          "co2_impact_factor_20": 730
+        }
+      },
+      "model_name": "albert-large",
+      "timestamp": "2026-03-14T09:15:00Z",
+      "kind": "response",
+      "provider_name": "albert_openai",
+      "provider_url": null,
+      "provider_details": null,
+      "provider_response_id": null,
+      "finish_reason": "tool_call",
+      "run_id": null,
+      "conversation_id": null,
+      "metadata": null,
+      "state": "complete"
+    },
+    {
+      "parts": [
+        {
+          "tool_name": "document_search_rag",
+          "content": "Extrait du rapport.",
+          "tool_call_id": "call_abc123",
+          "tool_kind": null,
+          "metadata": {
+            "sources": [
+              {
+                "document_name": "rapport.md",
+                "chunk_id": 7,
+                "score": 0.82
+              }
+            ]
+          },
+          "timestamp": "2026-03-14T09:15:00Z",
+          "outcome": "success",
+          "part_kind": "tool-return"
+        }
+      ],
+      "timestamp": "2026-03-14T09:15:00Z",
+      "instructions": "You are a helpful assistant.",
+      "kind": "request",
+      "run_id": null,
+      "conversation_id": null,
+      "metadata": null
+    },
+    {
+      "parts": [
+        {
+          "content": "Le rapport dit ceci.",
+          "id": null,
+          "provider_name": null,
+          "provider_details": null,
+          "part_kind": "text"
+        }
+      ],
+      "usage": {
+        "input_tokens": 120,
+        "cache_write_tokens": 0,
+        "cache_read_tokens": 0,
+        "output_tokens": 42,
+        "input_audio_tokens": 0,
+        "cache_audio_read_tokens": 0,
+        "output_audio_tokens": 0,
+        "details": {
+          "co2_impact_factor_20": 730
+        }
+      },
+      "model_name": "albert-large",
+      "timestamp": "2026-03-14T09:15:00Z",
+      "kind": "response",
+      "provider_name": null,
+      "provider_url": null,
+      "provider_details": null,
+      "provider_response_id": null,
+      "finish_reason": "stop",
+      "run_id": null,
+      "conversation_id": null,
+      "metadata": null,
+      "state": "complete"
+    }
+  ],
+  "thinking": [
+    {
+      "parts": [
+        {
+          "content": "Explique.",
+          "timestamp": "2026-03-14T09:15:00Z",
+          "part_kind": "user-prompt"
+        }
+      ],
+      "timestamp": "2026-03-14T09:15:00Z",
+      "instructions": "You are a helpful assistant.",
+      "kind": "request",
+      "run_id": null,
+      "conversation_id": null,
+      "metadata": null
+    },
+    {
+      "parts": [
+        {
+          "content": "L'utilisateur veut une explication.",
+          "id": null,
+          "signature": null,
+          "provider_name": null,
+          "provider_details": null,
+          "part_kind": "thinking"
+        },
+        {
+          "content": "Voici l'explication.",
+          "id": null,
+          "provider_name": null,
+          "provider_details": null,
+          "part_kind": "text"
+        }
+      ],
+      "usage": {
+        "input_tokens": 120,
+        "cache_write_tokens": 0,
+        "cache_read_tokens": 0,
+        "output_tokens": 42,
+        "input_audio_tokens": 0,
+        "cache_audio_read_tokens": 0,
+        "output_audio_tokens": 0,
+        "details": {
+          "co2_impact_factor_20": 730
+        }
+      },
+      "model_name": "mistral-medium-2508",
+      "timestamp": "2026-03-14T09:15:00Z",
+      "kind": "response",
+      "provider_name": "mistral",
+      "provider_url": null,
+      "provider_details": null,
+      "provider_response_id": null,
+      "finish_reason": "stop",
+      "run_id": null,
+      "conversation_id": null,
+      "metadata": null,
+      "state": "complete"
+    }
+  ],
+  "media_content": [
+    {
+      "parts": [
+        {
+          "content": [
+            "Que vois-tu ?",
+            {
+              "url": "https://s3.example/img.png?sig=x",
+              "force_download": false,
+              "vendor_metadata": null,
+              "kind": "image-url",
+              "media_type": "image/png",
+              "identifier": "photo.png"
+            },
+            {
+              "url": "https://s3.example/doc.pdf?sig=y",
+              "force_download": false,
+              "vendor_metadata": null,
+              "kind": "document-url",
+              "media_type": "application/pdf",
+              "identifier": "doc.pdf"
+            },
+            {
+              "data": "iVBORw0KGgo=",
+              "media_type": "image/png",
+              "vendor_metadata": null,
+              "kind": "binary",
+              "identifier": "4caece"
+            }
+          ],
+          "timestamp": "2026-03-14T09:15:00Z",
+          "part_kind": "user-prompt"
+        }
+      ],
+      "timestamp": "2026-03-14T09:15:00Z",
+      "instructions": "You are a helpful assistant.",
+      "kind": "request",
+      "run_id": null,
+      "conversation_id": null,
+      "metadata": null
+    },
+    {
+      "parts": [
+        {
+          "content": "Une image et un document.",
+          "id": null,
+          "provider_name": null,
+          "provider_details": null,
+          "part_kind": "text"
+        }
+      ],
+      "usage": {
+        "input_tokens": 120,
+        "cache_write_tokens": 0,
+        "cache_read_tokens": 0,
+        "output_tokens": 42,
+        "input_audio_tokens": 0,
+        "cache_audio_read_tokens": 0,
+        "output_audio_tokens": 0,
+        "details": {
+          "co2_impact_factor_20": 730
+        }
+      },
+      "model_name": "albert-large",
+      "timestamp": "2026-03-14T09:15:00Z",
+      "kind": "response",
+      "provider_name": null,
+      "provider_url": null,
+      "provider_details": null,
+      "provider_response_id": null,
+      "finish_reason": "stop",
+      "run_id": null,
+      "conversation_id": null,
+      "metadata": null,
+      "state": "complete"
+    }
+  ],
+  "retry_prompt": [
+    {
+      "parts": [
+        {
+          "content": "Meteo ?",
+          "timestamp": "2026-03-14T09:15:00Z",
+          "part_kind": "user-prompt"
+        }
+      ],
+      "timestamp": "2026-03-14T09:15:00Z",
+      "instructions": "You are a helpful assistant.",
+      "kind": "request",
+      "run_id": null,
+      "conversation_id": null,
+      "metadata": null
+    },
+    {
+      "parts": [
+        {
+          "tool_name": "get_weather",
+          "args": "{bad json",
+          "tool_call_id": "call_r1",
+          "tool_kind": null,
+          "id": null,
+          "provider_name": null,
+          "provider_details": null,
+          "part_kind": "tool-call"
+        }
+      ],
+      "usage": {
+        "input_tokens": 120,
+        "cache_write_tokens": 0,
+        "cache_read_tokens": 0,
+        "output_tokens": 42,
+        "input_audio_tokens": 0,
+        "cache_audio_read_tokens": 0,
+        "output_audio_tokens": 0,
+        "details": {
+          "co2_impact_factor_20": 730
+        }
+      },
+      "model_name": "albert-large",
+      "timestamp": "2026-03-14T09:15:00Z",
+      "kind": "response",
+      "provider_name": null,
+      "provider_url": null,
+      "provider_details": null,
+      "provider_response_id": null,
+      "finish_reason": "tool_call",
+      "run_id": null,
+      "conversation_id": null,
+      "metadata": null,
+      "state": "complete"
+    },
+    {
+      "parts": [
+        {
+          "content": "Invalid JSON in tool arguments.",
+          "tool_name": "get_weather",
+          "tool_call_id": "call_r1",
+          "timestamp": "2026-03-14T09:15:00Z",
+          "part_kind": "retry-prompt"
+        }
+      ],
+      "timestamp": "2026-03-14T09:15:00Z",
+      "instructions": "You are a helpful assistant.",
+      "kind": "request",
+      "run_id": null,
+      "conversation_id": null,
+      "metadata": null
+    },
+    {
+      "parts": [
+        {
+          "content": "Je ne peux pas repondre.",
+          "id": null,
+          "provider_name": null,
+          "provider_details": null,
+          "part_kind": "text"
+        }
+      ],
+      "usage": {
+        "input_tokens": 120,
+        "cache_write_tokens": 0,
+        "cache_read_tokens": 0,
+        "output_tokens": 42,
+        "input_audio_tokens": 0,
+        "cache_audio_read_tokens": 0,
+        "output_audio_tokens": 0,
+        "details": {
+          "co2_impact_factor_20": 730
+        }
+      },
+      "model_name": "albert-large",
+      "timestamp": "2026-03-14T09:15:00Z",
+      "kind": "response",
+      "provider_name": null,
+      "provider_url": null,
+      "provider_details": null,
+      "provider_response_id": null,
+      "finish_reason": "stop",
+      "run_id": null,
+      "conversation_id": null,
+      "metadata": null,
+      "state": "complete"
+    }
+  ],
+  "synthetic_ok_response": [
+    {
+      "parts": [
+        {
+          "tool_name": "web_search",
+          "content": "resultats",
+          "tool_call_id": "call_ok",
+          "tool_kind": null,
+          "metadata": null,
+          "timestamp": "2026-03-14T09:15:00Z",
+          "outcome": "success",
+          "part_kind": "tool-return"
+        }
+      ],
+      "timestamp": "2026-03-14T09:15:00Z",
+      "instructions": "You are a helpful assistant.",
+      "kind": "request",
+      "run_id": null,
+      "conversation_id": null,
+      "metadata": null
+    },
+    {
+      "parts": [
+        {
+          "content": "ok",
+          "id": null,
+          "provider_name": null,
+          "provider_details": null,
+          "part_kind": "text"
+        }
+      ],
+      "usage": {
+        "input_tokens": 0,
+        "cache_write_tokens": 0,
+        "cache_read_tokens": 0,
+        "output_tokens": 0,
+        "input_audio_tokens": 0,
+        "cache_audio_read_tokens": 0,
+        "output_audio_tokens": 0,
+        "details": {}
+      },
+      "model_name": null,
+      "timestamp": "2026-03-14T09:15:00Z",
+      "kind": "response",
+      "provider_name": null,
+      "provider_url": null,
+      "provider_details": null,
+      "provider_response_id": null,
+      "finish_reason": null,
+      "run_id": null,
+      "conversation_id": null,
+      "metadata": null,
+      "state": "complete"
+    }
+  ]
+}

--- a/src/backend/chat/tests/clients/pydantic_ai/test_message_history_v1_compatibility.py
+++ b/src/backend/chat/tests/clients/pydantic_ai/test_message_history_v1_compatibility.py
@@ -1,0 +1,157 @@
+"""Conversations persisted by pydantic-ai 1.x must still load under 2.x.
+
+`ChatConversation.pydantic_messages` stores `ModelMessagesTypeAdapter.dump_json()`
+output. Rows written before the 2.x upgrade stay in the database untouched, so every
+shape we ever wrote has to keep validating. The fixture was produced by running
+`ModelMessagesTypeAdapter.dump_json()` under pydantic-ai 1.107.1 (the last 1.x
+release) - do not regenerate it with the current version, that would defeat its
+purpose.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+from pydantic_ai import Agent
+from pydantic_ai.messages import (
+    BinaryContent,
+    DocumentUrl,
+    ImageUrl,
+    ModelMessagesTypeAdapter,
+    ModelRequest,
+    ModelResponse,
+    RetryPromptPart,
+    TextPart,
+    ThinkingPart,
+    ToolCallPart,
+    ToolReturnPart,
+)
+from pydantic_ai.models.function import FunctionModel
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+V1_HISTORY = json.loads((FIXTURES_DIR / "pydantic_ai_v1_message_history.json").read_text())
+
+# A run validates the history it is handed and drops leading messages it cannot repair.
+# Only `synthetic_ok_response` is affected: the fixture opens on a tool return whose
+# matching tool call is not part of the slice, so that first message never reaches the
+# model. Everything after it is forwarded untouched.
+LEADING_MESSAGES_REPAIRED_AWAY = {"synthetic_ok_response": 1}
+
+
+def _load(case_name):
+    return ModelMessagesTypeAdapter.validate_python(V1_HISTORY[case_name])
+
+
+@pytest.mark.parametrize("case_name", list(V1_HISTORY))
+def test_v1_history_validates(case_name):
+    """Every persisted 1.x shape still validates under the current version."""
+    messages = _load(case_name)
+
+    assert messages
+    assert all(isinstance(message, (ModelRequest, ModelResponse)) for message in messages)
+
+
+@pytest.mark.parametrize("case_name", list(V1_HISTORY))
+def test_v1_history_round_trips(case_name):
+    """Re-dumping a loaded 1.x history and re-validating it is stable."""
+    messages = _load(case_name)
+
+    redumped = json.loads(ModelMessagesTypeAdapter.dump_json(messages))
+
+    assert ModelMessagesTypeAdapter.validate_python(redumped) == messages
+
+
+def test_v1_text_only_content_survives():
+    """A plain exchange keeps its prompt, answer, instructions and usage details."""
+    request, response = _load("text_only")
+
+    assert request.instructions == "You are a helpful assistant."
+    assert request.parts[0].content == "Bonjour"
+    assert response.parts[0].content == "Bonjour !"
+    assert response.model_name == "albert-large"
+    # The CO2 accounting reads this back out of the persisted usage details.
+    assert response.usage.details["co2_impact_factor_20"] == 730
+
+
+def test_v1_tool_return_metadata_survives():
+    """The RAG `sources` metadata attached to tool returns is preserved."""
+    messages = _load("tool_call_with_sources_metadata")
+
+    tool_call = messages[1].parts[0]
+    tool_return = messages[2].parts[0]
+
+    assert isinstance(tool_call, ToolCallPart)
+    assert tool_call.tool_name == "document_search_rag"
+    assert isinstance(tool_return, ToolReturnPart)
+    assert tool_return.tool_call_id == tool_call.tool_call_id
+    assert tool_return.metadata == {
+        "sources": [{"document_name": "rapport.md", "chunk_id": 7, "score": 0.82}]
+    }
+
+
+def test_v1_thinking_part_survives():
+    """ThinkingPart is still a distinct part kind, not folded into the text."""
+    _, response = _load("thinking")
+
+    assert isinstance(response.parts[0], ThinkingPart)
+    assert response.parts[0].content == "L'utilisateur veut une explication."
+    assert isinstance(response.parts[1], TextPart)
+
+
+def test_v1_media_content_survives():
+    """Image/document URLs and binary content keep their part types."""
+    request, _ = _load("media_content")
+
+    content = request.parts[0].content
+
+    assert content[0] == "Que vois-tu ?"
+    assert isinstance(content[1], ImageUrl)
+    assert content[1].identifier == "photo.png"
+    assert isinstance(content[2], DocumentUrl)
+    assert isinstance(content[3], BinaryContent)
+    assert content[3].media_type == "image/png"
+
+
+def test_v1_retry_prompt_survives():
+    """A persisted retry keeps the tool name and call id it retries."""
+    messages = _load("retry_prompt")
+
+    retry = messages[2].parts[0]
+
+    assert isinstance(retry, RetryPromptPart)
+    assert retry.tool_name == "get_weather"
+    assert retry.tool_call_id == "call_r1"
+
+
+def test_v1_synthetic_ok_response_survives():
+    """The synthetic "ok" response inserted after a tool return still loads.
+
+    See `AIAgentService._run_agent`: it appends a bare `ModelResponse` so Mistral
+    never sees a user role directly after a tool role.
+    """
+    _, response = _load("synthetic_ok_response")
+
+    assert response.parts[0].content == "ok"
+    assert response.model_name is None
+
+
+@pytest.mark.parametrize("case_name", list(V1_HISTORY))
+@pytest.mark.asyncio
+async def test_v1_history_is_usable_as_message_history(case_name):
+    """A run forwards a 1.x-persisted history to the model, then the new prompt."""
+    history = _load(case_name)
+    sent = []
+
+    def _reply(messages, _info):
+        sent.append(messages)
+        return ModelResponse(parts=[TextPart(content="Suite.")])
+
+    agent = Agent(FunctionModel(_reply), output_type=str)
+
+    result = await agent.run("Et ensuite ?", message_history=history)
+
+    assert result.output == "Suite."
+    # Asserted outside `_reply` so a failure surfaces as itself, not as a model error.
+    forwarded = sent[0]
+    assert forwarded[-1].parts[-1].content == "Et ensuite ?"
+    assert forwarded[:-1] == history[LEADING_MESSAGES_REPAIRED_AWAY.get(case_name, 0) :]

--- a/src/backend/chat/tests/views/chat/conversations/test_conversation.py
+++ b/src/backend/chat/tests/views/chat/conversations/test_conversation.py
@@ -97,6 +97,7 @@ def _make_pydantic_request(  # pylint: disable=too-many-arguments,too-many-posit
         "metadata": None,
         "parts": [{"content": content, "part_kind": "user-prompt", "timestamp": timestamp}],
         "run_id": run_id,
+        "state": "complete",
         "timestamp": timestamp,
     }
 
@@ -630,6 +631,7 @@ def test_post_conversation_tool_call(api_client, mock_openai_stream_tool, settin
                 }
             ],
             "run_id": _run_id,
+            "state": "complete",
             "timestamp": FROZEN_TIMESTAMP,
         },
         _make_pydantic_text_response(
@@ -792,6 +794,7 @@ def test_post_conversation_tool_call_fails(api_client, mock_openai_stream_tool):
                 }
             ],
             "run_id": _run_id,
+            "state": "complete",
             "timestamp": FROZEN_TIMESTAMP,
         },
         _make_pydantic_text_response(

--- a/src/backend/chat/tests/views/chat/conversations/test_conversation_with_document_upload.py
+++ b/src/backend/chat/tests/views/chat/conversations/test_conversation_with_document_upload.py
@@ -517,6 +517,7 @@ def test_post_conversation_with_document_upload(
             },
         ],
         "run_id": _run_id,
+        "state": "complete",
         "timestamp": timezone_now,
     }
     assert chat_conversation.pydantic_messages[1] == {
@@ -581,6 +582,7 @@ def test_post_conversation_with_document_upload(
             }
         ],
         "run_id": _run_id,
+        "state": "complete",
         "timestamp": timezone_now,
     }
     assert chat_conversation.pydantic_messages[3] == {
@@ -855,6 +857,7 @@ def test_post_conversation_with_document_upload_summarize(  # pylint: disable=to
             },
         ],
         "run_id": _run_id,
+        "state": "complete",
         "timestamp": timezone_now,
     }
     assert chat_conversation.pydantic_messages[1] == {
@@ -913,6 +916,7 @@ def test_post_conversation_with_document_upload_summarize(  # pylint: disable=to
             }
         ],
         "run_id": _run_id,
+        "state": "complete",
         "timestamp": timezone_now,
     }
     assert chat_conversation.pydantic_messages[3] == {
@@ -1118,6 +1122,7 @@ def test_post_conversation_with_odt_document_upload(
             },
         ],
         "run_id": _run_id,
+        "state": "complete",
         "timestamp": timezone_now,
     }
     assert chat_conversation.pydantic_messages[1] == {
@@ -1182,6 +1187,7 @@ def test_post_conversation_with_odt_document_upload(
             }
         ],
         "run_id": _run_id,
+        "state": "complete",
         "timestamp": timezone_now,
     }
     assert chat_conversation.pydantic_messages[3] == {

--- a/src/backend/chat/tests/views/chat/conversations/test_conversation_with_document_url.py
+++ b/src/backend/chat/tests/views/chat/conversations/test_conversation_with_document_url.py
@@ -305,6 +305,7 @@ def test_post_conversation_with_local_pdf_document_url(
                 },
             ],
             "run_id": _run_id,
+            "state": "complete",
             "timestamp": timestamp,
         },
         {
@@ -805,6 +806,7 @@ def test_post_conversation_with_local_document_url_in_history(  # pylint: disabl
                 }
             ],
             "run_id": _run_id,
+            "state": "complete",
             "timestamp": "2025-10-18T20:48:20.286204Z",
         },
         {
@@ -1025,6 +1027,7 @@ def test_post_conversation_with_local_not_pdf_document_url(
                 },
             ],
             "run_id": _run_id,
+            "state": "complete",
             "timestamp": timestamp,
         },
         {

--- a/src/backend/chat/tests/views/chat/conversations/test_conversation_with_history.py
+++ b/src/backend/chat/tests/views/chat/conversations/test_conversation_with_history.py
@@ -1501,6 +1501,7 @@ def test_post_conversation_with_existing_tool_history(
             }
         ],
         "run_id": _run_id,
+        "state": "complete",
         "timestamp": "2025-07-25T10:36:35.297675Z",
     }
 
@@ -1567,6 +1568,7 @@ def test_post_conversation_with_existing_tool_history(
             }
         ],
         "run_id": _run_id,
+        "state": "complete",
         "timestamp": "2025-07-25T10:36:35.297675Z",
     }
 

--- a/src/backend/chat/tests/views/chat/conversations/test_conversation_with_image_url.py
+++ b/src/backend/chat/tests/views/chat/conversations/test_conversation_with_image_url.py
@@ -211,6 +211,7 @@ def test_post_conversation_with_local_image_url(
                 },
             ],
             "run_id": _run_id,
+            "state": "complete",
             "timestamp": "2025-10-18T20:48:20.286204Z",
         },
         {
@@ -794,6 +795,7 @@ def test_post_conversation_with_local_image_url_in_history(
                 }
             ],
             "run_id": _run_id,
+            "state": "complete",
             "timestamp": "2025-10-18T20:48:20.286204Z",
         },
         {

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -52,7 +52,7 @@ dependencies = [
     "nested-multipart-parser==1.6.0",
     "posthog==7.18.0",
     "pydantic==2.13.4",
-    "pydantic-ai-slim[openai,mistral,mcp]==1.107.1",
+    "pydantic-ai-slim[openai,mistral,mcp]==2.22.0",
     "psycopg[binary]==3.3.4",
     "PyJWT==2.13.0",
     "python-magic==0.4.27",

--- a/src/backend/uv.lock
+++ b/src/backend/uv.lock
@@ -613,7 +613,7 @@ requires-dist = [
     { name = "posthog", specifier = "==7.18.0" },
     { name = "psycopg", extras = ["binary"], specifier = "==3.3.4" },
     { name = "pydantic", specifier = "==2.13.4" },
-    { name = "pydantic-ai-slim", extras = ["openai", "mistral", "mcp"], specifier = "==1.107.1" },
+    { name = "pydantic-ai-slim", extras = ["openai", "mistral", "mcp"], specifier = "==2.22.0" },
     { name = "pyfakefs", marker = "extra == 'dev'", specifier = "==6.2.0" },
     { name = "pyjwt", specifier = "==2.13.0" },
     { name = "pylint", marker = "extra == 'dev'", specifier = "==4.0.5" },
@@ -1169,15 +1169,15 @@ wheels = [
 
 [[package]]
 name = "genai-prices"
-version = "0.0.66"
+version = "0.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx2" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0e/7c/c50fc8d18b283e9b56ff625d45dbe9577c676e1d16636c1011967182d813/genai_prices-0.0.66.tar.gz", hash = "sha256:f087dfe56da28a4c3933dcf846cf2b7111ba733cef674c0cbc66de80212bcd6b", size = 71130, upload-time = "2026-06-09T21:51:14.561Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/83/9b/85e646305a90a2da18f1edf055498668391e71f9849d3e1754d66559a311/genai_prices-0.1.1.tar.gz", hash = "sha256:54a2237691e0aaefb057d10a0c3c20160accc9fc09521c64c03fcdb7a4a69f68", size = 91182, upload-time = "2026-08-01T09:02:49.552Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5c/87/1a36166f91906e47f430f6d4150ec6bfc0001032a363e49fc389021c0609/genai_prices-0.0.66-py3-none-any.whl", hash = "sha256:86b83f107c1cf04bb449a120cd8d4439ceb6843660d9128cde560eb511686d7b", size = 73745, upload-time = "2026-06-09T21:51:13.523Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/5e/cfe36dff790ffad6aeff8a069b6f36743987ac17053579035ee0a67635dd/genai_prices-0.1.1-py3-none-any.whl", hash = "sha256:de2e3d8ea3ca1d0d292025995c598da447a74e94f22cd3342df46941aeb5416b", size = 95300, upload-time = "2026-08-01T09:02:48.308Z" },
 ]
 
 [[package]]
@@ -2007,7 +2007,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "2.41.1"
+version = "2.52.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -2019,9 +2019,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/40/36/4c926a91554483977608951360c18c2e911592785eb87a6437813f6123f7/openai-2.41.1.tar.gz", hash = "sha256:23d617a0432457ad844973bee8f540be9da90894f7c5686852d2d365da058f57", size = 783584, upload-time = "2026-06-10T16:10:37.667Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/5a/c45fa035cd72c70ebe67c6e079e3adf871492382634f69e3dff62c43597d/openai-2.52.0.tar.gz", hash = "sha256:7c736d592f81471ce1f734838390983c4d8c8aecff23dcd36e600a58e5032d9c", size = 1098876, upload-time = "2026-07-31T15:13:03.228Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/74/925d7b3892927e9804aaf58d374a45dc28e4420ff90e992272b77286343e/openai-2.41.1-py3-none-any.whl", hash = "sha256:a939565f350cb7443cb843b801b88c716ac8024b492fb94ca269d5f6b1bbefd6", size = 1353380, upload-time = "2026-06-10T16:10:35.756Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/ac/ceb40c995df49533ad4dcff6c37f0d85cf14446a212363fc9d2f927e60b4/openai-2.52.0-py3-none-any.whl", hash = "sha256:f97e231d9a8fa69ab55897df1080f02d99913fb0a30e3ee56ea16a1eb6c2d434", size = 1659569, upload-time = "2026-07-31T15:13:01.145Z" },
 ]
 
 [[package]]
@@ -2437,9 +2437,10 @@ email = [
 
 [[package]]
 name = "pydantic-ai-slim"
-version = "1.107.1"
+version = "2.22.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "anyio" },
     { name = "genai-prices" },
     { name = "griffelib" },
     { name = "httpx" },
@@ -2448,9 +2449,9 @@ dependencies = [
     { name = "pydantic-graph" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d5/a5/e4a515a5eaa2cef746356e69e706e6cfa4575d1065652b226104db693877/pydantic_ai_slim-1.107.1.tar.gz", hash = "sha256:c4c86aae407e62ea720e8911627219f34f60668dc4c35fdead5ad026efdd00fc", size = 780236, upload-time = "2026-07-11T03:22:16.105Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9b/aa/af0c3f1a0a34003a1f024ca7c50694e28b03d4cd4faa4b2026ff44979579/pydantic_ai_slim-2.22.0.tar.gz", hash = "sha256:00a09316951ba4587348a5233a5d0b395ed7cf97ee3991666841bd55e41ddc85", size = 939122, upload-time = "2026-08-01T02:38:22.531Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/92/26/a9f8761ce3789a67c930d2d93742a2c10382a6d1fe99fba0aa67430c7786/pydantic_ai_slim-1.107.1-py3-none-any.whl", hash = "sha256:8eade1c9a1bbdf19c06b4fba9424980b0f446ef2756d2559cc819971ec35cc8f", size = 964387, upload-time = "2026-07-11T03:22:09.178Z" },
+    { url = "https://files.pythonhosted.org/packages/78/0f/a9e71b83a74bb5773e31c5ccd1ad8d753fb99554be7842c9f1da18168772/pydantic_ai_slim-2.22.0-py3-none-any.whl", hash = "sha256:156e772b1a4a568c65d779ae1e1012dd58bc255e5355067981a490e9acd7cb45", size = 1130161, upload-time = "2026-08-01T02:38:15.741Z" },
 ]
 
 [package.optional-dependencies]
@@ -2508,17 +2509,18 @@ wheels = [
 
 [[package]]
 name = "pydantic-graph"
-version = "1.107.1"
+version = "2.22.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "anyio" },
     { name = "httpx" },
     { name = "logfire-api" },
     { name = "pydantic" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/d0/b10720e987f433d63af6cba046554f84cf20aee696209a90af6d6769b385/pydantic_graph-1.107.1.tar.gz", hash = "sha256:c83b255a67b1e64e460749a61195309738f42895ad5b93da2140d6bff76b14f1", size = 62563, upload-time = "2026-07-11T03:22:18.404Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/dd/a8/6c0a831e111f017339f2463b03eba6ab3cdf86c789f9d5ff279031df8204/pydantic_graph-2.22.0.tar.gz", hash = "sha256:1350e63b1af5cea421aba7ed996af5d853b5b1da3c92b7cf7439d558bda4c8dd", size = 45180, upload-time = "2026-08-01T02:38:24.632Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/dd/f0/27537e7c7df3dcca6b8ad2bff9a35c6a4f1b4e76d21cd6c6ab931d7ef0bc/pydantic_graph-1.107.1-py3-none-any.whl", hash = "sha256:b5893249b7fc1dc2e60dfc40a08ccd4cc0d1dd6e05aeeee2a50392c5663eac60", size = 80106, upload-time = "2026-07-11T03:22:12.083Z" },
+    { url = "https://files.pythonhosted.org/packages/97/38/3e51ef169df4d7c3fb6196b51064f3f39b2a9ee9b99edeb412333273825a/pydantic_graph-2.22.0-py3-none-any.whl", hash = "sha256:26663839b426114834e3b9047ae6620c2a0a88cdefe67e63a3074d378ff9ed8a", size = 52661, upload-time = "2026-08-01T02:38:18.621Z" },
 ]
 
 [[package]]


### PR DESCRIPTION


## Purpose

The AI layer was pinned to the 1.x series of the pydantic-ai library, which no longer receives fixes. This upgrades it to the 2.x series so the project stays on a supported release line and can pick up later fixes without a larger jump.

This is a migration only: no new capability offered by 2.x is adopted here, so that any behaviour change is attributable to the upgrade itself rather than to a feature we turned on at the same time.

The main risk is stored data. Conversation histories are persisted in the exact format the library serializes, so histories written before the upgrade have to keep loading afterwards. 
That is covered by a dedicated regression suite built from output produced by the last 1.x release, which shows those rows still validate, round-trip and can be replayed as history.


## Proposal

- [ ] upgrade the AI library to the 2.x series and adapt the call sites whose API changed
- [ ] replace the removed MCP server class with its supported equivalent
- [ ] keep telemetry on the attribute naming scheme emitted before the upgrade, so existing
      observability dashboards are unaffected; moving to the newer scheme is a separate change
- [ ] remove a workaround for Mistral citation handling that is fixed upstream, and guard the
      upstream behaviour we depend on with a test
- [ ] add a regression suite proving conversation histories written by the previous version
      still load, so no data migration is needed
- [ ] update the tests asserting on serialized messages to match the new payload shape

https://github.com/orgs/suitenumerique/projects/13/views/3?filterQuery=&pane=issue&itemId=222525714&issue=suitenumerique%7Cconversations%7C644

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for restoring and using conversation histories created with earlier versions, including tool calls, media, thinking content, and retry messages.
  * Conversation records now clearly indicate when messages and tool interactions are complete.
  * Improved MCP server connectivity using configured URLs and optional headers.

* **Bug Fixes**
  * Improved streaming behavior and handling of model profiles.
  * Preserved Langfuse tracing compatibility and message metadata during conversations.

* **Documentation**
  * Added release notes for the platform migration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->