### PR TITLE
♻️(back) replace requests with httpx as the single HTTP client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to
 - 🏗️(front) rename frontend build var from the NEXT_PUBLIC_ prefix to VITE_
 - 💬(back) rewrite the default agent instructions and tool descriptions
 - 💄(front) correct icon Docs button
+- ♻️(back) use httpx as the single HTTP client for outbound calls
 
 ### Removed
 

--- a/src/backend/activation_codes/tests/test_models.py
+++ b/src/backend/activation_codes/tests/test_models.py
@@ -7,8 +7,9 @@ from django.core.exceptions import ValidationError
 from django.db.models import ProtectedError
 from django.utils import timezone
 
+import httpx
 import pytest
-import responses
+import respx
 
 from core.factories import UserFactory
 
@@ -279,7 +280,7 @@ def test_user_activation_ordering():
     assert activations == [activation2, activation1]
 
 
-@responses.activate
+@respx.mock
 @pytest.mark.django_db(transaction=True)
 def test_activation_code_use_success_notify_brevo(settings):
     """Test successfully using an activation code and notify Brevo."""
@@ -287,22 +288,17 @@ def test_activation_code_use_success_notify_brevo(settings):
     settings.BREVO_WAITING_LIST_ID = "test_waiting_list_id"
     settings.BREVO_FOLLOWUP_LIST_ID = "test_followup_list_name"
 
