### PR TITLE
📈(posthog) track projects, Docs export, summarization and co2 footprint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to
 ### Added
 
 - 💄(settings) move analytics settings to general
+- 📈(posthog) track projects, Docs export, summarization and co2 footprint
 
 ### Changed
 

--- a/src/backend/chat/clients/pydantic_ai.py
+++ b/src/backend/chat/clients/pydantic_ai.py
@@ -126,6 +126,7 @@ from pydantic_ai.messages import (
 )
 from pydantic_ai.models import Model, infer_model_profile
 
+from core.analytics import acapture_event
 from core.feature_flags.helpers import is_feature_enabled
 
 from chat import models
@@ -811,6 +812,14 @@ class AIAgentService:  # pylint: disable=too-many-instance-attributes
         )
         if should_emit_summary_event:
             tool_call_id = str(uuid.uuid4())
+            summarization_started_at = time.monotonic()
+            # Reported before the yield: the consumer may drop the stream there,
+            # which would kill this generator and lose the start of the funnel.
+            await acapture_event(
+                "conversation_summarization_started",
+                self.user.pk,
+                properties={"conversation_id": str(self.conversation.pk)},
+            )
             yield events_v4.ToolCallPart(
                 tool_call_id=tool_call_id,
                 tool_name="summarize",
@@ -835,9 +844,25 @@ class AIAgentService:  # pylint: disable=too-many-instance-attributes
                 context_messages=settings.CONVERSATION_SUMMARY_CONTEXT_MESSAGES,
             ):
                 # No summary landed and still over budget: no degraded turn.
+                await acapture_event(
+                    "conversation_summarization_failed",
+                    self.user.pk,
+                    properties={
+                        "conversation_id": str(self.conversation.pk),
+                        "waited_seconds": round(time.monotonic() - summarization_started_at, 3),
+                    },
+                )
                 raise SummarizationRequiredError(
                     "Conversation summary did not land while the history exceeds the budget."
                 )