-    brevo_remove_mock = responses.post(
-        "https://api.brevo.com/v3/contacts/lists/test_waiting_list_id/contacts/remove",
-        json={"message": "Contacts added successfully"},
-        status=201,
+    brevo_remove_mock = respx.post(
+        "https://api.brevo.com/v3/contacts/lists/test_waiting_list_id/contacts/remove"
+    ).mock(return_value=httpx.Response(201, json={"message": "Contacts added successfully"}))
+
+    brevo_create_contact = respx.post("https://api.brevo.com/v3/contacts").mock(
+        return_value=httpx.Response(200)
     )
 
-    brevo_create_contact = responses.post(
-        "https://api.brevo.com/v3/contacts",
-        status=200,
-    )
-
-    brevo_add_mock = responses.post(
-        "https://api.brevo.com/v3/contacts/lists/test_followup_list_name/contacts/add",
-        json={"message": "Contacts added successfully"},
-        status=201,
-    )
+    brevo_add_mock = respx.post(
+        "https://api.brevo.com/v3/contacts/lists/test_followup_list_name/contacts/add"
+    ).mock(return_value=httpx.Response(201, json={"message": "Contacts added successfully"}))
 
     user = UserFactory()
     registration = UserRegistrationRequest.objects.create(user=user)
@@ -314,15 +310,15 @@ def test_activation_code_use_success_notify_brevo(settings):
 
     assert len(brevo_remove_mock.calls) == 1
     assert brevo_remove_mock.calls[0].request.headers["api-key"] == "test_brevo_api_key"
-    assert json.loads(brevo_remove_mock.calls[0].request.body) == {"emails": [user.email]}
+    assert json.loads(brevo_remove_mock.calls[0].request.content) == {"emails": [user.email]}
 
     assert len(brevo_create_contact.calls) == 1
     assert brevo_create_contact.calls[0].request.headers["api-key"] == "test_brevo_api_key"
-    assert json.loads(brevo_create_contact.calls[0].request.body) == {
+    assert json.loads(brevo_create_contact.calls[0].request.content) == {
         "email": user.email,
         "updateEnabled": True,
     }
 
     assert len(brevo_add_mock.calls) == 1
     assert brevo_add_mock.calls[0].request.headers["api-key"] == "test_brevo_api_key"
-    assert json.loads(brevo_add_mock.calls[0].request.body) == {"emails": [user.email]}
+    assert json.loads(brevo_add_mock.calls[0].request.content) == {"emails": [user.email]}

--- a/src/backend/activation_codes/tests/test_viewsets.py
+++ b/src/backend/activation_codes/tests/test_viewsets.py
@@ -6,8 +6,9 @@ from unittest.mock import patch
 
 from django.utils import timezone
 
+import httpx
 import pytest
-import responses
+import respx
 from rest_framework import status
 
 from core.factories import UserFactory
@@ -324,23 +325,20 @@ def test_validate_code_registered_user(api_client):
     assert _registration.user_activation.activation_code == activation_code
 
 
-@responses.activate
+@respx.mock
 @pytest.mark.django_db
 def test_register_email_success_brevo(api_client, settings):
     """Test successfully registering an email and notify Brevo."""
     settings.BREVO_API_KEY = "test_brevo_api_key"
     settings.BREVO_WAITING_LIST_ID = "test_waiting_list_id"
 
-    brevo_create_contact = responses.post(
-        "https://api.brevo.com/v3/contacts",
-        status=200,
+    brevo_create_contact = respx.post("https://api.brevo.com/v3/contacts").mock(
+        return_value=httpx.Response(200)
     )
 
-    brevo_mock = responses.post(
-        "https://api.brevo.com/v3/contacts/lists/test_waiting_list_id/contacts/add",
-        json={"message": "Contacts added successfully"},
-        status=201,
-    )
+    brevo_mock = respx.post(
+        "https://api.brevo.com/v3/contacts/lists/test_waiting_list_id/contacts/add"
+    ).mock(return_value=httpx.Response(201, json={"message": "Contacts added successfully"}))
 
     user = UserFactory()
     api_client.force_authenticate(user=user)
@@ -357,14 +355,14 @@ def test_register_email_success_brevo(api_client, settings):
 
     assert len(brevo_create_contact.calls) == 1
     assert brevo_create_contact.calls[0].request.headers["api-key"] == "test_brevo_api_key"
-    assert json.loads(brevo_create_contact.calls[0].request.body) == {
+    assert json.loads(brevo_create_contact.calls[0].request.content) == {
         "email": user.email,
         "updateEnabled": True,
     }
 
     assert len(brevo_mock.calls) == 1
     assert brevo_mock.calls[0].request.headers["api-key"] == "test_brevo_api_key"
-    assert json.loads(brevo_mock.calls[0].request.body) == {"emails": [user.email]}
+    assert json.loads(brevo_mock.calls[0].request.content) == {"emails": [user.email]}
 
     # Register again to test idempotency
     response = api_client.post(
@@ -377,22 +375,20 @@ def test_register_email_success_brevo(api_client, settings):
     assert len(brevo_mock.calls) == 1  # No new call made
 
 
-@responses.activate
+@respx.mock
 @pytest.mark.django_db
 def test_register_email_success_brevo_fails(api_client, settings):
     """Test successfully registering an email, even if Brevo fails."""
     settings.BREVO_API_KEY = "test_brevo_api_key"
     settings.BREVO_WAITING_LIST_ID = "test_waiting_list_id"
 
-    _brevo_create_contact = responses.post(
-        "https://api.brevo.com/v3/contacts",
-        status=200,
+    _brevo_create_contact = respx.post("https://api.brevo.com/v3/contacts").mock(
+        return_value=httpx.Response(200)
     )
 
-    brevo_mock = responses.post(
-        "https://api.brevo.com/v3/contacts/lists/test_waiting_list_id/contacts/add",
-        status=400,
-    )
+    brevo_mock = respx.post(
+        "https://api.brevo.com/v3/contacts/lists/test_waiting_list_id/contacts/add"
+    ).mock(return_value=httpx.Response(400))
 
     user = UserFactory()
     api_client.force_authenticate(user=user)

--- a/src/backend/chat/agent_rag/document_converter/parser.py
+++ b/src/backend/chat/agent_rag/document_converter/parser.py
@@ -9,7 +9,7 @@ from urllib.parse import urljoin
 
 from django.conf import settings
 
-import requests
+import httpx
 from pypdf import PdfReader, PdfWriter
 
 from chat.agent_rag.document_converter.guards import guard_pdf_page_count, guard_zip_bomb
@@ -74,7 +74,7 @@ class AlbertParser(OdtParserMixin, BaseParser):
     def parse_pdf_document(self, name: str, content_type: str, content: bytes) -> str:
         """Parse PDF document using Albert API."""
         file_data = base64.standard_b64encode(content).decode("utf-8")
-        response = requests.post(
+        response = httpx.post(
             self.endpoint,
             headers={
                 "Authorization": f"Bearer {settings.ALBERT_API_KEY}",
@@ -232,7 +232,7 @@ class AdaptivePdfParser(AdaptivePdfParserMixin, OdtParserMixin, BaseParser):
         last_exception = None
         for attempt in range(self.max_retries):
             try:
-                response = requests.post(
+                response = httpx.post(
                     self.endpoint,
                     headers=self.headers,
                     json=payload,
@@ -243,7 +243,7 @@ class AdaptivePdfParser(AdaptivePdfParserMixin, OdtParserMixin, BaseParser):
                 pages = response.json().get("pages", [])
                 return [page.get("markdown", "") for page in pages]
 
-            except (requests.Timeout, requests.RequestException) as e:
+            except httpx.HTTPError as e:
                 last_exception = e
                 if attempt < self.max_retries - 1:
                     logger.warning(

--- a/src/backend/chat/agent_rag/document_rag_backends/albert_rag_backend.py
+++ b/src/backend/chat/agent_rag/document_rag_backends/albert_rag_backend.py
@@ -10,7 +10,6 @@ from django.conf import settings
 from django.utils.module_loading import import_string
 
 import httpx
-import requests
 
 from chat.agent_rag.albert_api_constants import Searches
 from chat.agent_rag.constants import RAGWebResult, RAGWebResults, RAGWebUsage
@@ -69,7 +68,7 @@ class AlbertRagBackend(BaseRagBackend):  # pylint: disable=too-many-instance-att
         Create a temporary collection for the search operation.
         This method should handle the logic to create or retrieve an existing collection.
         """
-        response = requests.post(
+        response = httpx.post(
             self._collections_endpoint,
             headers=self._headers,
             json={
@@ -108,7 +107,7 @@ class AlbertRagBackend(BaseRagBackend):  # pylint: disable=too-many-instance-att
         """
         Delete the current collection
         """
-        response = requests.delete(
+        response = httpx.delete(
             urljoin(f"{self._collections_endpoint}/", self.collection_id),
             headers=self._headers,
             timeout=settings.ALBERT_API_TIMEOUT,
@@ -117,7 +116,7 @@ class AlbertRagBackend(BaseRagBackend):  # pylint: disable=too-many-instance-att
 
     def delete_document(self, document_id: str, **kwargs) -> None:
         """Remove a single document from Albert via DELETE /v1/documents/{id}."""
-        response = requests.delete(
+        response = httpx.delete(
             urljoin(f"{self._documents_endpoint}/", str(document_id)),
             headers=self._headers,
             timeout=settings.ALBERT_API_TIMEOUT,
@@ -150,13 +149,15 @@ class AlbertRagBackend(BaseRagBackend):  # pylint: disable=too-many-instance-att
             Optional[str]: The Albert document id, used later as a `document_ids`
             filter on `/v1/search` and as the target of `delete_document`.
         """
-        response = requests.post(
+        response = httpx.post(
             urljoin(self._base_url, self._documents_endpoint),
             headers=self._headers,
             files={
                 "file": (f"{name}.md", BytesIO(content.encode("utf-8")), MARKDOWN_MIME_TYPE),
-                "collection_id": (None, int(self.collection_id)),
-                "metadata": (None, json.dumps({"document_name": name})),  # undocumented API
+            },
+            data={
+                "collection_id": int(self.collection_id),
+                "metadata": json.dumps({"document_name": name}),  # undocumented API
             },
             timeout=settings.ALBERT_API_TIMEOUT,
         )
@@ -276,7 +277,7 @@ class AlbertRagBackend(BaseRagBackend):  # pylint: disable=too-many-instance-att
     ) -> RAGWebResults:
         """Perform a search using the Albert API based on the provided query."""
         payload = self._build_search_payload(query, results_count, document_name, document_id)
-        response = requests.post(
+        response = httpx.post(
             urljoin(self._base_url, self._search_endpoint),
             headers=self._headers,
             json=payload,

--- a/src/backend/chat/agent_rag/indexing.py
+++ b/src/backend/chat/agent_rag/indexing.py
@@ -28,7 +28,7 @@ from django.core.files.storage import default_storage
 from django.db import transaction
 from django.utils.module_loading import import_string
 
-import requests
+import httpx
 
 from core.file_upload.enums import AttachmentStatus
 
@@ -108,9 +108,9 @@ def _is_transient_rag_error(exc: Exception) -> bool:
     the chunks were already stored - retrying would duplicate them - so both skip
     the retry and fall through to the FAILED path.
     """
-    if isinstance(exc, (requests.ConnectionError, requests.Timeout)):
+    if isinstance(exc, (httpx.NetworkError, httpx.TimeoutException)):
         return True
-    if isinstance(exc, requests.HTTPError) and exc.response is not None:
+    if isinstance(exc, httpx.HTTPStatusError) and exc.response is not None:
         return exc.response.status_code == 429 or exc.response.status_code >= 500
     return False
 
@@ -128,7 +128,7 @@ def _albert_error_detail(exc: Exception) -> str:
     limit, validation message, model unavailable). Surface the status code and a
     truncated body when available; otherwise fall back to `str(exc)`.
     """
-    if isinstance(exc, requests.HTTPError) and exc.response is not None:
+    if isinstance(exc, httpx.HTTPStatusError) and exc.response is not None:
         body = (exc.response.text or "").strip()
         detail = f"HTTP {exc.response.status_code}"
         return f"{detail}: {body[:_ERROR_DETAIL_MAX_CHARS]}" if body else detail

--- a/src/backend/chat/clients/error_classification.py
+++ b/src/backend/chat/clients/error_classification.py
@@ -12,7 +12,6 @@ test suite a single place to lock down the status-code → kind mapping.
 """
 
 import httpx
-import requests
 
 # LLM-side error codes (also used by the frontend ChatErrorType union).
 MODEL_RATE_LIMITED = "model_rate_limited"
@@ -60,13 +59,13 @@ def resolve_llm_error_code(status_code: int | None) -> str | None:
 def resolve_rag_error_code(exc: Exception) -> str:
     """Map a RAG pipeline exception to a typed error code for the frontend.
 
-    Handles both ``requests`` (sync Albert calls) and ``httpx`` (async Albert
-    calls) exception hierarchies, plus the local-parser / missing-id paths that
-    raise non-HTTP exceptions.
+    Handles the ``httpx`` exception hierarchy shared by the sync and async
+    Albert calls, plus the local-parser / missing-id paths that raise non-HTTP
+    exceptions.
     """
     status_code = getattr(getattr(exc, "response", None), "status_code", None)
     if status_code is None:
-        if isinstance(exc, (requests.ConnectionError, requests.Timeout, httpx.RequestError)):
+        if isinstance(exc, httpx.RequestError):
             return RAG_CONNECTION_ERROR
         return RAG_ERROR
     if status_code in RAG_STATUS_TO_ERROR_CODE:

--- a/src/backend/chat/docs_client.py
+++ b/src/backend/chat/docs_client.py
@@ -7,7 +7,7 @@ from urllib.parse import urljoin
 from django.conf import settings
 from django.core.exceptions import PermissionDenied
 
-import requests
+import httpx
 
 
 class DocsClient:
@@ -40,7 +40,7 @@ class DocsClient:
         # Strip path separators and control characters so the title is a safe filename.
         safe_title = re.sub(r"[/\\\x00-\x1f]", " ", title).strip() or "document"
         file.name = f"{safe_title}.md"
-        response = requests.post(
+        response = httpx.post(
             urljoin(self.api_url, "documents/"),
             headers={"Authorization": f"Bearer {access_token}"},
             files={"file": (file.name, file, "text/markdown")},

--- a/src/backend/chat/management/commands/deindex_inactive_collections.py
+++ b/src/backend/chat/management/commands/deindex_inactive_collections.py
@@ -10,7 +10,7 @@ from django.core.management.base import BaseCommand
 from django.utils import timezone
 from django.utils.module_loading import import_string
 
-import requests
+import httpx
 
 from chat.enums import CollectionIndexState
 from chat.models import ChatConversation, ChatConversationAttachment
@@ -45,7 +45,7 @@ def _deindex_one(conv, *, backend_cls, threshold):
     try:
         backend_cls(collection_id=conv.collection_id).delete_collection()
     except Exception as exc:  # pylint: disable=broad-except
-        if isinstance(exc, requests.HTTPError):
+        if isinstance(exc, httpx.HTTPStatusError):
             response = exc.response
             if response is not None and response.status_code == 404:
                 # Collection already gone on the backend — the earlier

--- a/src/backend/chat/management/commands/fetch_model_health.py
+++ b/src/backend/chat/management/commands/fetch_model_health.py
@@ -6,7 +6,7 @@ from django.conf import settings
 from django.core.cache import cache
 from django.core.management.base import BaseCommand, CommandError
 
-import requests
+import httpx
 
 from core.models import ModelHealthSettings
 
@@ -87,9 +87,9 @@ class Command(BaseCommand):
             headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
 
             try:
-                response = requests.get(url, headers=headers, timeout=timeout)
+                response = httpx.get(url, headers=headers, timeout=timeout)
                 response.raise_for_status()
-            except requests.RequestException as exc:
+            except httpx.HTTPError as exc:
                 logger.exception("Failed to fetch model health for provider %s: %s", provider, exc)
                 raise CommandError(str(exc)) from exc
 

--- a/src/backend/chat/tests/agent_rag/document_converter/test_adaptive_pdf_parser.py
+++ b/src/backend/chat/tests/agent_rag/document_converter/test_adaptive_pdf_parser.py
@@ -4,8 +4,8 @@ from io import BytesIO
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import httpx
 import pytest
-import requests
 from pypdf import PdfReader
 
 from chat.agent_rag.document_converter.odt import OdtParsingError
@@ -148,7 +148,7 @@ def test_ocr_page_batch_success(text_pdf_1_page):
     """Should return markdown content on successful OCR."""
     parser = AdaptivePdfParser()
 
-    with patch("chat.agent_rag.document_converter.parser.requests.post") as mock_post:
+    with patch("chat.agent_rag.document_converter.parser.httpx.post") as mock_post:
         mock_post.return_value.json.return_value = {
             "pages": [
                 {"markdown": "# Page 1 content"},
@@ -166,10 +166,10 @@ def test_ocr_page_batch_retry_on_timeout(text_pdf_1_page):
     """Should retry on timeout with static delay."""
     parser = AdaptivePdfParser()
 
-    with patch("chat.agent_rag.document_converter.parser.requests.post") as mock_post:
+    with patch("chat.agent_rag.document_converter.parser.httpx.post") as mock_post:
         with patch("chat.agent_rag.document_converter.parser.time.sleep") as mock_sleep:
             mock_post.side_effect = [
-                requests.Timeout("Connection timed out"),
+                httpx.TimeoutException("Connection timed out"),
                 MagicMock(
                     json=MagicMock(return_value={"pages": [{"markdown": "# Content"}]}),
                     raise_for_status=MagicMock(),
@@ -187,11 +187,11 @@ def test_ocr_page_batch_fails_after_max_retries(text_pdf_1_page):
     """Should raise exception after max retries exceeded."""
     parser = AdaptivePdfParser()
 
-    with patch("chat.agent_rag.document_converter.parser.requests.post") as mock_post:
+    with patch("chat.agent_rag.document_converter.parser.httpx.post") as mock_post:
         with patch("chat.agent_rag.document_converter.parser.time.sleep"):
-            mock_post.side_effect = requests.Timeout("Connection timed out")
+            mock_post.side_effect = httpx.TimeoutException("Connection timed out")
 
-            with pytest.raises(requests.Timeout):
+            with pytest.raises(httpx.TimeoutException):
                 parser.ocr_page_batch("test.pdf", text_pdf_1_page, 0, 1)
 
             assert mock_post.call_count == OCR_MAX_RETRIES
@@ -201,11 +201,11 @@ def test_ocr_page_batch_retry_on_request_exception(text_pdf_1_page):
     """Should retry on general request exceptions."""
     parser = AdaptivePdfParser()
 
-    with patch("chat.agent_rag.document_converter.parser.requests.post") as mock_post:
+    with patch("chat.agent_rag.document_converter.parser.httpx.post") as mock_post:
         with patch("chat.agent_rag.document_converter.parser.time.sleep"):
             mock_post.side_effect = [
-                requests.RequestException("Network error"),
-                requests.RequestException("Network error"),
+                httpx.HTTPError("Network error"),
+                httpx.HTTPError("Network error"),
                 MagicMock(
                     json=MagicMock(return_value={"pages": [{"markdown": "# Content"}]}),
                     raise_for_status=MagicMock(),
@@ -222,7 +222,7 @@ def test_parse_pdf_with_ocr_single_batch(text_pdf_10_pages):
     """Should process PDF in single batch when pages <= batch size."""
     parser = AdaptivePdfParser()
 
-    with patch("chat.agent_rag.document_converter.parser.requests.post") as mock_post:
+    with patch("chat.agent_rag.document_converter.parser.httpx.post") as mock_post:
         mock_post.return_value.json.return_value = {
             "pages": [{"markdown": f"Page {i}"} for i in range(1, 11)]
         }
@@ -240,7 +240,7 @@ def test_parse_pdf_with_ocr_multiple_batches(text_pdf_10_pages, settings):
     settings.OCR_BATCH_PAGES = 4  # Force multiple batches
     parser = AdaptivePdfParser()
 
-    with patch("chat.agent_rag.document_converter.parser.requests.post") as mock_post:
+    with patch("chat.agent_rag.document_converter.parser.httpx.post") as mock_post:
         mock_post.return_value.json.side_effect = [
             {"pages": [{"markdown": f"Page {i}"} for i in range(1, 5)]},
             {"pages": [{"markdown": f"Page {i}"} for i in range(5, 9)]},
@@ -264,17 +264,17 @@ def test_parse_pdf_with_ocr_partial_failure(text_pdf_10_pages, settings):
     success_response.json.return_value = {"pages": [{"markdown": f"Page {i}"} for i in range(1, 5)]}
     success_response.raise_for_status = MagicMock()
 
-    with patch("chat.agent_rag.document_converter.parser.requests.post") as mock_post:
+    with patch("chat.agent_rag.document_converter.parser.httpx.post") as mock_post:
         with patch("chat.agent_rag.document_converter.parser.time.sleep"):
             # First batch succeeds, then all retries fail for remaining batches
             mock_post.side_effect = [
                 success_response,
-                requests.Timeout("OCR failed"),
-                requests.Timeout("OCR failed"),
-                requests.Timeout("OCR failed"),
-                requests.Timeout("OCR failed"),
-                requests.Timeout("OCR failed"),
-                requests.Timeout("OCR failed"),
+                httpx.TimeoutException("OCR failed"),
+                httpx.TimeoutException("OCR failed"),
+                httpx.TimeoutException("OCR failed"),
+                httpx.TimeoutException("OCR failed"),
+                httpx.TimeoutException("OCR failed"),
+                httpx.TimeoutException("OCR failed"),
             ]
 
             result = parser.parse_pdf_document_with_ocr("test.pdf", text_pdf_10_pages)

--- a/src/backend/chat/tests/agent_rag/document_converter/test_parser.py
+++ b/src/backend/chat/tests/agent_rag/document_converter/test_parser.py
@@ -5,8 +5,9 @@ import json
 from pathlib import Path
 from unittest.mock import patch
 
+import httpx
 import pytest
-import responses
+import respx
 
 from chat.agent_rag.document_converter.parser import (
     AlbertParser,
@@ -44,21 +45,21 @@ def test_base_parser_cannot_be_instantiated():
         BaseParser()  # pylint: disable=abstract-class-instantiated
 
 
-@responses.activate
+@respx.mock
 def test_albert_parser_pdf_success(settings):
     """AlbertParser should call Albert's OCR endpoint and join page markdown."""
     settings.OCR_MODEL = "test-ocr-model"
-    responses.add(
-        responses.POST,
-        ALBERT_PARSE_ENDPOINT,
-        json={
-            "pages": [
-                {"markdown": "# Page 1"},
-                {"markdown": "## Page 2"},
-                {"markdown": "End."},
-            ]
-        },
-        status=200,
+    respx.post(ALBERT_PARSE_ENDPOINT).mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "pages": [
+                    {"markdown": "# Page 1"},
+                    {"markdown": "## Page 2"},
+                    {"markdown": "End."},
+                ]
+            },
+        )
     )
 
     parser = AlbertParser()
@@ -66,11 +67,11 @@ def test_albert_parser_pdf_success(settings):
     result = parser.parse_document("report.pdf", "application/pdf", b"pdf-bytes")
 
     assert result == "# Page 1\n\n## Page 2\n\nEnd."
-    assert len(responses.calls) == 1
-    assert responses.calls[0].request.url == ALBERT_PARSE_ENDPOINT
+    assert len(respx.calls) == 1
+    assert respx.calls[0].request.url == ALBERT_PARSE_ENDPOINT
 
     # The OCR endpoint takes the document inline as a base64 data URL, not a file upload.
-    payload = json.loads(responses.calls[0].request.body)
+    payload = json.loads(respx.calls[0].request.content)
     encoded = base64.standard_b64encode(b"pdf-bytes").decode("utf-8")
     assert payload == {
         "document": {
@@ -82,14 +83,11 @@ def test_albert_parser_pdf_success(settings):
     }
 
 
-@responses.activate
+@respx.mock
 def test_albert_parser_pdf_http_error():
     """AlbertParser should propagate HTTP errors from Albert API."""
-    responses.add(
-        responses.POST,
-        ALBERT_PARSE_ENDPOINT,
-        json={"error": "Internal Server Error"},
-        status=500,
+    respx.post(ALBERT_PARSE_ENDPOINT).mock(
+        return_value=httpx.Response(500, json={"error": "Internal Server Error"})
     )
 
     parser = AlbertParser()

--- a/src/backend/chat/tests/agent_rag/document_rag_backends/test_albert_rag_backend.py
+++ b/src/backend/chat/tests/agent_rag/document_rag_backends/test_albert_rag_backend.py
@@ -12,8 +12,8 @@ and exercises the real backend class. Verifies:
 
 import json
 
+import httpx
 import pytest
-import responses
 import respx
 from httpx import Response
 
@@ -54,36 +54,32 @@ def _one_result_albert_response():
 # Sync search
 
 
-@responses.activate
+@respx.mock
 def test_search_without_filter_does_not_send_metadata_filters(albert_backend):
     """No document_name -> request body has no metadata_filters key."""
-    responses.post(
-        url=SEARCH_URL,
-        json=_one_result_albert_response(),
-        status=200,
+    respx.post(SEARCH_URL).mock(
+        return_value=httpx.Response(200, json=_one_result_albert_response())
     )
 
     albert_backend.search("any query")
 
-    assert len(responses.calls) == 1
-    payload = json.loads(responses.calls[0].request.body)
+    assert len(respx.calls) == 1
+    payload = json.loads(respx.calls[0].request.content)
     assert "metadata_filters" not in payload
     assert payload["query"] == "any query"
     assert payload["collection_ids"] == [123]
 
 
-@responses.activate
+@respx.mock
 def test_search_with_filter_sends_metadata_filters(albert_backend):
     """document_name -> request body carries the metadata_filters dict."""
-    responses.post(
-        url=SEARCH_URL,
-        json=_one_result_albert_response(),
-        status=200,
+    respx.post(SEARCH_URL).mock(
+        return_value=httpx.Response(200, json=_one_result_albert_response())
     )
 
     albert_backend.search("any query", document_name="report.pdf")
 
-    payload = json.loads(responses.calls[0].request.body)
+    payload = json.loads(respx.calls[0].request.content)
     assert payload["metadata_filters"] == {
         "key": "document_name",
         "value": "report.pdf",
@@ -91,53 +87,43 @@ def test_search_with_filter_sends_metadata_filters(albert_backend):
     }
 
 
-@responses.activate
+@respx.mock
 def test_search_with_filter_empty_returns_empty_no_recursion(albert_backend, caplog):
     """
     Filtered search returning empty must NOT recurse into an unfiltered call.
     Regression test for the silent-fallback removal.
     """
-    responses.post(
-        url=SEARCH_URL,
-        json=_empty_albert_response(),
-        status=200,
-    )
+    respx.post(SEARCH_URL).mock(return_value=httpx.Response(200, json=_empty_albert_response()))
 
     with caplog.at_level("INFO", logger="chat.agent_rag.document_rag_backends.albert_rag_backend"):
         results = albert_backend.search("any query", document_name="missing.pdf")
 
     assert results.data == []
     # Exactly one HTTP call: no recursive unfiltered retry.
-    assert len(responses.calls) == 1
+    assert len(respx.calls) == 1
     # And the empty-with-filter case is announced at info level.
     assert any("returned no results" in r.message for r in caplog.records)
 
 
-@responses.activate
+@respx.mock
 def test_search_without_filter_empty_returns_empty(albert_backend, caplog):
     """Unfiltered empty result returns empty RAGWebResults; no info log."""
-    responses.post(
-        url=SEARCH_URL,
-        json=_empty_albert_response(),
-        status=200,
-    )
+    respx.post(SEARCH_URL).mock(return_value=httpx.Response(200, json=_empty_albert_response()))
 
     with caplog.at_level("INFO", logger="chat.agent_rag.document_rag_backends.albert_rag_backend"):
         results = albert_backend.search("any query")
 
     assert results.data == []
-    assert len(responses.calls) == 1
+    assert len(respx.calls) == 1
     # The "returned no results" info log is only for filtered searches.
     assert not any("returned no results" in r.message for r in caplog.records)
 
 
-@responses.activate
+@respx.mock
 def test_search_returns_results_with_usage(albert_backend):
     """A successful search maps Albert chunks to RAGWebResult and propagates usage."""
-    responses.post(
-        url=SEARCH_URL,
-        json=_one_result_albert_response(),
-        status=200,
+    respx.post(SEARCH_URL).mock(
+        return_value=httpx.Response(200, json=_one_result_albert_response())
     )
 
     results = albert_backend.search("any query")

--- a/src/backend/chat/tests/agent_rag/test_indexing.py
+++ b/src/backend/chat/tests/agent_rag/test_indexing.py
@@ -7,8 +7,9 @@ import zipfile
 from django.core.files.base import ContentFile
 from django.core.files.storage import default_storage
 
+import httpx
 import pytest
-import responses
+import respx
 from rest_framework import status
 
 from core.file_upload.enums import AttachmentStatus
@@ -87,17 +88,17 @@ def test_is_indexable_for_rag_skips_companion_markdown():
     assert is_indexable_for_rag(attachment) is False
 
 
-@responses.activate
+@respx.mock
 def test_index_skips_attachment_without_project():
     """Conversation-scoped attachments are silently skipped."""
     attachment = factories.ChatConversationAttachmentFactory(content_type="text/plain")
 
     index_project_attachment(attachment)
 
-    assert len(responses.calls) == 0
+    assert len(respx.calls) == 0
 
 
-@responses.activate
+@respx.mock
 def test_index_skips_image_attachment(project_text_attachment):
     """Image attachments are skipped: no HTTP call, no collection created."""
     project_text_attachment.content_type = "image/png"
@@ -105,23 +106,19 @@ def test_index_skips_image_attachment(project_text_attachment):
 
     index_project_attachment(project_text_attachment)
 
-    assert len(responses.calls) == 0
+    assert len(respx.calls) == 0
     project_text_attachment.project.refresh_from_db()
     assert project_text_attachment.project.collection_id is None
 
 
-@responses.activate
+@respx.mock
 def test_index_creates_collection_when_project_has_none(project_text_attachment):
     """First indexable file in a fresh project triggers collection creation."""
-    create_mock = responses.post(
-        "https://albert.api.etalab.gouv.fr/v1/collections",
-        json={"id": "42"},
-        status=status.HTTP_200_OK,
+    create_mock = respx.post("https://albert.api.etalab.gouv.fr/v1/collections").mock(
+        return_value=httpx.Response(status.HTTP_200_OK, json={"id": "42"})
     )
-    documents_mock = responses.post(
-        "https://albert.api.etalab.gouv.fr/v1/documents",
-        json={"id": 1},
-        status=status.HTTP_201_CREATED,
+    documents_mock = respx.post("https://albert.api.etalab.gouv.fr/v1/documents").mock(
+        return_value=httpx.Response(status.HTTP_201_CREATED, json={"id": 1})
     )
 
     index_project_attachment(project_text_attachment)
@@ -136,21 +133,17 @@ def test_index_creates_collection_when_project_has_none(project_text_attachment)
     assert documents_mock.call_count == 1
 
 
-@responses.activate
+@respx.mock
 def test_index_reuses_existing_project_collection(project_text_attachment):
     """A project that already has a collection_id is not asked to create another."""
     project_text_attachment.project.collection_id = "999"
     project_text_attachment.project.save(update_fields=["collection_id"])
 
-    create_mock = responses.post(
-        "https://albert.api.etalab.gouv.fr/v1/collections",
-        json={"id": "should-not-be-called"},
-        status=status.HTTP_200_OK,
+    create_mock = respx.post("https://albert.api.etalab.gouv.fr/v1/collections").mock(
+        return_value=httpx.Response(status.HTTP_200_OK, json={"id": "should-not-be-called"})
     )
-    documents_mock = responses.post(
-        "https://albert.api.etalab.gouv.fr/v1/documents",
-        json={"id": 1},
-        status=status.HTTP_201_CREATED,
+    documents_mock = respx.post("https://albert.api.etalab.gouv.fr/v1/documents").mock(
+        return_value=httpx.Response(status.HTTP_201_CREATED, json={"id": 1})
     )
 
     index_project_attachment(project_text_attachment)
@@ -161,19 +154,15 @@ def test_index_reuses_existing_project_collection(project_text_attachment):
     assert documents_mock.call_count == 1
 
 
-@responses.activate
+@respx.mock
 def test_index_swallows_backend_errors(project_text_attachment, settings, caplog):
     """Backend failures must be logged but never raised."""
     settings.RAG_STORE_RETRY_DELAY_SECONDS = 0  # 500 triggers a retry; don't sleep
-    responses.post(
-        "https://albert.api.etalab.gouv.fr/v1/collections",
-        json={"id": "42"},
-        status=status.HTTP_200_OK,
+    respx.post("https://albert.api.etalab.gouv.fr/v1/collections").mock(
+        return_value=httpx.Response(status.HTTP_200_OK, json={"id": "42"})
     )
-    responses.post(
-        "https://albert.api.etalab.gouv.fr/v1/documents",
-        json={"error": "kaboom"},
-        status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+    respx.post("https://albert.api.etalab.gouv.fr/v1/documents").mock(
+        return_value=httpx.Response(status.HTTP_500_INTERNAL_SERVER_ERROR, json={"error": "kaboom"})
     )
     caplog.set_level(logging.ERROR, logger="chat.agent_rag.indexing")
 
@@ -187,22 +176,18 @@ def test_index_swallows_backend_errors(project_text_attachment, settings, caplog
     assert project_text_attachment.upload_state == AttachmentStatus.READY
 
 
-@responses.activate
+@respx.mock
 def test_index_fails_when_backend_returns_no_document_id(project_text_attachment):
     """A falsy document id must fail (FAILED), not leave the row stuck in INDEXING.
 
     The INDEXED transition and the idempotency guard both key off
     rag_document_id, so a missing id would otherwise wedge the row in INDEXING.
     """
-    responses.post(
-        "https://albert.api.etalab.gouv.fr/v1/collections",
-        json={"id": "42"},
-        status=status.HTTP_200_OK,
+    respx.post("https://albert.api.etalab.gouv.fr/v1/collections").mock(
+        return_value=httpx.Response(status.HTTP_200_OK, json={"id": "42"})
     )
-    responses.post(
-        "https://albert.api.etalab.gouv.fr/v1/documents",
-        json={"id": ""},
-        status=status.HTTP_201_CREATED,
+    respx.post("https://albert.api.etalab.gouv.fr/v1/documents").mock(
+        return_value=httpx.Response(status.HTTP_201_CREATED, json={"id": ""})
     )
 
     index_project_attachment(project_text_attachment)
@@ -214,7 +199,7 @@ def test_index_fails_when_backend_returns_no_document_id(project_text_attachment
     assert project_text_attachment.upload_state == AttachmentStatus.READY
 
 
-@responses.activate
+@respx.mock
 def test_index_failure_captures_albert_response_body(project_text_attachment, settings, caplog):
     """A failed store logs and stores the Albert response body (the real reason),
     plus the file identity, instead of a generic exception string."""
@@ -222,10 +207,11 @@ def test_index_failure_captures_albert_response_body(project_text_attachment, se
     project_text_attachment.project.collection_id = "999"
     project_text_attachment.project.save(update_fields=["collection_id"])
 
-    responses.post(
-        "https://albert.api.etalab.gouv.fr/v1/documents",
-        json={"detail": "model albert-large is overloaded"},
-        status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+    respx.post("https://albert.api.etalab.gouv.fr/v1/documents").mock(
+        return_value=httpx.Response(
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+            json={"detail": "model albert-large is overloaded"},
+        )
     )
     caplog.set_level(logging.ERROR, logger="chat.agent_rag.indexing")
 
@@ -240,89 +226,77 @@ def test_index_failure_captures_albert_response_body(project_text_attachment, se
     assert "model albert-large is overloaded" in caplog.text
 
 
-@responses.activate
+@respx.mock
 def test_index_retries_once_on_transient_store_error(project_text_attachment, settings):
     """A transient 5xx on the store call is retried once, then succeeds."""
     settings.RAG_STORE_RETRY_DELAY_SECONDS = 0  # don't actually sleep in tests
     project_text_attachment.project.collection_id = "999"
     project_text_attachment.project.save(update_fields=["collection_id"])
 
-    # responses returns registered mocks in order: first call 503, retry 201.
-    responses.post(
-        "https://albert.api.etalab.gouv.fr/v1/documents",
-        json={"error": "flaky"},
-        status=status.HTTP_503_SERVICE_UNAVAILABLE,
-    )
-    responses.post(
-        "https://albert.api.etalab.gouv.fr/v1/documents",
-        json={"id": 1},
-        status=status.HTTP_201_CREATED,
+    # respx returns the side effects in order: first call 503, retry 201.
+    respx.post("https://albert.api.etalab.gouv.fr/v1/documents").mock(
+        side_effect=[
+            httpx.Response(status.HTTP_503_SERVICE_UNAVAILABLE, json={"error": "flaky"}),
+            httpx.Response(status.HTTP_201_CREATED, json={"id": 1}),
+        ]
     )
 
     index_project_attachment(project_text_attachment)
 
-    assert len(responses.calls) == 2  # initial attempt + one retry
+    assert len(respx.calls) == 2  # initial attempt + one retry
     project_text_attachment.refresh_from_db()
     assert project_text_attachment.index_state == AttachmentIndexState.INDEXED
     assert project_text_attachment.rag_document_id == "1"
     assert project_text_attachment.processing_error is None
 
 
-@responses.activate
+@respx.mock
 def test_index_does_not_retry_on_client_error(project_text_attachment):
     """A 4xx store error is permanent for this input: no retry, straight to FAILED."""
     project_text_attachment.project.collection_id = "999"
     project_text_attachment.project.save(update_fields=["collection_id"])
 
-    responses.post(
-        "https://albert.api.etalab.gouv.fr/v1/documents",
-        json={"error": "bad request"},
-        status=status.HTTP_400_BAD_REQUEST,
+    respx.post("https://albert.api.etalab.gouv.fr/v1/documents").mock(
+        return_value=httpx.Response(status.HTTP_400_BAD_REQUEST, json={"error": "bad request"})
     )
 
     index_project_attachment(project_text_attachment)
 
-    assert len(responses.calls) == 1  # no retry
+    assert len(respx.calls) == 1  # no retry
     project_text_attachment.refresh_from_db()
     assert project_text_attachment.index_state == AttachmentIndexState.FAILED
 
 
-@responses.activate
+@respx.mock
 def test_index_does_not_retry_on_missing_document_id(project_text_attachment):
     """A 200 with no id means the chunks were stored; retrying would duplicate
     them, so it fails fast to FAILED instead of retrying."""
     project_text_attachment.project.collection_id = "999"
     project_text_attachment.project.save(update_fields=["collection_id"])
 
-    responses.post(
-        "https://albert.api.etalab.gouv.fr/v1/documents",
-        json={"id": ""},
-        status=status.HTTP_201_CREATED,
+    respx.post("https://albert.api.etalab.gouv.fr/v1/documents").mock(
+        return_value=httpx.Response(status.HTTP_201_CREATED, json={"id": ""})
     )
 
     index_project_attachment(project_text_attachment)
 
-    assert len(responses.calls) == 1  # no retry
+    assert len(respx.calls) == 1  # no retry
     project_text_attachment.refresh_from_db()
     assert project_text_attachment.index_state == AttachmentIndexState.FAILED
     assert not project_text_attachment.rag_document_id
 
 
-@responses.activate
+@respx.mock
 def test_index_is_idempotent_when_already_indexed(project_text_attachment):
     """An attachment that already carries a rag_document_id is not re-parsed."""
     project_text_attachment.rag_document_id = "777"
     project_text_attachment.save(update_fields=["rag_document_id"])
 
-    create_mock = responses.post(
-        "https://albert.api.etalab.gouv.fr/v1/collections",
-        json={"id": "42"},
-        status=status.HTTP_200_OK,
+    create_mock = respx.post("https://albert.api.etalab.gouv.fr/v1/collections").mock(
+        return_value=httpx.Response(status.HTTP_200_OK, json={"id": "42"})
     )
-    documents_mock = responses.post(
-        "https://albert.api.etalab.gouv.fr/v1/documents",
-        json={"id": 999},
-        status=status.HTTP_201_CREATED,
+    documents_mock = respx.post("https://albert.api.etalab.gouv.fr/v1/documents").mock(
+        return_value=httpx.Response(status.HTTP_201_CREATED, json={"id": 999})
     )
 
     index_project_attachment(project_text_attachment)
@@ -359,7 +333,7 @@ def test_index_reconcile_clears_stale_processing_error(project_text_attachment):
     assert project_text_attachment.processing_error is None
 
 
-@responses.activate
+@respx.mock
 def test_index_creates_markdown_companion_for_non_text_input():
     """Non-text inputs (e.g. PDF) get a hidden markdown companion attachment.
 
@@ -378,20 +352,16 @@ def test_index_creates_markdown_companion_for_non_text_input():
     )
     companion = None
     try:
-        responses.post(
-            "https://albert.api.etalab.gouv.fr/v1/ocr",
-            json={"pages": [{"markdown": "# Parsed PDF\n\nbody"}]},
-            status=status.HTTP_200_OK,
+        respx.post("https://albert.api.etalab.gouv.fr/v1/ocr").mock(
+            return_value=httpx.Response(
+                status.HTTP_200_OK, json={"pages": [{"markdown": "# Parsed PDF\n\nbody"}]}
+            )
         )
-        responses.post(
-            "https://albert.api.etalab.gouv.fr/v1/collections",
-            json={"id": "42"},
-            status=status.HTTP_200_OK,
+        respx.post("https://albert.api.etalab.gouv.fr/v1/collections").mock(
+            return_value=httpx.Response(status.HTTP_200_OK, json={"id": "42"})
         )
-        responses.post(
-            "https://albert.api.etalab.gouv.fr/v1/documents",
-            json={"id": 1},
-            status=status.HTTP_201_CREATED,
+        respx.post("https://albert.api.etalab.gouv.fr/v1/documents").mock(
+            return_value=httpx.Response(status.HTTP_201_CREATED, json={"id": 1})
         )
 
         index_project_attachment(attachment)
@@ -414,7 +384,7 @@ def test_index_creates_markdown_companion_for_non_text_input():
             default_storage.delete(companion.key)
 
 
-@responses.activate
+@respx.mock
 def test_index_reconcile_rebuilds_missing_markdown_companion():
     """The idempotent reconcile re-writes a companion a prior run failed to store.
 
@@ -433,15 +403,13 @@ def test_index_reconcile_rebuilds_missing_markdown_companion():
     )
     companion = None
     try:
-        parse_mock = responses.post(
-            "https://albert.api.etalab.gouv.fr/v1/ocr",
-            json={"pages": [{"markdown": "# Parsed PDF\n\nbody"}]},
-            status=status.HTTP_200_OK,
+        parse_mock = respx.post("https://albert.api.etalab.gouv.fr/v1/ocr").mock(
+            return_value=httpx.Response(
+                status.HTTP_200_OK, json={"pages": [{"markdown": "# Parsed PDF\n\nbody"}]}
+            )
         )
-        documents_mock = responses.post(
-            "https://albert.api.etalab.gouv.fr/v1/documents",
-            json={"id": 1},
-            status=status.HTTP_201_CREATED,
+        documents_mock = respx.post("https://albert.api.etalab.gouv.fr/v1/documents").mock(
+            return_value=httpx.Response(status.HTTP_201_CREATED, json={"id": 1})
         )
 
         index_project_attachment(attachment)
@@ -462,7 +430,7 @@ def test_index_reconcile_rebuilds_missing_markdown_companion():
             default_storage.delete(companion.key)
 
 
-@responses.activate
+@respx.mock
 def test_index_reconcile_skips_companion_when_present(project_text_attachment):
     """Reconcile does no parse work when the companion already exists.
 
@@ -472,10 +440,8 @@ def test_index_reconcile_skips_companion_when_present(project_text_attachment):
     project_text_attachment.rag_document_id = "already-stored"
     project_text_attachment.save(update_fields=["rag_document_id"])
 
-    parse_mock = responses.post(
-        "https://albert.api.etalab.gouv.fr/v1/ocr",
-        json={"pages": [{"markdown": "unused"}]},
-        status=status.HTTP_200_OK,
+    parse_mock = respx.post("https://albert.api.etalab.gouv.fr/v1/ocr").mock(
+        return_value=httpx.Response(status.HTTP_200_OK, json={"pages": [{"markdown": "unused"}]})
     )
 
     index_project_attachment(project_text_attachment)
@@ -483,7 +449,7 @@ def test_index_reconcile_skips_companion_when_present(project_text_attachment):
     assert parse_mock.call_count == 0
 
 
-@responses.activate
+@respx.mock
 def test_index_rejects_zip_bomb_and_marks_failed(settings):
     """A decompression-bomb project attachment is rejected before it is stored.
 
@@ -506,15 +472,11 @@ def test_index_rejects_zip_bomb_and_marks_failed(settings):
         upload_state=AttachmentStatus.READY,
     )
 
-    responses.post(
-        "https://albert.api.etalab.gouv.fr/v1/collections",
-        json={"id": "42"},
-        status=status.HTTP_200_OK,
+    respx.post("https://albert.api.etalab.gouv.fr/v1/collections").mock(
+        return_value=httpx.Response(status.HTTP_200_OK, json={"id": "42"})
     )
-    documents_mock = responses.post(
-        "https://albert.api.etalab.gouv.fr/v1/documents",
-        json={"id": 1},
-        status=status.HTTP_201_CREATED,
+    documents_mock = respx.post("https://albert.api.etalab.gouv.fr/v1/documents").mock(
+        return_value=httpx.Response(status.HTTP_201_CREATED, json={"id": 1})
     )
 
     try:
@@ -532,18 +494,14 @@ def test_index_rejects_zip_bomb_and_marks_failed(settings):
         default_storage.delete(saved_name)
 
 
-@responses.activate
+@respx.mock
 def test_index_does_not_create_companion_for_text_input(project_text_attachment):
     """A text/* input goes straight to the backend - no companion attachment."""
-    responses.post(
-        "https://albert.api.etalab.gouv.fr/v1/collections",
-        json={"id": "42"},
-        status=status.HTTP_200_OK,
+    respx.post("https://albert.api.etalab.gouv.fr/v1/collections").mock(
+        return_value=httpx.Response(status.HTTP_200_OK, json={"id": "42"})
     )
-    responses.post(
-        "https://albert.api.etalab.gouv.fr/v1/documents",
-        json={"id": 1},
-        status=status.HTTP_201_CREATED,
+    respx.post("https://albert.api.etalab.gouv.fr/v1/documents").mock(
+        return_value=httpx.Response(status.HTTP_201_CREATED, json={"id": 1})
     )
 
     index_project_attachment(project_text_attachment)

--- a/src/backend/chat/tests/clients/pydantic_ai/test_handle_input_documents_indexing.py
+++ b/src/backend/chat/tests/clients/pydantic_ai/test_handle_input_documents_indexing.py
@@ -7,8 +7,8 @@ from unittest.mock import AsyncMock
 
 from django.utils import timezone
 
+import httpx
 import pytest
-import requests
 from asgiref.sync import sync_to_async
 from pydantic_ai.messages import BinaryContent
 
@@ -117,11 +117,11 @@ async def test_no_busy_error_when_indexing_claim_timed_out():
 # --------------------------------------------------------------------------- #
 
 
-def _http_error(status_code: int) -> requests.HTTPError:
-    """Build a requests.HTTPError whose response carries the given status code."""
-    response = requests.Response()
-    response.status_code = status_code
-    return requests.HTTPError(response=response)
+def _http_error(status_code: int) -> httpx.HTTPStatusError:
+    """Build an httpx.HTTPStatusError whose response carries the given status code."""
+    request = httpx.Request("POST", "https://albert.example.com/v1/documents")
+    response = httpx.Response(status_code, request=request)
+    return httpx.HTTPStatusError(f"HTTP {status_code}", request=request, response=response)
 
 
 async def _collect_handle_input_documents(service, exc):
@@ -166,11 +166,11 @@ async def test_handle_input_documents_emits_rag_unavailable_on_500(caplog):
 
 @pytest.mark.asyncio
 async def test_handle_input_documents_emits_rag_connection_error_on_network_failure():
-    """A requests.ConnectionError surfaces as kind=rag_connection_error."""
+    """An httpx.ConnectError surfaces as kind=rag_connection_error."""
     conversation = await sync_to_async(ChatConversationFactory)()
     service = AIAgentService(conversation, user=conversation.owner)
 
-    events = await _collect_handle_input_documents(service, requests.ConnectionError("no route"))
+    events = await _collect_handle_input_documents(service, httpx.ConnectError("no route"))
 
     result = _tool_result(events).result
     assert result["kind"] == "rag_connection_error"

--- a/src/backend/chat/tests/clients/pydantic_ai/test_reindex_conversation.py
+++ b/src/backend/chat/tests/clients/pydantic_ai/test_reindex_conversation.py
@@ -6,7 +6,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
-import requests
 from asgiref.sync import sync_to_async
 
 from core.file_upload.enums import AttachmentStatus
@@ -519,11 +518,11 @@ async def test_reindex_all_failures_sets_error_and_saves_collection_id():
     assert conversation.collection_id == "col-new"
 
 
-def _http_error(status_code: int) -> requests.HTTPError:
-    """Build a requests.HTTPError whose response carries the given status code."""
-    response = requests.Response()
-    response.status_code = status_code
-    return requests.HTTPError(response=response)
+def _http_error(status_code: int) -> httpx.HTTPStatusError:
+    """Build an httpx.HTTPStatusError whose response carries the given status code."""
+    request = httpx.Request("POST", "https://albert.example.com/v1/documents")
+    response = httpx.Response(status_code, request=request)
+    return httpx.HTTPStatusError(f"HTTP {status_code}", request=request, response=response)
 
 
 async def _run_reindex_with_collection_failure(conversation, exc):

--- a/src/backend/chat/tests/clients/test_error_classification.py
+++ b/src/backend/chat/tests/clients/test_error_classification.py
@@ -2,7 +2,6 @@
 
 import httpx
 import pytest
-import requests
 
 from chat.clients.error_classification import (
     resolve_llm_error_code,
@@ -10,11 +9,11 @@ from chat.clients.error_classification import (
 )
 
 
-def _http_error(status_code: int) -> requests.HTTPError:
-    """Build a requests.HTTPError whose response carries the given status code."""
-    response = requests.Response()
-    response.status_code = status_code
-    return requests.HTTPError(response=response)
+def _http_error(status_code: int) -> httpx.HTTPStatusError:
+    """Build an httpx.HTTPStatusError whose response carries the given status code."""
+    request = httpx.Request("POST", "https://albert.example.com/v1/documents")
+    response = httpx.Response(status_code, request=request)
+    return httpx.HTTPStatusError(f"HTTP {status_code}", request=request, response=response)
 
 
 @pytest.mark.parametrize(
@@ -49,8 +48,6 @@ def test_resolve_llm_error_code(status_code, expected):
         (_http_error(404), "rag_internal_error"),
         (_http_error(403), "rag_internal_error"),
         (_http_error(422), "rag_internal_error"),
-        (requests.ConnectionError("boom"), "rag_connection_error"),
-        (requests.Timeout("boom"), "rag_connection_error"),
         (httpx.ConnectError("boom"), "rag_connection_error"),
         (httpx.ReadTimeout("boom"), "rag_connection_error"),
         (ValueError("local parse failed"), "rag_error"),

--- a/src/backend/chat/tests/management/commands/test_deindex_inactive_collections.py
+++ b/src/backend/chat/tests/management/commands/test_deindex_inactive_collections.py
@@ -6,8 +6,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from django.core.management import call_command
 from django.utils import timezone
 
+import httpx
 import pytest
-import requests
 
 from chat.enums import CollectionIndexState
 from chat.factories import ChatConversationAttachmentFactory, ChatConversationFactory
@@ -163,7 +163,7 @@ def test_treats_404_as_deindexed():
     )
 
     response = MagicMock(status_code=404)
-    error = requests.HTTPError("404 Not Found", response=response)
+    error = httpx.HTTPStatusError("404 Not Found", request=MagicMock(), response=response)
     mock_instance = MagicMock()
     mock_instance.delete_collection.side_effect = error
     mock_backend_cls = MagicMock(return_value=mock_instance)

--- a/src/backend/chat/tests/management/commands/test_fetch_model_health.py
+++ b/src/backend/chat/tests/management/commands/test_fetch_model_health.py
@@ -7,9 +7,9 @@ from django.core.cache import cache
 from django.core.management import call_command
 from django.core.management.base import CommandError
 
+import httpx
 import pytest
-import requests as requests_lib
-import responses as responses_lib
+import respx
 
 from core.models import ModelHealthSettings
 
@@ -25,23 +25,24 @@ def _clear_cache_between_tests(clear_cache):  # pylint: disable=unused-argument
 
 
 @pytest.mark.django_db
-@responses_lib.activate
+@respx.mock
 def test_fetch_model_health_inserts_rows_and_sets_cache():
     """On success: one DB row per model + Redis key set, Bearer token sent."""
-    responses_lib.add(
-        responses_lib.GET,
-        ALBERT_HEALTH_URL,
-        json={
-            "data": [
-                {"id": "BAAI/bge-m3", "status": "green"},
-                {"id": "mistral-medium-2508", "status": "red"},
-            ]
-        },
+    respx.get(ALBERT_HEALTH_URL).mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "data": [
+                    {"id": "BAAI/bge-m3", "status": "green"},
+                    {"id": "mistral-medium-2508", "status": "red"},
+                ]
+            },
+        )
     )
 
     call_command("fetch_model_health", "--provider", "albert")
 
-    assert responses_lib.calls[0].request.headers["Authorization"] == "Bearer test-key"
+    assert respx.calls[0].request.headers["Authorization"] == "Bearer test-key"
     assert ModelHealth.objects.count() == 2
     row = ModelHealth.objects.get(provider="albert", model_id="BAAI/bge-m3")
     assert row.status == "green"
@@ -50,23 +51,23 @@ def test_fetch_model_health_inserts_rows_and_sets_cache():
 
 
 @pytest.mark.django_db
-@responses_lib.activate
+@respx.mock
 def test_fetch_model_health_no_api_key_sends_no_auth_header(settings):
     """When ALBERT_API_KEY is None, no Authorization header is sent."""
     settings.ALBERT_API_KEY = None
 
-    responses_lib.add(responses_lib.GET, ALBERT_HEALTH_URL, json={"data": []})
+    respx.get(ALBERT_HEALTH_URL).mock(return_value=httpx.Response(200, json={"data": []}))
 
     call_command("fetch_model_health", "--provider", "albert")
 
-    assert "Authorization" not in responses_lib.calls[0].request.headers
+    assert "Authorization" not in respx.calls[0].request.headers
 
 
 @pytest.mark.django_db
-@responses_lib.activate
+@respx.mock
 def test_fetch_model_health_http_error_leaves_db_and_cache_untouched():
     """On HTTP error: no DB rows created, no cache writes, CommandError raised."""
-    responses_lib.add(responses_lib.GET, ALBERT_HEALTH_URL, status=500)
+    respx.get(ALBERT_HEALTH_URL).mock(return_value=httpx.Response(500))
 
     with pytest.raises(CommandError):
         call_command("fetch_model_health", "--provider", "albert")
@@ -77,14 +78,10 @@ def test_fetch_model_health_http_error_leaves_db_and_cache_untouched():
 
 
 @pytest.mark.django_db
-@responses_lib.activate
+@respx.mock
 def test_fetch_model_health_timeout_raises_command_error():
     """On network timeout: CommandError raised, DB untouched."""
-    responses_lib.add(
-        responses_lib.GET,
-        ALBERT_HEALTH_URL,
-        body=requests_lib.Timeout("timed out"),
-    )
+    respx.get(ALBERT_HEALTH_URL).mock(side_effect=httpx.TimeoutException("timed out"))
 
     with pytest.raises(CommandError):
         call_command("fetch_model_health", "--provider", "albert")
@@ -119,10 +116,10 @@ def test_skip_when_lock_present():
 
 
 @pytest.mark.django_db
-@responses_lib.activate
+@respx.mock
 def test_lock_acquired_on_run():
     """After a successful run, the Redis lock key is present."""
-    responses_lib.add(responses_lib.GET, ALBERT_HEALTH_URL, json={"data": []})
+    respx.get(ALBERT_HEALTH_URL).mock(return_value=httpx.Response(200, json={"data": []}))
 
     call_command("fetch_model_health", "--provider", "albert")
 
@@ -130,15 +127,13 @@ def test_lock_acquired_on_run():
 
 
 @pytest.mark.django_db
-@responses_lib.activate
+@respx.mock
 def test_no_new_row_if_status_unchanged(settings):
     """Same status on second run → still 1 row (no new insert)."""
     settings.ALBERT_API_KEY = None
 
-    responses_lib.add(
-        responses_lib.GET,
-        ALBERT_HEALTH_URL,
-        json={"data": [{"id": "BAAI/bge-m3", "status": "green"}]},
+    respx.get(ALBERT_HEALTH_URL).mock(
+        return_value=httpx.Response(200, json={"data": [{"id": "BAAI/bge-m3", "status": "green"}]})
     )
     call_command("fetch_model_health", "--provider", "albert")
 
@@ -146,10 +141,8 @@ def test_no_new_row_if_status_unchanged(settings):
 
     cache.delete("model_health:poll_lock:albert")
 
-    responses_lib.add(
-        responses_lib.GET,
-        ALBERT_HEALTH_URL,
-        json={"data": [{"id": "BAAI/bge-m3", "status": "green"}]},
+    respx.get(ALBERT_HEALTH_URL).mock(
+        return_value=httpx.Response(200, json={"data": [{"id": "BAAI/bge-m3", "status": "green"}]})
     )
     call_command("fetch_model_health", "--provider", "albert")
 
@@ -157,15 +150,13 @@ def test_no_new_row_if_status_unchanged(settings):
 
 
 @pytest.mark.django_db
-@responses_lib.activate
+@respx.mock
 def test_new_row_if_status_changed(settings):
     """Status changes green → red → 2 rows in DB."""
     settings.ALBERT_API_KEY = None
 
-    responses_lib.add(
-        responses_lib.GET,
-        ALBERT_HEALTH_URL,
-        json={"data": [{"id": "BAAI/bge-m3", "status": "green"}]},
+    respx.get(ALBERT_HEALTH_URL).mock(
+        return_value=httpx.Response(200, json={"data": [{"id": "BAAI/bge-m3", "status": "green"}]})
     )
     call_command("fetch_model_health", "--provider", "albert")
 
@@ -173,10 +164,8 @@ def test_new_row_if_status_changed(settings):
 
     cache.delete("model_health:poll_lock:albert")
 
-    responses_lib.add(
-        responses_lib.GET,
-        ALBERT_HEALTH_URL,
-        json={"data": [{"id": "BAAI/bge-m3", "status": "red"}]},
+    respx.get(ALBERT_HEALTH_URL).mock(
+        return_value=httpx.Response(200, json={"data": [{"id": "BAAI/bge-m3", "status": "red"}]})
     )
     call_command("fetch_model_health", "--provider", "albert")
 
@@ -185,15 +174,18 @@ def test_new_row_if_status_changed(settings):
 
 
 @pytest.mark.django_db
-@responses_lib.activate
+@respx.mock
 def test_cache_invalidated_for_removed_models(settings):
     """Models absent from the API response have their cache keys deleted."""
     settings.ALBERT_API_KEY = None
 
-    responses_lib.add(
-        responses_lib.GET,
-        ALBERT_HEALTH_URL,
-        json={"data": [{"id": "model-a", "status": "green"}, {"id": "model-b", "status": "green"}]},
+    respx.get(ALBERT_HEALTH_URL).mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "data": [{"id": "model-a", "status": "green"}, {"id": "model-b", "status": "green"}]
+            },
+        )
     )
     call_command("fetch_model_health", "--provider", "albert")
 
@@ -202,10 +194,8 @@ def test_cache_invalidated_for_removed_models(settings):
 
     cache.delete("model_health:poll_lock:albert")
 
-    responses_lib.add(
-        responses_lib.GET,
-        ALBERT_HEALTH_URL,
-        json={"data": [{"id": "model-a", "status": "green"}]},
+    respx.get(ALBERT_HEALTH_URL).mock(
+        return_value=httpx.Response(200, json={"data": [{"id": "model-a", "status": "green"}]})
     )
     call_command("fetch_model_health", "--provider", "albert")
 
@@ -214,17 +204,21 @@ def test_cache_invalidated_for_removed_models(settings):
 
 
 @pytest.mark.django_db
-@responses_lib.activate
+@respx.mock
 def test_unknown_status_skipped_with_warning(settings, caplog):
     """Items with unknown status values are skipped — no DB row, no cache write."""
     settings.ALBERT_API_KEY = None
 
-    responses_lib.add(
-        responses_lib.GET,
-        ALBERT_HEALTH_URL,
-        json={
-            "data": [{"id": "model-a", "status": "purple"}, {"id": "model-b", "status": "green"}]
-        },
+    respx.get(ALBERT_HEALTH_URL).mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "data": [
+                    {"id": "model-a", "status": "purple"},
+                    {"id": "model-b", "status": "green"},
+                ]
+            },
+        )
     )
 
     with caplog.at_level(logging.WARNING):
@@ -238,15 +232,13 @@ def test_unknown_status_skipped_with_warning(settings, caplog):
 
 
 @pytest.mark.django_db
-@responses_lib.activate
+@respx.mock
 def test_legacy_orange_status_mapped_to_yellow(settings):
     """A provider still emitting the legacy 'orange' status is stored as 'yellow'."""
     settings.ALBERT_API_KEY = None
 
-    responses_lib.add(
-        responses_lib.GET,
-        ALBERT_HEALTH_URL,
-        json={"data": [{"id": "model-a", "status": "orange"}]},
+    respx.get(ALBERT_HEALTH_URL).mock(
+        return_value=httpx.Response(200, json={"data": [{"id": "model-a", "status": "orange"}]})
     )
 
     call_command("fetch_model_health", "--provider", "albert")

--- a/src/backend/chat/tests/test_docs_client.py
+++ b/src/backend/chat/tests/test_docs_client.py
@@ -4,8 +4,8 @@ from unittest.mock import MagicMock, patch
 
 from django.core.exceptions import PermissionDenied
 
+import httpx
 import pytest
-import requests
 
 from chat.docs_client import DocsClient
 
@@ -75,7 +75,7 @@ def test_create_document_success(docs_client):
     fake_response = MagicMock()
     fake_response.json.return_value = {"id": "doc-abc", "url": "http://docs.example.com/doc-abc"}
 
-    with patch("requests.post", return_value=fake_response) as mock_post:
+    with patch("httpx.post", return_value=fake_response) as mock_post:
         result = docs_client.create_document(
             title="My Document", content="# Hello\n\nWorld", session=session
         )
@@ -90,7 +90,7 @@ def test_create_document_posts_to_correct_url(docs_client):
     fake_response = MagicMock()
     fake_response.json.return_value = {"id": "doc-abc"}
 
-    with patch("requests.post", return_value=fake_response) as mock_post:
+    with patch("httpx.post", return_value=fake_response) as mock_post:
         docs_client.create_document(title="Title", content="body", session=session)
 
     call_args = mock_post.call_args
@@ -103,7 +103,7 @@ def test_create_document_sends_bearer_token(docs_client):
     fake_response = MagicMock()
     fake_response.json.return_value = {"id": "doc-abc"}
 
-    with patch("requests.post", return_value=fake_response) as mock_post:
+    with patch("httpx.post", return_value=fake_response) as mock_post:
         docs_client.create_document(title="Title", content="body", session=session)
 
     headers = mock_post.call_args.kwargs["headers"]
@@ -116,7 +116,7 @@ def test_create_document_sends_markdown_file(docs_client):
     fake_response = MagicMock()
     fake_response.json.return_value = {"id": "doc-abc"}
 
-    with patch("requests.post", return_value=fake_response) as mock_post:
+    with patch("httpx.post", return_value=fake_response) as mock_post:
         docs_client.create_document(title="My Doc", content="# Hello", session=session)
 
     files = mock_post.call_args.kwargs["files"]
@@ -128,12 +128,12 @@ def test_create_document_sends_markdown_file(docs_client):
 
 
 def test_create_document_uses_configured_timeout(docs_client):
-    """create_document passes the configured timeout to requests.post."""
+    """create_document passes the configured timeout to httpx.post."""
     session = {"oidc_access_token": "tok"}
     fake_response = MagicMock()
     fake_response.json.return_value = {"id": "doc-abc"}
 
-    with patch("requests.post", return_value=fake_response) as mock_post:
+    with patch("httpx.post", return_value=fake_response) as mock_post:
         docs_client.create_document(title="T", content="c", session=session)
 
     assert mock_post.call_args.kwargs["timeout"] == 10
@@ -143,10 +143,12 @@ def test_create_document_raises_on_http_error(docs_client):
     """create_document propagates HTTPError from raise_for_status."""
     session = {"oidc_access_token": "tok"}
     fake_response = MagicMock()
-    fake_response.raise_for_status.side_effect = requests.exceptions.HTTPError("403 Forbidden")
+    fake_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+        "403 Forbidden", request=MagicMock(), response=MagicMock()
+    )
 
-    with patch("requests.post", return_value=fake_response):
-        with pytest.raises(requests.exceptions.HTTPError):
+    with patch("httpx.post", return_value=fake_response):
+        with pytest.raises(httpx.HTTPStatusError):
             docs_client.create_document(title="T", content="c", session=session)
 
 

--- a/src/backend/chat/tests/test_malware_detection.py
+++ b/src/backend/chat/tests/test_malware_detection.py
@@ -3,8 +3,9 @@
 from django.core.files.base import ContentFile
 from django.core.files.storage import default_storage
 
+import httpx
 import pytest
-import responses
+import respx
 from lasuite.malware_detection.enums import ReportStatus
 from rest_framework import status
 
@@ -141,21 +142,17 @@ def fixture_safe_project_text_file():
     default_storage.delete(file_path)
 
 
-@responses.activate
+@respx.mock
 @pytest.mark.usefixtures("ai_settings")
 def test_malware_detection_callback_safe_status_indexes_project_attachment(
     safe_project_text_file,
 ):
     """Project safe callback marks READY and indexes the file into the project collection."""
-    create_mock = responses.post(
-        "https://albert.api.etalab.gouv.fr/v1/collections",
-        json={"id": "42"},
-        status=status.HTTP_200_OK,
+    create_mock = respx.post("https://albert.api.etalab.gouv.fr/v1/collections").mock(
+        return_value=httpx.Response(status.HTTP_200_OK, json={"id": "42"})
     )
-    documents_mock = responses.post(
-        "https://albert.api.etalab.gouv.fr/v1/documents",
-        json={"id": 1},
-        status=status.HTTP_201_CREATED,
+    documents_mock = respx.post("https://albert.api.etalab.gouv.fr/v1/documents").mock(
+        return_value=httpx.Response(status.HTTP_201_CREATED, json={"id": 1})
     )
     attachment = ChatProjectAttachmentFactory(
         key=safe_project_text_file,
@@ -179,7 +176,7 @@ def test_malware_detection_callback_safe_status_indexes_project_attachment(
     assert documents_mock.call_count == 1
 
 
-@responses.activate
+@respx.mock
 @pytest.mark.usefixtures("ai_settings")
 def test_malware_detection_callback_safe_status_skips_indexing_for_image(
     safe_project_text_file,
@@ -203,10 +200,10 @@ def test_malware_detection_callback_safe_status_skips_indexing_for_image(
     attachment.project.refresh_from_db()
     assert attachment.upload_state == AttachmentStatus.READY
     assert attachment.project.collection_id is None
-    assert len(responses.calls) == 0
+    assert len(respx.calls) == 0
 
 
-@responses.activate
+@respx.mock
 @pytest.mark.usefixtures("ai_settings")
 def test_malware_detection_callback_safe_status_no_attachment(safe_project_text_file):
     """Callback survives when no attachment matches the key (already deleted)."""
@@ -222,10 +219,10 @@ def test_malware_detection_callback_safe_status_no_attachment(safe_project_text_
 
     project.refresh_from_db()
     assert project.collection_id is None
-    assert len(responses.calls) == 0
+    assert len(respx.calls) == 0
 
 
-@responses.activate
+@respx.mock
 @pytest.mark.usefixtures("ai_settings")
 def test_malware_detection_callback_unsafe_status_skips_indexing(
     safe_project_text_file,
@@ -248,10 +245,10 @@ def test_malware_detection_callback_unsafe_status_skips_indexing(
     attachment.project.refresh_from_db()
     assert attachment.upload_state == AttachmentStatus.SUSPICIOUS
     assert attachment.project.collection_id is None
-    assert len(responses.calls) == 0
+    assert len(respx.calls) == 0
 
 
-@responses.activate
+@respx.mock
 @pytest.mark.usefixtures("ai_settings")
 def test_malware_detection_callback_unknown_status_skips_indexing(
     safe_project_text_file,
@@ -274,10 +271,10 @@ def test_malware_detection_callback_unknown_status_skips_indexing(
     attachment.project.refresh_from_db()
     assert attachment.upload_state == AttachmentStatus.SUSPICIOUS
     assert attachment.project.collection_id is None
-    assert len(responses.calls) == 0
+    assert len(respx.calls) == 0
 
 
-@responses.activate
+@respx.mock
 @pytest.mark.usefixtures("ai_settings")
 def test_malware_detection_callback_unknown_status_too_large_project(
     safe_project_text_file,
@@ -300,4 +297,4 @@ def test_malware_detection_callback_unknown_status_too_large_project(
     attachment.project.refresh_from_db()
     assert attachment.upload_state == AttachmentStatus.FILE_TOO_LARGE_TO_ANALYZE
     assert attachment.project.collection_id is None
-    assert len(responses.calls) == 0
+    assert len(respx.calls) == 0

--- a/src/backend/chat/tests/test_tasks.py
+++ b/src/backend/chat/tests/test_tasks.py
@@ -10,8 +10,9 @@ from django.core.files.base import ContentFile
 from django.core.files.storage import default_storage
 from django.utils import timezone
 
+import httpx
 import pytest
-import responses
+import respx
 from pydantic_ai.exceptions import ModelHTTPError
 from rest_framework import status
 
@@ -44,7 +45,7 @@ def ai_settings(settings):
     return settings
 
 
-@responses.activate
+@respx.mock
 def test_index_project_attachment_task_indexes_attachment():
     """The task resolves the id and indexes the file into the project collection."""
     saved_name = default_storage.save("task-rag-test.txt", ContentFile(b"Hello task content"))
@@ -55,15 +56,11 @@ def test_index_project_attachment_task_indexes_attachment():
         upload_state=AttachmentStatus.READY,
     )
     try:
-        responses.post(
-            "https://albert.api.etalab.gouv.fr/v1/collections",
-            json={"id": "42"},
-            status=status.HTTP_200_OK,
+        respx.post("https://albert.api.etalab.gouv.fr/v1/collections").mock(
+            return_value=httpx.Response(status.HTTP_200_OK, json={"id": "42"})
         )
-        responses.post(
-            "https://albert.api.etalab.gouv.fr/v1/documents",
-            json={"id": 1},
-            status=status.HTTP_201_CREATED,
+        respx.post("https://albert.api.etalab.gouv.fr/v1/documents").mock(
+            return_value=httpx.Response(status.HTTP_201_CREATED, json={"id": 1})
         )
 
         index_project_attachment_task.delay(attachment.pk)
@@ -80,17 +77,15 @@ def test_index_project_attachment_task_ignores_missing_attachment():
     index_project_attachment_task.delay(999999)
 
 
-@responses.activate
+@respx.mock
 def test_parse_and_store_conversation_document_task_returns_parsed_and_id():
     """The task reads the file from storage, parses + stores it, and returns (content, id)."""
     saved_name = default_storage.save(
         "conv-task-test.txt", ContentFile(b"Hello conversation content")
     )
     try:
-        responses.post(
-            "https://albert.api.etalab.gouv.fr/v1/documents",
-            json={"id": 7},
-            status=status.HTTP_201_CREATED,
+        respx.post("https://albert.api.etalab.gouv.fr/v1/documents").mock(
+            return_value=httpx.Response(status.HTTP_201_CREATED, json={"id": 7})
         )
 
         parsed_content, rag_document_id = parse_and_store_conversation_document_task.delay(

--- a/src/backend/chat/tests/tools/test_document_generic_search_rag.py
+++ b/src/backend/chat/tests/tools/test_document_generic_search_rag.py
@@ -89,6 +89,7 @@ def test_get_specific_rag_search_tool_config_with_enabled_features(settings):
     }
 
 
+# PostHog calls its flags endpoint through `requests`, so this one stays on `responses`.
 @responses.activate
 def test_get_specific_rag_search_tool_config_with_dynamic_features(settings, posthog):
     """Test get_specific_rag_search_tool_config with dynamic features."""

--- a/src/backend/chat/tests/tools/test_web_search_tavily.py
+++ b/src/backend/chat/tests/tools/test_web_search_tavily.py
@@ -2,8 +2,9 @@
 
 import json
 
+import httpx
 import pytest
-import responses
+import respx
 
 from chat.tools.web_search_tavily import web_search_tavily
 
@@ -18,19 +19,19 @@ def tavily_settings(settings):
     settings.TAVILY_API_TIMEOUT = 5
 
 
-@responses.activate
+@respx.mock
 def test_agent_web_search_tavily_success():
     """Test successful Tavily web search."""
-    responses.add(
-        responses.POST,
-        TAVILY_URL,
-        json={
-            "results": [
-                {"url": "https://example.com/1", "title": "Result 1", "content": "Snippet 1"},
-                {"url": "https://example.com/2", "title": "Result 2", "content": "Snippet 2"},
-            ]
-        },
-        status=200,
+    respx.post(TAVILY_URL).mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "results": [
+                    {"url": "https://example.com/1", "title": "Result 1", "content": "Snippet 1"},
+                    {"url": "https://example.com/2", "title": "Result 2", "content": "Snippet 2"},
+                ]
+            },
+        )
     )
     results = web_search_tavily("test query")
     assert results == [
@@ -39,34 +40,26 @@ def test_agent_web_search_tavily_success():
     ]
 
     # Check request payload
-    tavily_request = responses.calls[0].request
-    payload = json.loads(tavily_request.body.decode("utf-8"))
+    tavily_request = respx.calls[0].request
+    payload = json.loads(tavily_request.content.decode("utf-8"))
     assert payload["query"] == "test query"
     assert payload["api_key"] == "test_api_key"
     assert payload["max_results"] == 3
 
 
-@responses.activate
+@respx.mock
 def test_agent_web_search_tavily_empty_results():
     """Test Tavily web search with no results."""
-    responses.add(
-        responses.POST,
-        TAVILY_URL,
-        json={"results": []},
-        status=200,
-    )
+    respx.post(TAVILY_URL).mock(return_value=httpx.Response(200, json={"results": []}))
     results = web_search_tavily("no results query")
     assert results == []
 
 
-@responses.activate
+@respx.mock
 def test_agent_web_search_tavily_http_error():
     """Test Tavily web search with HTTP error."""
-    responses.add(
-        responses.POST,
-        TAVILY_URL,
-        status=500,
-        json={"error": "Internal Server Error"},
+    respx.post(TAVILY_URL).mock(
+        return_value=httpx.Response(500, json={"error": "Internal Server Error"})
     )
     with pytest.raises(Exception) as exc:
         web_search_tavily("error query")

--- a/src/backend/chat/tests/views/attachments/test_project_attachments.py
+++ b/src/backend/chat/tests/views/attachments/test_project_attachments.py
@@ -7,8 +7,9 @@ from unittest import mock
 from django.core.files.storage import default_storage
 from django.test import override_settings
 
+import httpx
 import pytest
-import responses
+import respx
 from rest_framework import status as http_status
 
 from core.file_upload.enums import AttachmentStatus, FileUploadMode
@@ -393,7 +394,7 @@ def test_project_attachment_delete_success(api_client):
     assert not models.ChatConversationAttachment.objects.filter(pk=attachment.pk).exists()
 
 
-@responses.activate
+@respx.mock
 def test_project_attachment_delete_drops_rag_document(api_client, albert_settings):
     """Deleting an indexed attachment removes its document from the RAG collection."""
     project = factories.ChatProjectFactory(collection_id="42")
@@ -402,9 +403,8 @@ def test_project_attachment_delete_drops_rag_document(api_client, albert_setting
         rag_document_id="123",
     )
     api_client.force_login(project.owner)
-    delete_doc_mock = responses.delete(
-        f"{albert_settings.ALBERT_API_URL}/v1/documents/123",
-        status=http_status.HTTP_204_NO_CONTENT,
+    delete_doc_mock = respx.delete(f"{albert_settings.ALBERT_API_URL}/v1/documents/123").mock(
+        return_value=httpx.Response(http_status.HTTP_204_NO_CONTENT)
     )
 
     url = f"/api/v1.0/projects/{project.pk}/attachments/{attachment.pk!s}/"
@@ -415,7 +415,7 @@ def test_project_attachment_delete_drops_rag_document(api_client, albert_setting
     assert not models.ChatConversationAttachment.objects.filter(pk=attachment.pk).exists()
 
 
-@responses.activate
+@respx.mock
 def test_project_attachment_delete_skips_backend_when_no_doc_id(api_client, albert_settings):
     """An attachment without rag_document_id (image, Find backend) skips the backend call."""
     project = factories.ChatProjectFactory(collection_id="42")
@@ -424,9 +424,8 @@ def test_project_attachment_delete_skips_backend_when_no_doc_id(api_client, albe
         rag_document_id=None,
     )
     api_client.force_login(project.owner)
-    delete_doc_mock = responses.delete(
-        f"{albert_settings.ALBERT_API_URL}/v1/documents/anything",
-        status=http_status.HTTP_204_NO_CONTENT,
+    delete_doc_mock = respx.delete(f"{albert_settings.ALBERT_API_URL}/v1/documents/anything").mock(
+        return_value=httpx.Response(http_status.HTTP_204_NO_CONTENT)
     )
 
     url = f"/api/v1.0/projects/{project.pk}/attachments/{attachment.pk!s}/"
@@ -437,7 +436,7 @@ def test_project_attachment_delete_skips_backend_when_no_doc_id(api_client, albe
     assert not models.ChatConversationAttachment.objects.filter(pk=attachment.pk).exists()
 
 
-@responses.activate
+@respx.mock
 def test_project_attachment_delete_succeeds_when_backend_fails(api_client, albert_settings, caplog):
     """A backend failure is logged but does not block the attachment delete."""
     project = factories.ChatProjectFactory(collection_id="42")
@@ -446,9 +445,8 @@ def test_project_attachment_delete_succeeds_when_backend_fails(api_client, alber
         rag_document_id="123",
     )
     api_client.force_login(project.owner)
-    responses.delete(
-        f"{albert_settings.ALBERT_API_URL}/v1/documents/123",
-        status=http_status.HTTP_500_INTERNAL_SERVER_ERROR,
+    respx.delete(f"{albert_settings.ALBERT_API_URL}/v1/documents/123").mock(
+        return_value=httpx.Response(http_status.HTTP_500_INTERNAL_SERVER_ERROR)
     )
     caplog.set_level(logging.ERROR, logger="chat.views")
 
@@ -460,7 +458,7 @@ def test_project_attachment_delete_succeeds_when_backend_fails(api_client, alber
     assert any("Failed to delete RAG document 123" in record.message for record in caplog.records)
 
 
-@responses.activate
+@respx.mock
 def test_project_attachment_delete_removes_markdown_companion(api_client, albert_settings):
     """Deleting the original drops its hidden markdown companion row too.
 
@@ -490,9 +488,8 @@ def test_project_attachment_delete_removes_markdown_companion(api_client, albert
         content_type="text/markdown",
         conversion_from=None,
     )
-    responses.delete(
-        f"{albert_settings.ALBERT_API_URL}/v1/documents/123",
-        status=http_status.HTTP_204_NO_CONTENT,
+    respx.delete(f"{albert_settings.ALBERT_API_URL}/v1/documents/123").mock(
+        return_value=httpx.Response(http_status.HTTP_204_NO_CONTENT)
     )
     api_client.force_login(project.owner)
 
@@ -506,7 +503,7 @@ def test_project_attachment_delete_removes_markdown_companion(api_client, albert
     assert models.ChatConversationAttachment.objects.filter(pk=unrelated.pk).exists()
 
 
-@responses.activate
+@respx.mock
 def test_project_attachment_delete_runs_rag_before_s3(api_client, albert_settings):
     """`perform_destroy` must remove the RAG document before deleting the S3 blob.
 
@@ -520,9 +517,8 @@ def test_project_attachment_delete_runs_rag_before_s3(api_client, albert_setting
         rag_document_id="123",
     )
     api_client.force_login(project.owner)
-    responses.delete(
-        f"{albert_settings.ALBERT_API_URL}/v1/documents/123",
-        status=http_status.HTTP_204_NO_CONTENT,
+    respx.delete(f"{albert_settings.ALBERT_API_URL}/v1/documents/123").mock(
+        return_value=httpx.Response(http_status.HTTP_204_NO_CONTENT)
     )
 
     call_order = []

--- a/src/backend/chat/tests/views/chat/conversations/test_conversation_with_document_upload.py
+++ b/src/backend/chat/tests/views/chat/conversations/test_conversation_with_document_upload.py
@@ -14,7 +14,6 @@ from django.utils import formats, timezone
 
 import httpx
 import pytest
-import responses
 import respx
 from dirty_equals import IsUUID
 from freezegun import freeze_time
@@ -123,24 +122,22 @@ def fixture_mock_document_api():
     search_method = "semantic"
     search_score = 0.9
 
-    responses.post(
-        "https://albert.api.etalab.gouv.fr/v1/collections",
-        json={"id": "123", "name": "test-collection"},
-        status=status.HTTP_200_OK,
+    respx.post("https://albert.api.etalab.gouv.fr/v1/collections").mock(
+        return_value=httpx.Response(
+            status.HTTP_200_OK, json={"id": "123", "name": "test-collection"}
+        )
     )
 
     # Mock PDF parsing
-    responses.post(
-        "https://albert.api.etalab.gouv.fr/v1/ocr",
-        json={"pages": [{"markdown": "This is the content of the PDF."}]},
-        status=status.HTTP_200_OK,
+    respx.post("https://albert.api.etalab.gouv.fr/v1/ocr").mock(
+        return_value=httpx.Response(
+            status.HTTP_200_OK, json={"pages": [{"markdown": "This is the content of the PDF."}]}
+        )
     )
 
     # Mock document upload
-    responses.post(
-        "https://albert.api.etalab.gouv.fr/v1/documents",
-        json={"id": 456},
-        status=status.HTTP_201_CREATED,
+    respx.post("https://albert.api.etalab.gouv.fr/v1/documents").mock(
+        return_value=httpx.Response(status.HTTP_201_CREATED, json={"id": 456})
     )
 
     # Mock document search. AlbertRagBackend.asearch calls this endpoint via
@@ -159,35 +156,29 @@ def fixture_mock_document_api():
         ],
         "usage": {"prompt_tokens": prompt_tokens, "completion_tokens": completion_tokens},
     }
-    responses.post(
-        "https://albert.api.etalab.gouv.fr/v1/search",
-        json=search_response_body,
-        status=status.HTTP_200_OK,
-    )
     respx.post("https://albert.api.etalab.gouv.fr/v1/search").mock(
         return_value=httpx.Response(status.HTTP_200_OK, json=search_response_body)
     )
 
     # Mock document indexing (Find API)
-    responses.post(
-        "https://app-find/api/v1.0/documents/index/",
-        json={"id": "456", "status": "indexed"},
-        status=status.HTTP_200_OK,
+    respx.post("https://app-find/api/v1.0/documents/index/").mock(
+        return_value=httpx.Response(status.HTTP_200_OK, json={"id": "456", "status": "indexed"})
     )
 
     # Mock document search (Find API)
-    responses.post(
-        "https://app-find/api/v1.0/documents/search/",
-        json=[
-            {
-                "_source": {
-                    "title.fr": document_name,
-                    "content.fr": document_content,
-                },
-                "_score": search_score,
-            }
-        ],
-        status=status.HTTP_200_OK,
+    respx.post("https://app-find/api/v1.0/documents/search/").mock(
+        return_value=httpx.Response(
+            status.HTTP_200_OK,
+            json=[
+                {
+                    "_source": {
+                        "title.fr": document_name,
+                        "content.fr": document_content,
+                    },
+                    "_score": search_score,
+                }
+            ],
+        )
     )
 
 
@@ -203,24 +194,22 @@ def fixture_mock_odt_document_api():
     search_method = "semantic"
     search_score = 0.9
 
-    responses.post(
-        "https://albert.api.etalab.gouv.fr/v1/collections",
-        json={"id": "123", "name": "test-collection"},
-        status=status.HTTP_200_OK,
+    respx.post("https://albert.api.etalab.gouv.fr/v1/collections").mock(
+        return_value=httpx.Response(
+            status.HTTP_200_OK, json={"id": "123", "name": "test-collection"}
+        )
     )
 
     # Mock PDF parsing
-    responses.post(
-        "https://albert.api.etalab.gouv.fr/v1/ocr",
-        json={"pages": [{"markdown": "This is the content of the ODT."}]},
-        status=status.HTTP_200_OK,
+    respx.post("https://albert.api.etalab.gouv.fr/v1/ocr").mock(
+        return_value=httpx.Response(
+            status.HTTP_200_OK, json={"pages": [{"markdown": "This is the content of the ODT."}]}
+        )
     )
 
     # Mock document upload
-    responses.post(
-        "https://albert.api.etalab.gouv.fr/v1/documents",
-        json={"id": 456},
-        status=status.HTTP_201_CREATED,
+    respx.post("https://albert.api.etalab.gouv.fr/v1/documents").mock(
+        return_value=httpx.Response(status.HTTP_201_CREATED, json={"id": 456})
     )
 
     # Mock document search (sync via responses, async via respx).
@@ -238,35 +227,29 @@ def fixture_mock_odt_document_api():
         ],
         "usage": {"prompt_tokens": prompt_tokens, "completion_tokens": completion_tokens},
     }
-    responses.post(
-        "https://albert.api.etalab.gouv.fr/v1/search",
-        json=search_response_body,
-        status=status.HTTP_200_OK,
-    )
     respx.post("https://albert.api.etalab.gouv.fr/v1/search").mock(
         return_value=httpx.Response(status.HTTP_200_OK, json=search_response_body)
     )
 
     # Mock document indexing (Find API)
-    responses.post(
-        "https://app-find/api/v1.0/documents/index/",
-        json={"id": "456", "status": "indexed"},
-        status=status.HTTP_200_OK,
+    respx.post("https://app-find/api/v1.0/documents/index/").mock(
+        return_value=httpx.Response(status.HTTP_200_OK, json={"id": "456", "status": "indexed"})
     )
 
     # Mock document search (Find API)
-    responses.post(
-        "https://app-find/api/v1.0/documents/search/",
-        json=[
-            {
-                "_source": {
-                    "title.fr": document_name,
-                    "content.fr": document_content,
-                },
-                "_score": search_score,
-            }
-        ],
-        status=status.HTTP_200_OK,
+    respx.post("https://app-find/api/v1.0/documents/search/").mock(
+        return_value=httpx.Response(
+            status.HTTP_200_OK,
+            json=[
+                {
+                    "_source": {
+                        "title.fr": document_name,
+                        "content.fr": document_content,
+                    },
+                    "_score": search_score,
+                }
+            ],
+        )
     )
 
 
@@ -349,7 +332,7 @@ def fixture_mock_openai_stream():
     return route
 
 
-@responses.activate
+@respx.mock
 @respx.mock
 @freeze_time()
 def test_post_conversation_with_document_upload(
@@ -620,7 +603,7 @@ def test_post_conversation_with_document_upload(
     }
 
 
-@responses.activate
+@respx.mock
 @respx.mock
 @freeze_time("2025-07-25T10:36:35.297675Z")
 def test_post_conversation_with_document_upload_feature_disabled(
@@ -691,7 +674,7 @@ def test_post_conversation_with_document_upload_feature_disabled(
     assert "Document upload feature is disabled, ignoring input documents." in caplog.text
 
 
-@responses.activate
+@respx.mock
 @respx.mock
 @freeze_time()
 def test_post_conversation_with_document_upload_summarize(  # pylint: disable=too-many-arguments,too-many-positional-arguments  # noqa: PLR0913
@@ -954,7 +937,7 @@ def test_post_conversation_with_document_upload_summarize(  # pylint: disable=to
     }
 
 
-@responses.activate
+@respx.mock
 @respx.mock
 @freeze_time()
 def test_post_conversation_with_odt_document_upload(

--- a/src/backend/chat/tests/views/chat/conversations/test_conversation_with_document_url.py
+++ b/src/backend/chat/tests/views/chat/conversations/test_conversation_with_document_url.py
@@ -10,8 +10,9 @@ from unittest.mock import ANY
 from django.core.files.storage import default_storage
 from django.utils import formats, timezone
 
+import httpx
 import pytest
-import responses
+import respx
 from dirty_equals import IsUUID
 from freezegun import freeze_time
 from pydantic_ai import ModelRequest, RequestUsage
@@ -142,7 +143,7 @@ def fixture_sample_document_content():
     )
 
 
-@responses.activate
+@respx.mock
 @freeze_time()
 def test_post_conversation_with_local_pdf_document_url(
     # pylint: disable=too-many-arguments,too-many-positional-arguments
@@ -155,25 +156,16 @@ def test_post_conversation_with_local_pdf_document_url(
     Test POST to /api/v1/chats/{pk}/conversation/ with a document URL.
     """
 
-    responses.post(
-        "https://albert.api.etalab.gouv.fr/v1/collections",
-        json={"id": 123, "object": "collection"},
-        status=200,
+    respx.post("https://albert.api.etalab.gouv.fr/v1/collections").mock(
+        return_value=httpx.Response(200, json={"id": 123, "object": "collection"})
     )
-    responses.post(
-        "https://albert.api.etalab.gouv.fr/v1/ocr",
-        json={"pages": [{"markdown": "document content"}]},
-        status=200,
+    respx.post("https://albert.api.etalab.gouv.fr/v1/ocr").mock(
+        return_value=httpx.Response(200, json={"pages": [{"markdown": "document content"}]})
     )
-    responses.post(
-        "https://albert.api.etalab.gouv.fr/v1/documents",
-        json={"id": "document_id", "object": "document"},
-        status=200,
+    respx.post("https://albert.api.etalab.gouv.fr/v1/documents").mock(
+        return_value=httpx.Response(200, json={"id": "document_id", "object": "document"})
     )
-    responses.post(
-        "https://app-find/api/v1.0/documents/index/",
-        status=200,
-    )
+    respx.post("https://app-find/api/v1.0/documents/index/").mock(return_value=httpx.Response(200))
 
     chat_conversation = ChatConversationFactory(owner__language="en-us")
     api_client.force_authenticate(user=chat_conversation.owner)
@@ -845,7 +837,7 @@ def test_post_conversation_with_local_document_url_in_history(  # pylint: disabl
     ]
 
 
-@responses.activate
+@respx.mock
 @freeze_time()
 @pytest.mark.parametrize(
     "file_name,content_type",
@@ -866,25 +858,16 @@ def test_post_conversation_with_local_not_pdf_document_url(
     """
     Test POST to /api/v1/chats/{pk}/conversation/ with a document URL.
     """
-    responses.post(
-        "https://albert.api.etalab.gouv.fr/v1/collections",
-        json={"id": 123, "object": "collection"},
-        status=200,
+    respx.post("https://albert.api.etalab.gouv.fr/v1/collections").mock(
+        return_value=httpx.Response(200, json={"id": 123, "object": "collection"})
     )
-    responses.post(
-        "https://albert.api.etalab.gouv.fr/v1/ocr",
-        json={"pages": [{"markdown": "document content"}]},
-        status=200,
+    respx.post("https://albert.api.etalab.gouv.fr/v1/ocr").mock(
+        return_value=httpx.Response(200, json={"pages": [{"markdown": "document content"}]})
     )
-    responses.post(
-        "https://albert.api.etalab.gouv.fr/v1/documents",
-        json={"id": "document_id", "object": "document"},
-        status=200,
+    respx.post("https://albert.api.etalab.gouv.fr/v1/documents").mock(
+        return_value=httpx.Response(200, json={"id": "document_id", "object": "document"})
     )
-    responses.post(
-        "https://app-find/api/v1.0/documents/index/",
-        status=200,
-    )
+    respx.post("https://app-find/api/v1.0/documents/index/").mock(return_value=httpx.Response(200))
 
     chat_conversation = ChatConversationFactory(owner__language="en-us", collection_id="123")
     api_client.force_authenticate(user=chat_conversation.owner)

--- a/src/backend/chat/tests/views/chat/conversations/test_edit_in_docs.py
+++ b/src/backend/chat/tests/views/chat/conversations/test_edit_in_docs.py
@@ -4,8 +4,8 @@ from unittest.mock import MagicMock, patch
 
 from django.utils import formats, timezone
 
+import httpx
 import pytest
-import requests
 from rest_framework import status
 
 from core.factories import UserFactory
@@ -305,7 +305,7 @@ def test_edit_in_docs_docs_service_unavailable_returns_503(
 
     with patch(
         "chat.views.edit_in_docs.DocsClient.create_document",
-        side_effect=requests.exceptions.ConnectionError("Docs unreachable"),
+        side_effect=httpx.ConnectError("Docs unreachable"),
     ):
         response = api_client.post(url, data={"message_id": "assistant-message-1"}, format="json")
 
@@ -314,11 +314,10 @@ def test_edit_in_docs_docs_service_unavailable_returns_503(
 
 
 def _http_error(docs_status):
-    """Build a requests.HTTPError carrying a response with the given status."""
-    response = requests.Response()
-    response.status_code = docs_status
-    response._content = b"docs error body"  # pylint: disable=protected-access
-    return requests.exceptions.HTTPError(response=response)
+    """Build an httpx.HTTPStatusError carrying a response with the given status."""
+    request = httpx.Request("POST", "http://docs.example.com/external_api/v1.0/documents/")
+    response = httpx.Response(docs_status, content=b"docs error body", request=request)
+    return httpx.HTTPStatusError(f"HTTP {docs_status}", request=request, response=response)
 
 
 @pytest.mark.parametrize(

--- a/src/backend/chat/tests/views/chat/test_delete.py
+++ b/src/backend/chat/tests/views/chat/test_delete.py
@@ -3,8 +3,9 @@
 import logging
 from unittest import mock
 
+import httpx
 import pytest
-import responses
+import respx
 from botocore.exceptions import ClientError
 from rest_framework import status
 
@@ -58,13 +59,12 @@ def test_delete_conversation_anonymous(api_client):
     assert ChatConversation.objects.filter(id=chat_conversation.pk).exists()
 
 
-@responses.activate
+@respx.mock
 def test_delete_conversation_drops_rag_collection(api_client, albert_settings):
     """Deleting a conversation removes its RAG collection on the backend."""
     conversation = ChatConversationFactory(collection_id="11")
-    delete_mock = responses.delete(
-        f"{albert_settings.ALBERT_API_URL}/v1/collections/11",
-        status=status.HTTP_204_NO_CONTENT,
+    delete_mock = respx.delete(f"{albert_settings.ALBERT_API_URL}/v1/collections/11").mock(
+        return_value=httpx.Response(status.HTTP_204_NO_CONTENT)
     )
 
     api_client.force_login(conversation.owner)
@@ -75,13 +75,12 @@ def test_delete_conversation_drops_rag_collection(api_client, albert_settings):
     assert not ChatConversation.objects.filter(id=conversation.pk).exists()
 
 
-@responses.activate
+@respx.mock
 def test_delete_conversation_without_collection_skips_backend(api_client, albert_settings):
     """A conversation that never indexed anything must not call the RAG backend."""
     conversation = ChatConversationFactory(collection_id=None)
-    delete_mock = responses.delete(
-        f"{albert_settings.ALBERT_API_URL}/v1/collections/anything",
-        status=status.HTTP_204_NO_CONTENT,
+    delete_mock = respx.delete(f"{albert_settings.ALBERT_API_URL}/v1/collections/anything").mock(
+        return_value=httpx.Response(status.HTTP_204_NO_CONTENT)
     )
 
     api_client.force_login(conversation.owner)
@@ -91,13 +90,12 @@ def test_delete_conversation_without_collection_skips_backend(api_client, albert
     assert delete_mock.call_count == 0
 
 
-@responses.activate
+@respx.mock
 def test_delete_conversation_succeeds_when_backend_fails(api_client, albert_settings, caplog):
     """A backend failure must be logged but must not block the conversation delete."""
     conversation = ChatConversationFactory(collection_id="11")
-    responses.delete(
-        f"{albert_settings.ALBERT_API_URL}/v1/collections/11",
-        status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+    respx.delete(f"{albert_settings.ALBERT_API_URL}/v1/collections/11").mock(
+        return_value=httpx.Response(status.HTTP_500_INTERNAL_SERVER_ERROR)
     )
     caplog.set_level(logging.ERROR, logger="chat.views")
 

--- a/src/backend/chat/tests/views/chat/test_media_auth.py
+++ b/src/backend/chat/tests/views/chat/test_media_auth.py
@@ -8,8 +8,8 @@ from django.conf import settings
 from django.core.files.storage import default_storage
 from django.utils import timezone
 
+import httpx
 import pytest
-import requests
 from freezegun import freeze_time
 
 from core.factories import UserFactory
@@ -77,7 +77,7 @@ def test_api_media_auth_owner(api_client):
 
     s3_url = urlparse(settings.AWS_S3_ENDPOINT_URL)
     file_url = f"{settings.AWS_S3_ENDPOINT_URL:s}/conversations-media-storage/{attachment.key:s}"
-    response = requests.get(
+    response = httpx.get(
         file_url,
         headers={
             "authorization": authorization,

--- a/src/backend/chat/tests/views/projects/test_delete.py
+++ b/src/backend/chat/tests/views/projects/test_delete.py
@@ -3,8 +3,9 @@
 import logging
 from unittest import mock
 
+import httpx
 import pytest
-import responses
+import respx
 from botocore.exceptions import ClientError
 from rest_framework import status
 
@@ -88,13 +89,12 @@ def test_delete_project_user_anonymous(api_client):
     assert ChatProject.objects.filter(id=project.pk).exists()
 
 
-@responses.activate
+@respx.mock
 def test_delete_project_drops_rag_collection(api_client, albert_settings):
     """Deleting a project removes its RAG collection on the backend."""
     project = ChatProjectFactory(collection_id="42")
-    delete_mock = responses.delete(
-        f"{albert_settings.ALBERT_API_URL}/v1/collections/42",
-        status=status.HTTP_204_NO_CONTENT,
+    delete_mock = respx.delete(f"{albert_settings.ALBERT_API_URL}/v1/collections/42").mock(
+        return_value=httpx.Response(status.HTTP_204_NO_CONTENT)
     )
 
     api_client.force_login(project.owner)
@@ -105,13 +105,12 @@ def test_delete_project_drops_rag_collection(api_client, albert_settings):
     assert not ChatProject.objects.filter(id=project.pk).exists()
 
 
-@responses.activate
+@respx.mock
 def test_delete_project_without_collection_skips_backend(api_client, albert_settings):
     """A project that never indexed anything must not call the RAG backend."""
     project = ChatProjectFactory(collection_id=None)
-    delete_mock = responses.delete(
-        f"{albert_settings.ALBERT_API_URL}/v1/collections/anything",
-        status=status.HTTP_204_NO_CONTENT,
+    delete_mock = respx.delete(f"{albert_settings.ALBERT_API_URL}/v1/collections/anything").mock(
+        return_value=httpx.Response(status.HTTP_204_NO_CONTENT)
     )
 
     api_client.force_login(project.owner)
@@ -122,13 +121,12 @@ def test_delete_project_without_collection_skips_backend(api_client, albert_sett
     assert not ChatProject.objects.filter(id=project.pk).exists()
 
 
-@responses.activate
+@respx.mock
 def test_delete_project_succeeds_when_backend_fails(api_client, albert_settings, caplog):
     """A backend failure must be logged but must not block the project delete."""
     project = ChatProjectFactory(collection_id="42")
-    responses.delete(
-        f"{albert_settings.ALBERT_API_URL}/v1/collections/42",
-        status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+    respx.delete(f"{albert_settings.ALBERT_API_URL}/v1/collections/42").mock(
+        return_value=httpx.Response(status.HTTP_500_INTERNAL_SERVER_ERROR)
     )
     caplog.set_level(logging.ERROR, logger="chat.views")
 

--- a/src/backend/chat/tools/web_search_tavily.py
+++ b/src/backend/chat/tools/web_search_tavily.py
@@ -2,7 +2,7 @@
 
 from django.conf import settings
 
-import requests
+import httpx
 
 
 def web_search_tavily(query: str) -> list[dict]:
@@ -21,7 +21,7 @@ def web_search_tavily(query: str) -> list[dict]:
         "api_key": settings.TAVILY_API_KEY,
         "max_results": settings.TAVILY_MAX_RESULTS,
     }
-    response = requests.post(url, json=data, timeout=settings.TAVILY_API_TIMEOUT)
+    response = httpx.post(url, json=data, timeout=settings.TAVILY_API_TIMEOUT)
     response.raise_for_status()
 
     json_response = response.json()

--- a/src/backend/chat/views/edit_in_docs.py
+++ b/src/backend/chat/views/edit_in_docs.py
@@ -12,7 +12,7 @@ from django.conf import settings
 from django.utils import formats, timezone
 from django.utils.translation import gettext as _
 
-import requests as http_requests
+import httpx
 from rest_framework import decorators, status
 from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
@@ -142,11 +142,11 @@ class EditInDocsMixin:
                 content=content,
                 session=request.session,  # for OIDC token
             )
-        except http_requests.exceptions.HTTPError as exc:
+        except httpx.HTTPStatusError as exc:
             # Docs answered with a 4xx/5xx — map it to a meaningful client status
             # instead of masking everything as 503.
             return _docs_http_error_response(exc)
-        except http_requests.exceptions.RequestException as exc:
+        except httpx.RequestError as exc:
             # Transport failure (connection refused, timeout, DNS) — Docs unreachable.
             logger.exception("Docs service unreachable during edit-in-docs: %s", exc)
             return Response(

--- a/src/backend/conftest.py
+++ b/src/backend/conftest.py
@@ -3,6 +3,8 @@
 import freezegun
 import posthog
 import pytest
+from httpcore._backends.anyio import AnyIOBackend
+from httpcore._backends.sync import SyncBackend
 from rest_framework.test import APIClient
 from urllib3.connectionpool import HTTPConnectionPool
 
@@ -27,6 +29,15 @@ def no_http_requests(monkeypatch):
     This is useful for tests that do not require actual HTTP requests
     and helps to avoid network-related issues.
 
+    Both transports are covered: urllib3, used by `requests` (still pulled in by
+    third-party libraries such as mozilla-django-oidc, posthog and the OTLP
+    exporter), and httpcore, used by `httpx` for our own outbound calls.
+
+    The httpcore patch sits on the network backend rather than on the connection
+    pool, which is where respx installs its own patch. A mocked route is served
+    by respx and never opens a socket, so this guard only fires for calls no test
+    mocked at all.
+
     Credits: https://blog.jerrycodes.com/no-http-requests/
     """
 
@@ -40,6 +51,25 @@ def no_http_requests(monkeypatch):
         raise RuntimeError(f"The test was about to {method} {self.scheme}://{self.host}{url}")
 
     monkeypatch.setattr("urllib3.connectionpool.HTTPConnectionPool.urlopen", urlopen_mock)
+
+    original_connect_tcp = SyncBackend.connect_tcp
+    original_connect_tcp_async = AnyIOBackend.connect_tcp
+
+    def _refuse(host, port):
+        """Raise unless the connection targets an allowed host."""
+        if host not in allowed_hosts and f"{host}:{port}" not in allowed_hosts:
+            raise RuntimeError(f"The test was about to connect to {host}:{port}")
+
+    def connect_tcp_mock(self, host, port, *args, **kwargs):
+        _refuse(host, port)
+        return original_connect_tcp(self, host, port, *args, **kwargs)
+
+    async def connect_tcp_async_mock(self, host, port, *args, **kwargs):
+        _refuse(host, port)
+        return await original_connect_tcp_async(self, host, port, *args, **kwargs)
+
+    monkeypatch.setattr("httpcore._backends.sync.SyncBackend.connect_tcp", connect_tcp_mock)
+    monkeypatch.setattr("httpcore._backends.anyio.AnyIOBackend.connect_tcp", connect_tcp_async_mock)
 
 
 @pytest.fixture(name="feature_flags", scope="function")

--- a/src/backend/core/brevo.py
+++ b/src/backend/core/brevo.py
@@ -5,7 +5,7 @@ from typing import List, Optional
 
 from django.conf import settings
 
-import requests
+import httpx
 
 logger = logging.getLogger(__name__)
 
@@ -40,12 +40,12 @@ def create_contact_in_brevo(email: str) -> bool:
         "updateEnabled": True,
     }
     try:
-        response = requests.post(url, json=payload, headers=headers, timeout=5)
-    except requests.RequestException as e:
+        response = httpx.post(url, json=payload, headers=headers, timeout=5)
+    except httpx.HTTPError as e:
         logger.exception(e)
         return False
 
-    if not response.ok:
+    if not response.is_success:
         logger.error(
             "Error creating contact in Brevo %s: (%s) %s",
             email,
@@ -88,8 +88,8 @@ def add_user_to_brevo_list(emails: List[str], list_id: Optional[str]) -> None:
         "emails": emails,
     }
     try:
-        response = requests.post(url, json=payload, headers=headers, timeout=5)
-    except requests.RequestException as e:
+        response = httpx.post(url, json=payload, headers=headers, timeout=5)
+    except httpx.HTTPError as e:
         logger.exception(e)
         return
 
@@ -131,8 +131,8 @@ def remove_user_from_brevo_list(emails: List[str], list_id: Optional[str]) -> No
         "emails": emails,
     }
     try:
-        response = requests.post(url, json=payload, headers=headers, timeout=5)
-    except requests.RequestException as e:
+        response = httpx.post(url, json=payload, headers=headers, timeout=5)
+    except httpx.HTTPError as e:
         logger.exception(e)
         return
     if response.status_code != 201:

--- a/src/backend/core/tests/authentication/test_backends.py
+++ b/src/backend/core/tests/authentication/test_backends.py
@@ -9,8 +9,10 @@ from django.core.exceptions import SuspiciousOperation
 from django.test.utils import override_settings
 from django.utils import timezone
 
+import httpx
 import pytest
 import responses
+import respx
 from cryptography.fernet import Fernet
 from lasuite.oidc_login.backends import get_oidc_refresh_token
 
@@ -544,6 +546,7 @@ def test_authentication_session_tokens(django_assert_num_queries, monkeypatch, r
 
 
 @responses.activate
+@respx.mock
 def test_authentication_user_added_to_brevo(monkeypatch, rf, settings):
     """
     Test that a user is added to the Brevo follow-up list upon authentication.
@@ -552,14 +555,12 @@ def test_authentication_user_added_to_brevo(monkeypatch, rf, settings):
     settings.BREVO_API_KEY = "test-api-key"
     settings.BREVO_FOLLOWUP_LIST_ID = "follow-up-list-id"
 
-    brevo_create_contact = responses.post(
-        "https://api.brevo.com/v3/contacts",
-        status=200,
+    brevo_create_contact = respx.post("https://api.brevo.com/v3/contacts").mock(
+        return_value=httpx.Response(200)
     )
-    brevo_add_to_list = responses.post(
-        "https://api.brevo.com/v3/contacts/lists/follow-up-list-id/contacts/add",
-        status=400,
-    )
+    brevo_add_to_list = respx.post(
+        "https://api.brevo.com/v3/contacts/lists/follow-up-list-id/contacts/add"
+    ).mock(return_value=httpx.Response(400))
 
     klass = OIDCAuthenticationBackend()
     request = rf.get("/some-url", {"state": "test-state", "code": "test-code"})
@@ -596,14 +597,14 @@ def test_authentication_user_added_to_brevo(monkeypatch, rf, settings):
 
     assert len(brevo_create_contact.calls) == 1
     assert brevo_create_contact.calls[0].request.headers["api-key"] == "test-api-key"
-    assert json.loads(brevo_create_contact.calls[0].request.body) == {
+    assert json.loads(brevo_create_contact.calls[0].request.content) == {
         "email": user.email,
         "updateEnabled": True,
     }
 
     assert len(brevo_add_to_list.calls) == 1
     assert brevo_add_to_list.calls[0].request.headers["api-key"] == "test-api-key"
-    assert json.loads(brevo_add_to_list.calls[0].request.body) == {"emails": [user.email]}
+    assert json.loads(brevo_add_to_list.calls[0].request.content) == {"emails": [user.email]}
 
     # A returning user is already in the list: Brevo must not be called again
     klass.authenticate(
@@ -618,6 +619,7 @@ def test_authentication_user_added_to_brevo(monkeypatch, rf, settings):
 
 
 @responses.activate
+@respx.mock
 def test_post_get_or_create_user_only_syncs_new_users(settings):
     """Only a freshly created user is pushed to the Brevo follow-up list."""
 
@@ -625,11 +627,10 @@ def test_post_get_or_create_user_only_syncs_new_users(settings):
     settings.BREVO_FOLLOWUP_LIST_ID = "follow-up-list-id"
     settings.ACTIVATION_REQUIRED = False
 
-    responses.post("https://api.brevo.com/v3/contacts", status=201)
-    brevo_add_to_list = responses.post(
-        "https://api.brevo.com/v3/contacts/lists/follow-up-list-id/contacts/add",
-        status=201,
-    )
+    respx.post("https://api.brevo.com/v3/contacts").mock(return_value=httpx.Response(201))
+    brevo_add_to_list = respx.post(
+        "https://api.brevo.com/v3/contacts/lists/follow-up-list-id/contacts/add"
+    ).mock(return_value=httpx.Response(201))
 
     klass = OIDCAuthenticationBackend()
     user = UserFactory()
@@ -642,6 +643,7 @@ def test_post_get_or_create_user_only_syncs_new_users(settings):
 
 
 @responses.activate
+@respx.mock
 def test_post_get_or_create_user_not_synced_when_activation_required(settings):
     """A new user is not pushed to the follow-up list while activation is required."""
 
@@ -649,11 +651,10 @@ def test_post_get_or_create_user_not_synced_when_activation_required(settings):
     settings.BREVO_FOLLOWUP_LIST_ID = "follow-up-list-id"
     settings.ACTIVATION_REQUIRED = True
 
-    responses.post("https://api.brevo.com/v3/contacts", status=201)
-    brevo_add_to_list = responses.post(
-        "https://api.brevo.com/v3/contacts/lists/follow-up-list-id/contacts/add",
-        status=201,
-    )
+    respx.post("https://api.brevo.com/v3/contacts").mock(return_value=httpx.Response(201))
+    brevo_add_to_list = respx.post(
+        "https://api.brevo.com/v3/contacts/lists/follow-up-list-id/contacts/add"
+    ).mock(return_value=httpx.Response(201))
 
     klass = OIDCAuthenticationBackend()
 
@@ -663,6 +664,7 @@ def test_post_get_or_create_user_not_synced_when_activation_required(settings):
 
 
 @responses.activate
+@respx.mock
 def test_authentication_user_not_added_to_brevo_without_list_id(monkeypatch, rf, settings):
     """
     Test that no Brevo call is made when BREVO_FOLLOWUP_LIST_ID is not configured.
@@ -670,9 +672,8 @@ def test_authentication_user_not_added_to_brevo_without_list_id(monkeypatch, rf,
 
     settings.BREVO_API_KEY = "test-api-key"
 
-    brevo_create_contact = responses.post(
-        "https://api.brevo.com/v3/contacts",
-        status=200,
+    brevo_create_contact = respx.post("https://api.brevo.com/v3/contacts").mock(
+        return_value=httpx.Response(200)
     )
 
     klass = OIDCAuthenticationBackend()
@@ -713,6 +714,7 @@ def test_authentication_user_not_added_to_brevo_without_list_id(monkeypatch, rf,
 
 
 @responses.activate
+@respx.mock
 def test_authentication_role_denied_user_not_added_to_brevo(monkeypatch, rf, settings):
     """
     Test that a user denied by the role gate is not added to the Brevo list.
@@ -722,14 +724,12 @@ def test_authentication_role_denied_user_not_added_to_brevo(monkeypatch, rf, set
     settings.BREVO_FOLLOWUP_LIST_ID = "follow-up-list-id"
     settings.OIDC_ALLOWED_ROLES = ["agent_public_etat"]
 
-    brevo_create_contact = responses.post(
-        "https://api.brevo.com/v3/contacts",
-        status=200,
+    brevo_create_contact = respx.post("https://api.brevo.com/v3/contacts").mock(
+        return_value=httpx.Response(200)
     )
-    brevo_add_to_list = responses.post(
-        "https://api.brevo.com/v3/contacts/lists/follow-up-list-id/contacts/add",
-        status=200,
-    )
+    brevo_add_to_list = respx.post(
+        "https://api.brevo.com/v3/contacts/lists/follow-up-list-id/contacts/add"
+    ).mock(return_value=httpx.Response(200))
 
     klass = OIDCAuthenticationBackend()
     request = rf.get("/some-url", {"state": "test-state", "code": "test-code"})

--- a/src/backend/core/tests/test_brevo.py
+++ b/src/backend/core/tests/test_brevo.py
@@ -2,7 +2,8 @@
 
 import logging
 
-import responses
+import httpx
+import respx
 
 from core.brevo import add_user_to_brevo_list
 
@@ -17,15 +18,14 @@ def brevo_logs(caplog):
     return [record.levelno for record in caplog.records if record.name == "core.brevo"]
 
 
-@responses.activate
+@respx.mock
 def test_add_user_to_brevo_list_success(settings, caplog):
     """Adding a new contact to a list is not logged."""
     settings.BREVO_API_KEY = "test-api-key"
 
-    responses.post("https://api.brevo.com/v3/contacts", status=201)
-    add_to_list = responses.post(
-        "https://api.brevo.com/v3/contacts/lists/list-id/contacts/add",
-        status=201,
+    respx.post("https://api.brevo.com/v3/contacts").mock(return_value=httpx.Response(201))
+    add_to_list = respx.post("https://api.brevo.com/v3/contacts/lists/list-id/contacts/add").mock(
+        return_value=httpx.Response(201)
     )
 
     with caplog.at_level(logging.INFO, logger="core.brevo"):
@@ -35,7 +35,7 @@ def test_add_user_to_brevo_list_success(settings, caplog):
     assert brevo_logs(caplog) == []
 
 
-@responses.activate
+@respx.mock
 def test_add_user_to_brevo_list_already_in_list_is_not_an_error(settings, caplog):
     """
     Brevo answers 400 when the contact is already in the list.
@@ -46,11 +46,9 @@ def test_add_user_to_brevo_list_already_in_list_is_not_an_error(settings, caplog
     """
     settings.BREVO_API_KEY = "test-api-key"
 
-    responses.post("https://api.brevo.com/v3/contacts", status=204)
-    responses.post(
-        "https://api.brevo.com/v3/contacts/lists/list-id/contacts/add",
-        json=ALREADY_IN_LIST_BODY,
-        status=400,
+    respx.post("https://api.brevo.com/v3/contacts").mock(return_value=httpx.Response(204))
+    respx.post("https://api.brevo.com/v3/contacts/lists/list-id/contacts/add").mock(
+        return_value=httpx.Response(400, json=ALREADY_IN_LIST_BODY)
     )
 
     with caplog.at_level(logging.INFO, logger="core.brevo"):
@@ -59,16 +57,14 @@ def test_add_user_to_brevo_list_already_in_list_is_not_an_error(settings, caplog
     assert brevo_logs(caplog) == [logging.INFO]
 
 
-@responses.activate
+@respx.mock
 def test_add_user_to_brevo_list_genuine_failure_still_logs_an_error(settings, caplog):
     """Any other Brevo failure is still reported as an error."""
     settings.BREVO_API_KEY = "test-api-key"
 
-    responses.post("https://api.brevo.com/v3/contacts", status=204)
-    responses.post(
-        "https://api.brevo.com/v3/contacts/lists/list-id/contacts/add",
-        json={"code": "unauthorized", "message": "Key not found"},
-        status=401,
+    respx.post("https://api.brevo.com/v3/contacts").mock(return_value=httpx.Response(204))
+    respx.post("https://api.brevo.com/v3/contacts/lists/list-id/contacts/add").mock(
+        return_value=httpx.Response(401, json={"code": "unauthorized", "message": "Key not found"})
     )
 
     with caplog.at_level(logging.INFO, logger="core.brevo"):
@@ -77,16 +73,16 @@ def test_add_user_to_brevo_list_genuine_failure_still_logs_an_error(settings, ca
     assert brevo_logs(caplog) == [logging.ERROR]
 
 
-@responses.activate
+@respx.mock
 def test_add_user_to_brevo_list_other_400_still_logs_an_error(settings, caplog):
     """A 400 that is not the 'already in list' one is still an error."""
     settings.BREVO_API_KEY = "test-api-key"
 
-    responses.post("https://api.brevo.com/v3/contacts", status=204)
-    responses.post(
-        "https://api.brevo.com/v3/contacts/lists/list-id/contacts/add",
-        json={"code": "invalid_parameter", "message": "Invalid list id"},
-        status=400,
+    respx.post("https://api.brevo.com/v3/contacts").mock(return_value=httpx.Response(204))
+    respx.post("https://api.brevo.com/v3/contacts/lists/list-id/contacts/add").mock(
+        return_value=httpx.Response(
+            400, json={"code": "invalid_parameter", "message": "Invalid list id"}
+        )
     )
 
     with caplog.at_level(logging.INFO, logger="core.brevo"):

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -43,6 +43,7 @@ dependencies = [
     "dockerflow==2026.3.4",
     "factory_boy==3.3.3",
     "gunicorn==26.0.0",
+    "httpx==0.28.1",
     "jsonschema==4.26.0",
     "langfuse==4.7.1",
     "lxml==6.1.1",
@@ -57,7 +58,6 @@ dependencies = [
     "PyJWT==2.13.0",
     "python-magic==0.4.27",
     "redis<6.0.0",
-    "requests==2.34.2",
     "semchunk==4.0.0",
     "sentry-sdk==2.61.1",
     "trafilatura==2.1.0",
@@ -98,7 +98,6 @@ dev = [
     "responses==0.26.1",
     "respx==0.23.1",
     "ruff==0.15.16",
-    "types-requests==2.33.0.20260518",
     "debugpy>=1.8.20",
 ]
 

--- a/src/backend/uv.lock
+++ b/src/backend/uv.lock
@@ -521,6 +521,7 @@ dependencies = [
     { name = "drf-spectacular" },
     { name = "factory-boy" },
     { name = "gunicorn" },
+    { name = "httpx" },
     { name = "jsonschema" },
     { name = "langfuse" },
     { name = "lxml" },
@@ -537,7 +538,6 @@ dependencies = [
     { name = "pypdf" },
     { name = "python-magic" },
     { name = "redis" },
-    { name = "requests" },
     { name = "semchunk" },
     { name = "sentry-sdk" },
     { name = "tiktoken" },
@@ -570,7 +570,6 @@ dev = [
     { name = "responses" },
     { name = "respx" },
     { name = "ruff" },
-    { name = "types-requests" },
 ]
 
 [package.metadata]
@@ -600,6 +599,7 @@ requires-dist = [
     { name = "factory-boy", specifier = "==3.3.3" },
     { name = "freezegun", marker = "extra == 'dev'", specifier = "==1.5.5" },
     { name = "gunicorn", specifier = "==26.0.0" },
+    { name = "httpx", specifier = "==0.28.1" },
     { name = "ipdb", marker = "extra == 'dev'", specifier = "==0.13.13" },
     { name = "ipython", marker = "extra == 'dev'", specifier = "==9.14.1" },
     { name = "jsonschema", specifier = "==4.26.0" },
@@ -629,7 +629,6 @@ requires-dist = [
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = "==3.8.0" },
     { name = "python-magic", specifier = "==0.4.27" },
     { name = "redis", specifier = "<6.0.0" },
-    { name = "requests", specifier = "==2.34.2" },
     { name = "responses", marker = "extra == 'dev'", specifier = "==0.26.1" },
     { name = "respx", marker = "extra == 'dev'", specifier = "==0.23.1" },
     { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.16" },
@@ -637,7 +636,6 @@ requires-dist = [
     { name = "sentry-sdk", specifier = "==2.61.1" },
     { name = "tiktoken", specifier = "==0.13.0" },
     { name = "trafilatura", specifier = "==2.1.0" },
-    { name = "types-requests", marker = "extra == 'dev'", specifier = "==2.33.0.20260518" },
     { name = "uvicorn", specifier = "==0.49.0" },
     { name = "whitenoise", specifier = "==6.12.0" },
 ]
@@ -3284,18 +3282,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
-]
-
-[[package]]
-name = "types-requests"
-version = "2.33.0.20260518"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "urllib3" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e0/01/c5a19253fe1ac159159ddf9a3a07cec8bb5e486ec4d9002ad2821da0e5d2/types_requests-2.33.0.20260518.tar.gz", hash = "sha256:df7bd3bfe0ca8402dfb841e7d9be714bb5578203283d66d7dc4ef69343449a5e", size = 24752, upload-time = "2026-05-18T06:07:37.966Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1c/bc/b139710a3b6018f7fb2b9508b35c8af564e61bf2bf4fa619d088f3e16f85/types_requests-2.33.0.20260518-py3-none-any.whl", hash = "sha256:626d697d1adaaff76e2044dc8c5c051d8f21abc157bdfe204a75558076fe0bf0", size = 21391, upload-time = "2026-05-18T06:07:37.044Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Purpose

The backend relied on two HTTP client libraries at once. One is mandatory, because the agent framework and every asynchronous code path require it. The other covered the synchronous calls purely by habit. Carrying both meant the same remote API was called through two different libraries, the error classification had to map two separate exception hierarchies, and the test suite needed two mocking libraries. This unifies all outbound HTTP on a single client.

## Proposal

- [ ] Move every outbound call in the backend onto one HTTP client
- [ ] Declare and pin that client, which until now was only ever installed as an indirect dependency despite being imported directly
- [ ] Simplify the error classification so it maps a single exception hierarchy
- [ ] Realign the synchronous and asynchronous document upload paths, which had silently drifted apart because each library encodes multipart form fields differently
- [ ] Migrate the affected HTTP mocks in the test suite to the mocking library that matches the new client
- [ ] Extend the test network guard to cover the new transport, so an unmocked call still fails loudly instead of reaching the network

Three test modules deliberately keep the previous mocking library, because they mock traffic emitted by third party dependencies that continue to use the old client internally.

NB: we'll move to httpx2 when pydantic libs use it 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Standardized outbound service communication to improve consistency across document processing, search, notifications, and health checks.
  * Preserved existing request handling, response validation, retry behavior, and error reporting.
  * Strengthened protection against unintended external requests during automated validation.

* **Documentation**
  * Updated the unreleased changelog to reflect the standardized HTTP communication approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->