+            await acapture_event(
+                "conversation_summarization_succeeded",
+                self.user.pk,
+                properties={
+                    "conversation_id": str(self.conversation.pk),
+                    "waited_seconds": round(time.monotonic() - summarization_started_at, 3),
+                },
+            )
             yield events_v4.ToolResultPart(
                 tool_call_id=tool_call_id,
                 result={"state": "done"},

--- a/src/backend/chat/tests/clients/pydantic_ai/test_run_agent_summary.py
+++ b/src/backend/chat/tests/clients/pydantic_ai/test_run_agent_summary.py
@@ -508,3 +508,83 @@ async def test_run_agent_fails_when_summary_never_lands(ui_messages):
             _ = [event async for event in service._run_agent(ui_messages)]
 
     task.delay.assert_called_once_with(str(conversation.pk))
+
+
+def _captured_events(mock_posthog):
+    """The PostHog event names captured, in order."""
+    return [call.args[0] for call in mock_posthog.capture.call_args_list]
+
+
+@pytest.mark.asyncio
+async def test_run_agent_captures_the_summarization_funnel(ui_messages, settings):
+    """A summarized turn reports its start and its success, attributed to the user."""
+    settings.POSTHOG_KEY = {"id": "key", "host": "https://posthog.test"}
+    conversation = await sync_to_async(ChatConversationFactory)()
+    service = AIAgentService(conversation, user=conversation.owner)
+
+    with (
+        _run_agent_patches(service),
+        patch(
+            "chat.clients.pydantic_ai.should_generate_conversation_summary",
+            side_effect=[True, False],  # over budget, then the summary lands
+        ),
+        patch("chat.clients.pydantic_ai.summarize_conversation_history"),
+        patch.object(service, "_wait_for_history_summary", side_effect=_empty_async_gen),
+        patch("core.analytics.posthog") as mock_posthog,
+    ):
+        _ = [event async for event in service._run_agent(ui_messages)]
+
+    assert _captured_events(mock_posthog) == [
+        "conversation_summarization_started",
+        "conversation_summarization_succeeded",
+    ]
+    success = mock_posthog.capture.call_args_list[1]
+    assert success.kwargs["distinct_id"] == str(conversation.owner.pk)
+    assert success.kwargs["properties"]["conversation_id"] == str(conversation.pk)
+    assert success.kwargs["properties"]["waited_seconds"] >= 0
+
+
+@pytest.mark.asyncio
+async def test_run_agent_captures_the_summarization_failure(ui_messages, settings):
+    """A turn that fails for want of a summary reports the failure after the start."""
+    settings.POSTHOG_KEY = {"id": "key", "host": "https://posthog.test"}
+    conversation = await sync_to_async(ChatConversationFactory)()
+    service = AIAgentService(conversation, user=conversation.owner)
+
+    with (
+        _run_agent_patches(service),
+        patch(
+            "chat.clients.pydantic_ai.should_generate_conversation_summary",
+            side_effect=[True, True],  # still over budget after the fruitless wait
+        ),
+        patch("chat.clients.pydantic_ai.summarize_conversation_history"),
+        patch.object(service, "_wait_for_history_summary", side_effect=_empty_async_gen),
+        patch("core.analytics.posthog") as mock_posthog,
+    ):
+        with pytest.raises(SummarizationRequiredError):
+            _ = [event async for event in service._run_agent(ui_messages)]
+
+    assert _captured_events(mock_posthog) == [
+        "conversation_summarization_started",
+        "conversation_summarization_failed",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_run_agent_captures_nothing_without_summarization(ui_messages, settings):
+    """A turn that stays within budget reports no summarization event at all."""
+    settings.POSTHOG_KEY = {"id": "key", "host": "https://posthog.test"}
+    conversation = await sync_to_async(ChatConversationFactory)()
+    service = AIAgentService(conversation, user=conversation.owner)
+
+    with (
+        _run_agent_patches(service),
+        patch(
+            "chat.clients.pydantic_ai.should_generate_conversation_summary",
+            return_value=False,
+        ),
+        patch("core.analytics.posthog") as mock_posthog,
+    ):
+        _ = [event async for event in service._run_agent(ui_messages)]
+
+    mock_posthog.capture.assert_not_called()

--- a/src/backend/chat/tests/views/attachments/test_attachments.py
+++ b/src/backend/chat/tests/views/attachments/test_attachments.py
@@ -143,7 +143,7 @@ def test_attachment_retrieve_success(api_client, upload_state, expected_url_pres
 
 
 @override_settings(POSTHOG_KEY="test_key")
-@mock.patch("chat.views.attachments.posthog")
+@mock.patch("core.analytics.posthog")
 @mock.patch("chat.views.attachments.malware_detection.analyse_file")
 def test_upload_ended_success(mock_analyse_file, mock_posthog, api_client):
     """
@@ -182,6 +182,7 @@ def test_upload_ended_success(mock_analyse_file, mock_posthog, api_client):
         conversation_id=attachment.conversation.pk,
     )
     mock_posthog.capture.assert_called_once()
+    assert mock_posthog.capture.call_args.kwargs["properties"]["holder"] == "conversation"
 
 
 def test_upload_ended_not_pending(api_client):

--- a/src/backend/chat/tests/views/attachments/test_project_attachments.py
+++ b/src/backend/chat/tests/views/attachments/test_project_attachments.py
@@ -243,7 +243,7 @@ def test_project_attachment_retrieve_success(api_client, upload_state, expected_
 
 
 @override_settings(POSTHOG_KEY="test_key")
-@mock.patch("chat.views.attachments.posthog")
+@mock.patch("core.analytics.posthog")
 @mock.patch("chat.views.attachments.malware_detection.analyse_file")
 def test_project_upload_ended_success(mock_analyse_file, mock_posthog, api_client):
     """The 'upload_ended' action should change the attachment state and trigger analysis."""
@@ -278,6 +278,9 @@ def test_project_upload_ended_success(mock_analyse_file, mock_posthog, api_clien
         project_id=attachment.project.pk,
     )
     mock_posthog.capture.assert_called_once()
+    # Conversation and project uploads share this action: without the holder
+    # they are indistinguishable in PostHog.
+    assert mock_posthog.capture.call_args.kwargs["properties"]["holder"] == "project"
 
 
 def test_project_upload_ended_not_pending(api_client):

--- a/src/backend/chat/tests/views/chat/conversations/test_edit_in_docs.py
+++ b/src/backend/chat/tests/views/chat/conversations/test_edit_in_docs.py
@@ -399,3 +399,87 @@ def test_conditional_refresh_passthrough_when_refresh_disabled(settings):
         return None
 
     assert conditional_refresh_oidc_token(action) is action
+
+
+# ---------------------------------------------------------------------------
+# Analytics
+# ---------------------------------------------------------------------------
+def _export_the_message(api_client, conversation, settings, create_document):
+    """Drive one edit-in-docs export and return the PostHog capture mock."""
+    settings.DOCS_BASE_URL = "http://docs.example.com/"
+    settings.OIDC_STORE_ACCESS_TOKEN = True
+    settings.POSTHOG_KEY = {"id": "key", "host": "https://posthog.test"}
+
+    api_client.force_login(conversation.owner)
+    session = api_client.session
+    session["oidc_access_token"] = "test-token"
+    session.save()
+
+    url = f"/api/v1.0/chats/{conversation.pk}/edit-in-docs/"
+    with (
+        patch("chat.views.edit_in_docs.DocsClient.create_document", create_document),
+        patch("core.analytics.posthog") as mock_posthog,
+    ):
+        api_client.post(url, data={"message_id": "assistant-message-1"}, format="json")
+
+    return mock_posthog
+
+
+def test_edit_in_docs_captures_a_successful_export(
+    api_client, settings, conversation_with_messages
+):
+    """A successful export reports success, attributed to the exporting user."""
+    conversation = conversation_with_messages
+
+    mock_posthog = _export_the_message(
+        api_client, conversation, settings, MagicMock(return_value={"id": "doc-123"})
+    )
+
+    mock_posthog.capture.assert_called_once()
+    call = mock_posthog.capture.call_args
+    assert call.args[0] == "conversation_exported_to_docs"
+    assert call.kwargs["distinct_id"] == str(conversation.owner.pk)
+    assert call.kwargs["properties"] == {
+        "success": True,
+        "outcome": "success",
+        "docs_status": None,
+    }
+
+
+def test_edit_in_docs_captures_the_status_docs_answered_with(
+    api_client, settings, conversation_with_messages
+):
+    """The Docs status is only knowable server-side, so the failure event carries it."""
+    mock_posthog = _export_the_message(
+        api_client,
+        conversation_with_messages,
+        settings,
+        MagicMock(side_effect=_http_error(status.HTTP_403_FORBIDDEN)),
+    )
+
+    call = mock_posthog.capture.call_args
+    assert call.args[0] == "conversation_exported_to_docs"
+    assert call.kwargs["properties"] == {
+        "success": False,
+        "outcome": "docs_http_error",
+        "docs_status": status.HTTP_403_FORBIDDEN,
+    }
+
+
+def test_edit_in_docs_captures_an_unreachable_docs(
+    api_client, settings, conversation_with_messages
+):
+    """A transport failure is reported apart from a Docs-side rejection."""
+    mock_posthog = _export_the_message(
+        api_client,
+        conversation_with_messages,
+        settings,
+        MagicMock(side_effect=httpx.RequestError("connection refused")),
+    )
+
+    call = mock_posthog.capture.call_args
+    assert call.kwargs["properties"] == {
+        "success": False,
+        "outcome": "docs_unreachable",
+        "docs_status": None,
+    }

--- a/src/backend/chat/tests/views/projects/test_analytics.py
+++ b/src/backend/chat/tests/views/projects/test_analytics.py
@@ -1,0 +1,160 @@
+"""Unit tests for the PostHog events reported by the project viewset."""
+
+from unittest.mock import patch
+
+import pytest
+
+from core.factories import UserFactory
+
+from chat.factories import ChatProjectFactory
+from chat.models import ChatProject, ChatProjectColor, ChatProjectIcon
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture(name="posthog_configured", autouse=True)
+def posthog_configured_fixture(settings):
+    """Configure PostHog so the capture guard lets the events through."""
+    settings.POSTHOG_KEY = {"id": "key", "host": "https://posthog.test"}
+
+
+def test_create_project_is_captured(api_client):
+    """Creating a project reports it, without leaking the title."""
+    user = UserFactory()
+    api_client.force_login(user)
+
+    with patch("core.analytics.posthog") as mock_posthog:
+        response = api_client.post(
+            "/api/v1.0/projects/",
+            {
+                "title": "Quarterly budget",
+                "icon": ChatProjectIcon.FOLDER,
+                "color": ChatProjectColor.COLOR_1,
+                "llm_instructions": "Answer in French.",
+            },
+            format="json",
+        )
+
+    assert response.status_code == 201
+    mock_posthog.capture.assert_called_once()
+    call = mock_posthog.capture.call_args
+    assert call.args[0] == "project_created"
+    assert call.kwargs["distinct_id"] == str(user.pk)
+    assert call.kwargs["properties"] == {
+        "id": str(response.data["id"]),
+        "icon": ChatProjectIcon.FOLDER,
+        "color": ChatProjectColor.COLOR_1,
+        "has_instructions": True,
+    }
+    assert "Quarterly budget" not in str(call.kwargs["properties"])
+
+
+def test_create_project_without_instructions_is_captured(api_client):
+    """`has_instructions` distinguishes a bare project from a customised one."""
+    user = UserFactory()
+    api_client.force_login(user)
+
+    with patch("core.analytics.posthog") as mock_posthog:
+        response = api_client.post(
+            "/api/v1.0/projects/",
+            {
+                "title": "Bare",
+                "icon": ChatProjectIcon.FOLDER,
+                "color": ChatProjectColor.COLOR_1,
+            },
+            format="json",
+        )
+
+    assert response.status_code == 201
+    assert mock_posthog.capture.call_args.kwargs["properties"]["has_instructions"] is False
+
+
+def test_update_project_is_captured(api_client):
+    """Updating a project reports the state it ends up in."""
+    project = ChatProjectFactory(icon=ChatProjectIcon.FOLDER, llm_instructions="")
+    api_client.force_login(project.owner)
+
+    with patch("core.analytics.posthog") as mock_posthog:
+        response = api_client.patch(
+            f"/api/v1.0/projects/{project.pk}/",
+            {"llm_instructions": "Be concise."},
+            format="json",
+        )
+
+    assert response.status_code == 200
+    call = mock_posthog.capture.call_args
+    assert call.args[0] == "project_updated"
+    assert call.kwargs["properties"]["id"] == str(project.pk)
+    assert call.kwargs["properties"]["has_instructions"] is True
+
+
+def test_delete_project_is_captured(api_client):
+    """A project that is really gone reports the identity it had."""
+    project = ChatProjectFactory()
+    api_client.force_login(project.owner)
+
+    with patch("core.analytics.posthog") as mock_posthog:
+        response = api_client.delete(f"/api/v1.0/projects/{project.pk}/")
+
+    assert response.status_code == 204
+    assert not ChatProject.objects.filter(pk=project.pk).exists()
+    call = mock_posthog.capture.call_args
+    assert call.args[0] == "project_deleted"
+    assert call.kwargs["distinct_id"] == str(project.owner.pk)
+    assert call.kwargs["properties"]["id"] == str(project.pk)
+
+
+def test_a_failed_delete_is_not_captured(api_client):
+    """A project the database refused to drop must not report a deletion."""
+    project = ChatProjectFactory()
+    api_client.force_login(project.owner)
+
+    with (
+        patch("core.analytics.posthog") as mock_posthog,
+        patch.object(ChatProject, "delete", side_effect=RuntimeError("delete failed")),
+        pytest.raises(RuntimeError),
+    ):
+        api_client.delete(f"/api/v1.0/projects/{project.pk}/")
+
+    mock_posthog.capture.assert_not_called()
+
+
+def test_nothing_is_captured_without_a_posthog_key(api_client, settings):
+    """With PostHog unconfigured, the viewset must not reach for the SDK."""
+    settings.POSTHOG_KEY = None
+    user = UserFactory()
+    api_client.force_login(user)
+
+    with patch("core.analytics.posthog") as mock_posthog:
+        response = api_client.post(
+            "/api/v1.0/projects/",
+            {
+                "title": "Quiet",
+                "icon": ChatProjectIcon.FOLDER,
+                "color": ChatProjectColor.COLOR_1,
+            },
+            format="json",
+        )
+
+    assert response.status_code == 201
+    mock_posthog.capture.assert_not_called()
+
+
+def test_a_failing_capture_does_not_fail_the_request(api_client):
+    """Analytics is never worth a 500: a broken capture is swallowed."""
+    user = UserFactory()
+    api_client.force_login(user)
+
+    with patch("core.analytics.posthog") as mock_posthog:
+        mock_posthog.capture.side_effect = RuntimeError("posthog is down")
+        response = api_client.post(
+            "/api/v1.0/projects/",
+            {
+                "title": "Resilient",
+                "icon": ChatProjectIcon.FOLDER,
+                "color": ChatProjectColor.COLOR_1,
+            },
+            format="json",
+        )
+
+    assert response.status_code == 201

--- a/src/backend/chat/views/attachments.py
+++ b/src/backend/chat/views/attachments.py
@@ -11,12 +11,12 @@ from django.utils.module_loading import import_string
 from django.utils.translation import gettext_lazy as _
 
 import magic
-import posthog
 from lasuite.malware_detection import malware_detection
 from rest_framework import decorators, mixins, permissions, status, viewsets
 from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
 
+from core.analytics import capture_event
 from core.api.viewsets import SerializerPerActionMixin
 from core.file_upload import enums
 from core.file_upload.enums import AttachmentStatus
@@ -149,17 +149,19 @@ class BaseAttachmentViewSet(
 
         serializer = self.get_serializer(attachment)
 
-        if settings.POSTHOG_KEY:
-            posthog.capture(
-                "item_uploaded",
-                distinct_id=str(request.user.pk),  # same as set by the frontend
-                properties={
-                    "id": attachment.pk,
-                    "file_name": attachment.file_name,
-                    "size": attachment.size,
-                    "mimetype": attachment.content_type,
-                },
-            )
+        capture_event(
+            "item_uploaded",
+            request.user.pk,
+            properties={
+                "id": attachment.pk,
+                "file_name": attachment.file_name,
+                "size": attachment.size,
+                "mimetype": attachment.content_type,
+                # Both subclasses share this action, so without the holder the
+                # project and conversation uploads are indistinguishable.
+                "holder": self.holder_field,
+            },
+        )
 
         return Response(serializer.data, status=status.HTTP_200_OK)
 
@@ -227,18 +229,18 @@ class BaseAttachmentViewSet(
             **self._malware_kwargs(),
         )
 
-        if settings.POSTHOG_KEY:
-            posthog.capture(
-                "item_uploaded_backend",
-                distinct_id=str(request.user.pk),
-                properties={
-                    "id": attachment.pk,
-                    "file_name": attachment.file_name,
-                    "size": attachment.size,
-                    "mimetype": attachment.content_type,
-                    "mode": settings.FILE_UPLOAD_MODE,
-                },
-            )
+        capture_event(
+            "item_uploaded_backend",
+            request.user.pk,
+            properties={
+                "id": attachment.pk,
+                "file_name": attachment.file_name,
+                "size": attachment.size,
+                "mimetype": attachment.content_type,
+                "mode": settings.FILE_UPLOAD_MODE,
+                "holder": self.holder_field,
+            },
+        )
 
         serializer = self.get_serializer(attachment)
         return Response(serializer.data, status=status.HTTP_201_CREATED)

--- a/src/backend/chat/views/edit_in_docs.py
+++ b/src/backend/chat/views/edit_in_docs.py
@@ -17,6 +17,8 @@ from rest_framework import decorators, status
 from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
 
+from core.analytics import capture_event
+
 from chat import serializers
 from chat.docs_client import DocsClient
 from chat.views.helpers import conditional_refresh_oidc_token
@@ -88,6 +90,23 @@ def _docs_http_error_response(exc):
 class EditInDocsMixin:
     """Adds the ``edit-in-docs`` action to a conversation viewset."""
 
+    @staticmethod
+    def _capture_export(request, outcome, docs_status=None):
+        """Report the outcome of a Docs export.
+
+        Docs is called from here, so the browser only ever learns "it failed";
+        the outcome (and the status Docs answered with) is only knowable here.
+        """
+        capture_event(
+            "conversation_exported_to_docs",
+            request.user.pk,
+            properties={
+                "success": outcome == "success",
+                "outcome": outcome,
+                "docs_status": docs_status,
+            },
+        )
+
     @conditional_refresh_oidc_token
     @decorators.action(
         methods=["post"], detail=True, url_path="edit-in-docs", url_name="edit-in-docs"
@@ -145,14 +164,19 @@ class EditInDocsMixin:
         except httpx.HTTPStatusError as exc:
             # Docs answered with a 4xx/5xx — map it to a meaningful client status
             # instead of masking everything as 503.
+            docs_status = exc.response.status_code if exc.response is not None else None
+            self._capture_export(request, "docs_http_error", docs_status=docs_status)
             return _docs_http_error_response(exc)
         except httpx.RequestError as exc:
             # Transport failure (connection refused, timeout, DNS) — Docs unreachable.
             logger.exception("Docs service unreachable during edit-in-docs: %s", exc)
+            self._capture_export(request, "docs_unreachable")
             return Response(
                 {"detail": "Docs service is currently unavailable. Please try again later."},
                 status=status.HTTP_503_SERVICE_UNAVAILABLE,
             )
+
+        self._capture_export(request, "success")
 
         return Response(
             {

--- a/src/backend/chat/views/projects.py
+++ b/src/backend/chat/views/projects.py
@@ -8,6 +8,7 @@ from django.utils.module_loading import import_string
 
 from rest_framework import filters, permissions, viewsets
 
+from core.analytics import capture_event
 from core.api.viewsets import Pagination
 
 from activation_codes.permissions import IsActivatedUser
@@ -44,6 +45,30 @@ class ChatProjectViewSet(viewsets.ModelViewSet):  # pylint: disable=too-many-anc
             if self.request.user.is_authenticated
             else self.queryset.none()
         )
+
+    @staticmethod
+    def _event_properties(project):
+        """Describe a project for analytics, without leaking its title."""
+        return {
+            "id": str(project.pk),
+            "icon": project.icon,
+            "color": project.color,
+            "has_instructions": bool(project.llm_instructions),
+        }
+
+    def _capture(self, event, project):
+        """Report a project lifecycle event, without leaking the project title."""
+        capture_event(event, self.request.user.pk, properties=self._event_properties(project))
+
+    def perform_create(self, serializer):
+        """Create the project, then report it."""
+        project = serializer.save()
+        self._capture("project_created", project)
+
+    def perform_update(self, serializer):
+        """Update the project, then report it."""
+        project = serializer.save()
+        self._capture("project_updated", project)
 
     def perform_destroy(self, instance):
         """Delete a project, its conversations, RAG collections, and S3 blobs.
@@ -101,4 +126,8 @@ class ChatProjectViewSet(viewsets.ModelViewSet):  # pylint: disable=too-many-anc
                     instance.pk,
                 )
         _bulk_delete_s3_blobs(attachment_keys)
+        # Snapshotted first because `instance.delete()` clears `instance.pk`, but
+        # only reported once the delete succeeded, so a failed one stays silent.
+        properties = self._event_properties(instance)
         instance.delete()
+        capture_event("project_deleted", self.request.user.pk, properties=properties)

--- a/src/backend/core/analytics.py
+++ b/src/backend/core/analytics.py
@@ -1,0 +1,40 @@
+"""Product event capture towards PostHog."""
+
+import asyncio
+import logging
+
+from django.conf import settings
+
+import posthog
+
+logger = logging.getLogger(__name__)
+
+
+def capture_event(event: str, user_id, properties: dict | None = None) -> None:
+    """Send a product event to PostHog, when PostHog is configured.
+
+    `user_id` must be the user's primary key: the frontend identifies people by
+    that same value, so browser and backend events land on the same person.
+
+    Properties must stay free of user content (titles, file names, prompts).
+
+    Analytics is never worth failing a request over, so capture errors are
+    logged and swallowed.
+    """
+    if not settings.POSTHOG_KEY:
+        return
+
+    try:
+        posthog.capture(event, distinct_id=str(user_id), properties=properties)
+    except Exception:  # pylint: disable=broad-except
+        logger.exception("Failed to capture the PostHog event %s", event)
+
+
+async def acapture_event(event: str, user_id, properties: dict | None = None) -> None:
+    """`capture_event` for async code paths.
+
+    The PostHog client only enqueues onto a background worker, but the streaming
+    generators must not call into third-party SDKs directly (same rule as the
+    Langfuse calls), so the capture runs off the event loop.
+    """
+    await asyncio.to_thread(capture_event, event, user_id, properties)

--- a/src/frontend/apps/conversations/src/features/chat/components/MessageEnergyIndicator.tsx
+++ b/src/frontend/apps/conversations/src/features/chat/components/MessageEnergyIndicator.tsx
@@ -12,6 +12,7 @@ import ArrowUpRightIcon from '@/assets/icons/uikit-custom/arrow-up-right.svg?rea
 import LeavesIcon from '@/assets/icons/uikit-custom/leaves.svg?react';
 import { Box, Text } from '@/components';
 import { useCunninghamTheme } from '@/cunningham';
+import { useAnalytics } from '@/libs';
 import { useResponsiveStore } from '@/stores';
 
 import {
@@ -40,6 +41,7 @@ export const MessageEnergyIndicator = ({
   const { isMobile } = useResponsiveStore();
   const theme = useCunninghamTheme((state) => state.theme);
   const modal = useModal();
+  const { trackEvent } = useAnalytics();
   const impactLabel = t('This request: {{co2}}', {
     co2: formatCo2Impact(co2ImpactKg),
   });
@@ -71,6 +73,14 @@ export const MessageEnergyIndicator = ({
     [dataSearch],
   );
 
+  const handleOpen = () => {
+    trackEvent({
+      eventName: 'carbon_footprint_opened',
+      properties: { co2_impact_kg: co2ImpactKg },
+    });
+    modal.open();
+  };
+
   const button = (
     <Button
       size="nano"
@@ -80,7 +90,7 @@ export const MessageEnergyIndicator = ({
       data-testid="message-energy-indicator"
       icon={<LeavesIcon width={14} height={14} aria-hidden />}
       className="c__button--neutral action-chat-button"
-      onClick={() => modal.open()}
+      onClick={handleOpen}
     />
   );
 

--- a/src/frontend/apps/conversations/src/features/chat/components/__tests__/MessageEnergyIndicator.test.tsx
+++ b/src/frontend/apps/conversations/src/features/chat/components/__tests__/MessageEnergyIndicator.test.tsx
@@ -1,7 +1,9 @@
 import { CunninghamProvider } from '@gouvfr-lasuite/cunningham-react';
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { Fragment } from 'react';
 
+import { AbstractAnalytic, AnalyticEvent, Analytics } from '@/libs';
 import { useResponsiveStore } from '@/stores';
 
 import { buildImpactCo2ComparateurUrl } from '../../utils/impactCo2';
@@ -22,6 +24,22 @@ vi.mock('@/stores', () => ({
 }));
 
 const mockUseResponsiveStore = vi.mocked(useResponsiveStore);
+
+const trackEventMock = vi.fn();
+
+class TestAnalytic extends AbstractAnalytic {
+  public Provider() {
+    return <Fragment />;
+  }
+
+  public trackEvent(evt: AnalyticEvent) {
+    trackEventMock(evt);
+  }
+
+  public isFeatureFlagActivated(): boolean {
+    return true;
+  }
+}
 
 const setResponsive = (isMobile: boolean) =>
   mockUseResponsiveStore.mockReturnValue({
@@ -44,6 +62,9 @@ const renderIndicator = () =>
 
 describe('MessageEnergyIndicator', () => {
   beforeEach(() => {
+    trackEventMock.mockClear();
+    Analytics.clearAnalytics();
+    new TestAnalytic();
     setResponsive(false);
   });
 
@@ -78,6 +99,20 @@ describe('MessageEnergyIndicator', () => {
     await user.click(screen.getByRole('button', { name: 'OK' }));
 
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('captures the carbon footprint opening, not the mere render', async () => {
+    const user = userEvent.setup();
+    renderIndicator();
+
+    expect(trackEventMock).not.toHaveBeenCalled();
+
+    await user.click(screen.getByLabelText('Carbon impact'));
+
+    expect(trackEventMock).toHaveBeenCalledWith({
+      eventName: 'carbon_footprint_opened',
+      properties: { co2_impact_kg: TEST_CO2_IMPACT_KG },
+    });
   });
 
   it('renders the impactco2 widget container in the modal', async () => {

--- a/src/frontend/apps/conversations/src/libs/Analytics.tsx
+++ b/src/frontend/apps/conversations/src/libs/Analytics.tsx
@@ -10,7 +10,33 @@ type AnalyticEventUser = {
   sub?: string;
 };
 
-export type AnalyticEvent = AnalyticEventClick | AnalyticEventUser;
+/**
+ * Product events forwarded as-is to the analytics backends. Listed here so
+ * every captured name is discoverable from a single place, and so a typo in a
+ * call site fails the build instead of creating a stray event.
+ *
+ * Only purely client-side interactions belong here: anything that maps to an
+ * API call is captured by the backend instead, where the outcome is known for
+ * certain and no ad blocker can drop it.
+ *
+ * Properties must stay free of user content (no titles, file names, prompts).
+ */
+export type AnalyticFeatureEventName = 'carbon_footprint_opened';
+
+export type AnalyticEventProperties = Record<
+  string,
+  string | number | boolean | undefined
+>;
+
+type AnalyticEventFeature = {
+  eventName: AnalyticFeatureEventName;
+  properties?: AnalyticEventProperties;
+};
+
+export type AnalyticEvent =
+  | AnalyticEventClick
+  | AnalyticEventUser
+  | AnalyticEventFeature;
 
 export abstract class AbstractAnalytic {
   public constructor() {

--- a/src/frontend/apps/conversations/src/services/PosthogAnalytic.tsx
+++ b/src/frontend/apps/conversations/src/services/PosthogAnalytic.tsx
@@ -24,7 +24,16 @@ export class PostHogAnalytic extends AbstractAnalytic {
       if (evt.sub) {
         posthog.alias(evt.sub, evt.id);
       }
+      return;
     }
+
+    // `click` is a legacy placeholder that nothing emits and that carries no
+    // payload worth capturing.
+    if (evt.eventName === 'click') {
+      return;
+    }
+
+    posthog.capture(evt.eventName, evt.properties);
   }
 
   public isFeatureFlagActivated(flagName: string): boolean {

--- a/src/frontend/apps/conversations/src/services/__tests__/PosthogAnalytic.test.tsx
+++ b/src/frontend/apps/conversations/src/services/__tests__/PosthogAnalytic.test.tsx
@@ -1,0 +1,64 @@
+import posthog from 'posthog-js';
+import { PropsWithChildren } from 'react';
+
+import { PostHogAnalytic } from '../PosthogAnalytic';
+
+vi.mock('posthog-js', () => ({
+  default: {
+    identify: vi.fn(),
+    alias: vi.fn(),
+    capture: vi.fn(),
+  },
+}));
+
+vi.mock('posthog-js/react', () => ({
+  PostHogProvider: ({ children }: PropsWithChildren) => children,
+}));
+
+describe('PostHogAnalytic.trackEvent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('identifies the user instead of capturing an event', () => {
+    new PostHogAnalytic().trackEvent({
+      eventName: 'user',
+      id: 'user-id',
+      email: 'user@example.com',
+      sub: 'user-sub',
+    });
+
+    expect(posthog.identify).toHaveBeenCalledWith('user-id', {
+      email: 'user@example.com',
+    });
+    expect(posthog.alias).toHaveBeenCalledWith('user-sub', 'user-id');
+    expect(posthog.capture).not.toHaveBeenCalled();
+  });
+
+  it('captures a feature event with its properties', () => {
+    new PostHogAnalytic().trackEvent({
+      eventName: 'carbon_footprint_opened',
+      properties: { co2_impact_kg: 0.0002 },
+    });
+
+    expect(posthog.capture).toHaveBeenCalledWith('carbon_footprint_opened', {
+      co2_impact_kg: 0.0002,
+    });
+  });
+
+  it('captures a feature event that carries no properties', () => {
+    new PostHogAnalytic().trackEvent({ eventName: 'carbon_footprint_opened' });
+
+    expect(posthog.capture).toHaveBeenCalledWith(
+      'carbon_footprint_opened',
+      undefined,
+    );
+  });
+
+  it('ignores the payload-less legacy click event', () => {
+    new PostHogAnalytic().trackEvent({ eventName: 'click' });
+
+    expect(posthog.capture).not.toHaveBeenCalled();
+    expect(posthog.identify).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Purpose

Product usage is only partly visible today. A couple of upload events are reported from the server, the rest of the product is invisible, and the browser side layer meant to report feature usage was never actually sending anything.

This adds coverage for the features we want to measure - projects, export to Docs, conversation summarization and the carbon footprint modal - and puts each event where its outcome is genuinely known rather than merely guessed at.

## Proposal

- [ ] Add a shared server side capture helper so every event goes through one       guarded, failure tolerant path
- [ ] Report project creation, update and deletion
- [ ] Report the outcome of an export to Docs, including why it failed when it does
- [ ] Report the conversation summarization funnel, along with how long the user waited
- [ ] Tell project uploads apart from conversation uploads, which until now shared  a single indistinguishable event
- [ ] Make the browser analytics layer actually forward feature events, and report the carbon footprint modal from there since it maps to no server call
- [ ] Keep every new event free of user content: no titles, file names or prompts
- [ ] Cover the new events with tests on both sides

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added analytics tracking for project creation, updates, and deletion.
  * Added tracking for document export outcomes, including successful and failed exports.
  * Added conversation summarization start, completion, and failure tracking.
  * Added CO₂ footprint indicator interaction tracking.
  * Improved attachment upload analytics with conversation or project context.
* **Refactor**
  * Centralized analytics handling for consistent event capture and safer failure handling.
  * Analytics failures are now handled without disrupting normal application activity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->