### PR TITLE
Update ai sdk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,12 +28,13 @@ and this project adheres to
 - ✨(back) sort conversations by stored size in the admin list
 - 🚸(back) show 200 conversations per admin list page for bulk actions
 - ♻️(back) split the settings module into per-domain configuration mixins
+- ⬆️(chat) upgrade the Vercel AI SDK from v4 to v5
 
 ### Fixed
 
 - 🐛(front) fix the frontend dev container failing to start
 - 🐛(back) read the OIDC_CREATE_USER setting from its documented env var
-
+ 
 ### Removed
 
 - 🔥(back) remove the unused Albert web search manager and its tool

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to
 - 💄(front) correct icon Docs button
 - ♻️(back) use httpx as the single HTTP client for outbound calls
 - ⬆️(back) update django, pypdf and pydantic-settings
+- ⬆️(chat) upgrade the Vercel AI SDK from v4 to v5
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to
 - 🔥(back) remove the unused Albert web search manager and its tool
 - 🔥(back) remove the unused RAG_WEB_SEARCH_PROMPT_UPDATE setting
 - 🔥(back) remove the unused Tavily web search tool
+- 🔥(back) remove the unused text streaming protocol
 
 ## [0.0.22] - 2026-08-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to
 - 🔥(back) remove the unused RAG_WEB_SEARCH_PROMPT_UPDATE setting
 - 🔥(back) remove the unused Tavily web search tool
 - 🔥(back) remove the activation code gate, keeping past records for history
+- 🔥(back) remove the unused text streaming protocol
 
 ## [0.0.22] - 2026-08-10
 

--- a/src/backend/chat/ai_sdk_types.py
+++ b/src/backend/chat/ai_sdk_types.py
@@ -3,7 +3,19 @@
 from datetime import datetime
 from typing import Any, Dict, List, Literal, Optional, Union
 
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator, model_validator
+
+TOOL_PART_PREFIX = "tool-"
+
+# Stand-in for a v4 attachment stored without a content type.
+DEFAULT_MEDIA_TYPE = "application/octet-stream"
+
+# v4 tool-invocation states, mapped to their v5 equivalent.
+TOOL_STATE_V4_TO_V5 = {
+    "partial-call": "input-streaming",
+    "call": "input-available",
+    "result": "output-available",
+}
 
 # JSONValue type
 JSONValue = Union[None, str, int, float, bool, Dict[str, Any], List[Any]]
@@ -158,26 +170,45 @@ class ReasoningUIPart(BaseModel):
 
     Attributes:
         type: The type of UI part, fixed to 'reasoning'.
-        reasoning: The reasoning text.
-        details: List of reasoning details.
+        text: The reasoning text.
     """
 
     type: Literal["reasoning"]
-    reasoning: str
-    details: List[ReasoningDetail]
+    text: str
 
 
-class ToolInvocationUIPart(BaseModel):
+class ToolUIPart(BaseModel):
     """
     Represents a tool invocation part of a message.
 
     Attributes:
-        type: The type of UI part, fixed to 'tool-invocation'.
-        toolInvocation: The tool invocation details.
+        type: The type of UI part, ``tool-<toolName>``.
+        toolCallId: A unique identifier for the tool call.
+        state: How far the invocation got.
+        input: The arguments the tool was called with.
+        output: The result the tool returned, once it has one.
+        errorText: The failure message, when the invocation errored.
     """
 
-    type: Literal["tool-invocation"]
-    toolInvocation: ToolInvocation
+    type: str
+    toolCallId: str
+    state: Literal["input-streaming", "input-available", "output-available", "output-error"]
+    input: Optional[Any] = None
+    output: Optional[Any] = None
+    errorText: Optional[str] = None
+
+    @field_validator("type")
+    @classmethod
+    def _check_tool_type(cls, value: str) -> str:
+        """The part type carries the tool name, so it must be prefixed."""
+        if not value.startswith(TOOL_PART_PREFIX) or value == TOOL_PART_PREFIX:
+            raise ValueError(f"Tool part type must be '{TOOL_PART_PREFIX}<name>', got {value!r}")
+        return value
+
+    @property
+    def tool_name(self) -> str:
+        """The name of the invoked tool."""
+        return self.type[len(TOOL_PART_PREFIX) :]
 
 
 class LanguageModelV1Source(BaseModel):
@@ -199,17 +230,21 @@ class LanguageModelV1Source(BaseModel):
     providerMetadata: Dict[str, Any]  # LanguageModelV1ProviderMetadata
 
 
-class SourceUIPart(BaseModel):
+class SourceUrlUIPart(BaseModel):
     """
-    Represents a source part of a message.
+    Represents a URL source part of a message.
 
     Attributes:
-        type: The type of UI part, fixed to 'source'.
-        source: The source information.
+        type: The type of UI part, fixed to 'source-url'.
+        sourceId: The ID of the source.
+        url: The URL of the source.
+        title: The title of the source.
     """
 
-    type: Literal["source"]
-    source: LanguageModelV1Source
+    type: Literal["source-url"]
+    sourceId: str
+    url: str
+    title: Optional[str] = None
 
 
 class FileUIPart(BaseModel):
@@ -218,13 +253,20 @@ class FileUIPart(BaseModel):
 
     Attributes:
         type: The type of UI part, fixed to 'file'.
-        mimeType: The MIME type of the file.
-        data: The file data.
+        mediaType: The MIME type of the file.
+        url: The file URL, either hosted or a data URL.
+        filename: Optional name of the file.
+        skipped: Optional marker stamped by the backend when this file was kept
+            on the persisted message but excluded from what the model saw, e.g.
+            an image attached to a chat now pinned to a text-only model.
+            Shape: ``{"reason": "<short_code>"}``.
     """
 
     type: Literal["file"]
-    mimeType: str
-    data: str
+    mediaType: str
+    url: str
+    filename: Optional[str] = None
+    skipped: Optional[Dict[str, Any]] = None
 
 
 class StepStartUIPart(BaseModel):
@@ -241,11 +283,101 @@ class StepStartUIPart(BaseModel):
 UIPart = Union[
     TextUIPart,
     ReasoningUIPart,
-    ToolInvocationUIPart,
-    SourceUIPart,
+    ToolUIPart,
+    SourceUrlUIPart,
     FileUIPart,
     StepStartUIPart,
 ]
+
+
+def upconvert_v4_message(message: Dict[str, Any]) -> Dict[str, Any]:
+    """Bring a v4-shaped message dict up to the v5 shape, in place.
+
+    Conversations stored before the SDK v5 upgrade (and any client still posting
+    v4 messages) go through this on their way in; it is idempotent, so a v5
+    message passes through untouched.
+    """
+    parts = [_upconvert_v4_part(part) for part in message.get("parts") or []]
+
+    # v5 carries files as parts rather than a message-level list. `contentType`
+    # was optional in v4 while `mediaType` is required here, and this runs on
+    # every read: without a fallback one such attachment would fail validation
+    # and take down the whole conversation.
+    for attachment in message.pop("experimental_attachments", None) or []:
+        parts.append(
+            {
+                "type": "file",
+                "mediaType": attachment.get("contentType") or DEFAULT_MEDIA_TYPE,
+                "url": attachment.get("url"),
+                "filename": attachment.get("name"),
+                "skipped": attachment.get("skipped"),
+            }
+        )
+
+    # The deprecated `content` was the only text of messages stored before parts
+    # were populated; keep it readable by giving it a part of its own.
+    content = message.get("content")
+    if content and not any(_part_type(part) == "text" for part in parts):
+        parts.insert(0, {"type": "text", "text": content})
+
+    message["parts"] = parts
+
+    # Annotations became message metadata; this is where the CO2 impact lives.
+    annotations = message.pop("annotations", None)
+    if annotations:
+        metadata = dict(message.get("metadata") or {})
+        for annotation in annotations:
+            if isinstance(annotation, dict):
+                metadata.update(annotation)
+        message["metadata"] = metadata
+
+    return message
+
+
+def _part_type(part: Any) -> Optional[str]:
+    """The ``type`` of a part, which may still be a raw dict or already a model."""
+    return part.get("type") if isinstance(part, dict) else getattr(part, "type", None)
+
+
+def _upconvert_v4_part(part: Dict[str, Any]) -> Dict[str, Any]:
+    """Bring a single v4 message part up to its v5 shape."""
+    if not isinstance(part, dict):
+        return part
+
+    part_type = part.get("type")
+
+    if part_type == "tool-invocation":
+        invocation = part.get("toolInvocation") or {}
+        upconverted = {
+            "type": f"{TOOL_PART_PREFIX}{invocation.get('toolName')}",
+            "toolCallId": invocation.get("toolCallId"),
+            "state": TOOL_STATE_V4_TO_V5.get(invocation.get("state"), "output-available"),
+            "input": invocation.get("args"),
+        }
+        if "result" in invocation:
+            upconverted["output"] = invocation["result"]
+        return upconverted
+
+    if part_type == "reasoning" and "text" not in part:
+        return {"type": "reasoning", "text": part.get("reasoning", "")}
+
+    if part_type == "source":
+        source = part.get("source") or {}
+        return {
+            "type": "source-url",
+            "sourceId": source.get("id"),
+            "url": source.get("url"),
+            "title": source.get("title"),
+        }
+
+    if part_type == "file" and "data" in part:
+        return {
+            "type": "file",
+            "mediaType": part.get("mimeType"),
+            "url": f"data:{part.get('mimeType')};base64,{part['data']}",
+        }
+
+    return part
 
 
 # Message and related types
@@ -256,22 +388,25 @@ class Message(BaseModel):
     Attributes:
         id: A unique identifier for the message.
         createdAt: Optional timestamp when the message was created.
-        experimental_attachments: Optional list of attachments.
         role: The role of the sender (system, user, assistant, or data).
-        annotations: Optional list of annotations.
+        metadata: Optional per-message metadata (token usage, CO2 impact...).
         parts: Optional list of UI parts that make up the message content.
     """
 
     id: str
     createdAt: Optional[datetime] = None
-    content: str  # deprecated, use parts instead
-    reasoning: Optional[str] = None  # deprecated, use parts instead
-    experimental_attachments: Optional[List[Attachment]] = None
+    content: Optional[str] = None  # deprecated, use parts instead
     role: Literal["system", "user", "assistant", "data"]
-    # data: Optional[JSONValue] = None
-    annotations: Optional[List[JSONValue]] = None
-    toolInvocations: Optional[List[ToolInvocation]] = None  # deprecated, use parts instead
+    metadata: Optional[Dict[str, Any]] = None
     parts: Optional[List[UIPart]] = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def _upconvert(cls, value):
+        """Accept v4-shaped messages: stored history and older clients send them."""
+        if isinstance(value, dict):
+            return upconvert_v4_message(dict(value))
+        return value
 
 
 class UIMessage(Message):

--- a/src/backend/chat/ai_sdk_types.py
+++ b/src/backend/chat/ai_sdk_types.py
@@ -3,7 +3,19 @@
 from datetime import datetime
 from typing import Any, Dict, List, Literal, Optional, Union
 
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator, model_validator
+
+TOOL_PART_PREFIX = "tool-"
+
+# Stand-in for a v4 attachment stored without a content type.
+DEFAULT_MEDIA_TYPE = "application/octet-stream"
+
+# v4 tool-invocation states, mapped to their v5 equivalent.
+TOOL_STATE_V4_TO_V5 = {
+    "partial-call": "input-streaming",
+    "call": "input-available",
+    "result": "output-available",
+}
 
 # JSONValue type
 JSONValue = Union[None, str, int, float, bool, Dict[str, Any], List[Any]]
@@ -158,26 +170,45 @@ class ReasoningUIPart(BaseModel):
 
     Attributes:
         type: The type of UI part, fixed to 'reasoning'.
-        reasoning: The reasoning text.
-        details: List of reasoning details.
+        text: The reasoning text.
     """
 
     type: Literal["reasoning"]
-    reasoning: str
-    details: List[ReasoningDetail]
+    text: str
 
 
-class ToolInvocationUIPart(BaseModel):
+class ToolUIPart(BaseModel):
     """
     Represents a tool invocation part of a message.
 
     Attributes:
-        type: The type of UI part, fixed to 'tool-invocation'.
-        toolInvocation: The tool invocation details.
+        type: The type of UI part, ``tool-<toolName>``.
+        toolCallId: A unique identifier for the tool call.
+        state: How far the invocation got.
+        input: The arguments the tool was called with.
+        output: The result the tool returned, once it has one.
+        errorText: The failure message, when the invocation errored.
     """
 
-    type: Literal["tool-invocation"]
-    toolInvocation: ToolInvocation
+    type: str
+    toolCallId: str
+    state: Literal["input-streaming", "input-available", "output-available", "output-error"]
+    input: Optional[Any] = None
+    output: Optional[Any] = None
+    errorText: Optional[str] = None
+
+    @field_validator("type")
+    @classmethod
+    def _check_tool_type(cls, value: str) -> str:
+        """The part type carries the tool name, so it must be prefixed."""
+        if not value.startswith(TOOL_PART_PREFIX) or value == TOOL_PART_PREFIX:
+            raise ValueError(f"Tool part type must be '{TOOL_PART_PREFIX}<name>', got {value!r}")
+        return value
+
+    @property
+    def tool_name(self) -> str:
+        """The name of the invoked tool."""
+        return self.type[len(TOOL_PART_PREFIX) :]
 
 
 class LanguageModelV1Source(BaseModel):
@@ -199,17 +230,21 @@ class LanguageModelV1Source(BaseModel):
     providerMetadata: Dict[str, Any]  # LanguageModelV1ProviderMetadata
 
 
-class SourceUIPart(BaseModel):
+class SourceUrlUIPart(BaseModel):
     """
-    Represents a source part of a message.
+    Represents a URL source part of a message.
 
     Attributes:
-        type: The type of UI part, fixed to 'source'.
-        source: The source information.
+        type: The type of UI part, fixed to 'source-url'.
+        sourceId: The ID of the source.
+        url: The URL of the source.
+        title: The title of the source.
     """
 
-    type: Literal["source"]
-    source: LanguageModelV1Source
+    type: Literal["source-url"]
+    sourceId: str
+    url: str
+    title: Optional[str] = None
 
 
 class FileUIPart(BaseModel):
@@ -218,13 +253,20 @@ class FileUIPart(BaseModel):
 
     Attributes:
         type: The type of UI part, fixed to 'file'.
-        mimeType: The MIME type of the file.
-        data: The file data.
+        mediaType: The MIME type of the file.
+        url: The file URL, either hosted or a data URL.
+        filename: Optional name of the file.
+        skipped: Optional marker stamped by the backend when this file was kept
+            on the persisted message but excluded from what the model saw, e.g.
+            an image attached to a chat now pinned to a text-only model.
+            Shape: ``{"reason": "<short_code>"}``.
     """
 
     type: Literal["file"]
-    mimeType: str
-    data: str
+    mediaType: str
+    url: str
+    filename: Optional[str] = None
+    skipped: Optional[Dict[str, Any]] = None
 
 
 class StepStartUIPart(BaseModel):
@@ -241,11 +283,114 @@ class StepStartUIPart(BaseModel):
 UIPart = Union[
     TextUIPart,
     ReasoningUIPart,
-    ToolInvocationUIPart,
-    SourceUIPart,
+    ToolUIPart,
+    SourceUrlUIPart,
     FileUIPart,
     StepStartUIPart,
 ]
+
+
+def upconvert_v4_message(message: Dict[str, Any]) -> Dict[str, Any]:
+    """Bring a v4-shaped message dict up to the v5 shape, in place.
+
+    Conversations stored before the SDK v5 upgrade (and any client still posting
+    v4 messages) go through this on their way in; it is idempotent, so a v5
+    message passes through untouched.
+    """
+    parts = [_upconvert_v4_part(part) for part in message.get("parts") or []]
+
+    # v5 carries files as parts rather than a message-level list. `contentType`
+    # was optional in v4 while `mediaType` is required here, and this runs on
+    # every read: without a fallback one such attachment would fail validation
+    # and take down the whole conversation.
+    for attachment in message.pop("experimental_attachments", None) or []:
+        parts.append(
+            {
+                "type": "file",
+                "mediaType": attachment.get("contentType") or DEFAULT_MEDIA_TYPE,
+                "url": attachment.get("url"),
+                "filename": attachment.get("name"),
+                "skipped": attachment.get("skipped"),
+            }
+        )
+
+    # The deprecated `content` was the only text of messages stored before parts
+    # were populated; keep it readable by giving it a part of its own.
+    content = message.get("content")
+    if content and not any(_part_type(part) == "text" for part in parts):
+        parts.insert(0, {"type": "text", "text": content})
+
+    message["parts"] = parts
+
+    # Annotations became message metadata; this is where the CO2 impact lives.
+    annotations = message.pop("annotations", None)
+    if annotations:
+        metadata = dict(message.get("metadata") or {})
+        for annotation in annotations:
+            if isinstance(annotation, dict):
+                metadata.update(annotation)
+        message["metadata"] = metadata
+
+    return message
+
+
+def _part_type(part: Any) -> Optional[str]:
+    """The ``type`` of a part, which may still be a raw dict or already a model."""
+    return part.get("type") if isinstance(part, dict) else getattr(part, "type", None)
+
+
+def _upconvert_v4_tool_part(part: Dict[str, Any]) -> Dict[str, Any]:
+    """Bring a v4 ``tool-invocation`` part up to its v5 ``tool-<name>`` shape."""
+    invocation = part.get("toolInvocation") or {}
+    state = TOOL_STATE_V4_TO_V5.get(invocation.get("state"))
+    if state is None:
+        # An invocation stored (or posted) without a known state: only the
+        # presence of a result says whether it ran to completion, and
+        # `output-available` with no output would render as a tool call
+        # that answered nothing.
+        state = "output-available" if "result" in invocation else "input-available"
+
+    upconverted = {
+        "type": f"{TOOL_PART_PREFIX}{invocation.get('toolName')}",
+        "toolCallId": invocation.get("toolCallId"),
+        "state": state,
+        "input": invocation.get("args"),
+    }
+    if "result" in invocation:
+        upconverted["output"] = invocation["result"]
+    return upconverted
+
+
+def _upconvert_v4_part(part: Dict[str, Any]) -> Dict[str, Any]:
+    """Bring a single v4 message part up to its v5 shape."""
+    if not isinstance(part, dict):
+        return part
+
+    part_type = part.get("type")
+
+    if part_type == "tool-invocation":
+        return _upconvert_v4_tool_part(part)
+
+    if part_type == "reasoning" and "text" not in part:
+        return {"type": "reasoning", "text": part.get("reasoning", "")}
+
+    if part_type == "source":
+        source = part.get("source") or {}
+        return {
+            "type": "source-url",
+            "sourceId": source.get("id"),
+            "url": source.get("url"),
+            "title": source.get("title"),
+        }
+
+    if part_type == "file" and "data" in part:
+        return {
+            "type": "file",
+            "mediaType": part.get("mimeType"),
+            "url": f"data:{part.get('mimeType')};base64,{part['data']}",
+        }
+
+    return part
 
 
 # Message and related types
@@ -256,22 +401,25 @@ class Message(BaseModel):
     Attributes:
         id: A unique identifier for the message.
         createdAt: Optional timestamp when the message was created.
-        experimental_attachments: Optional list of attachments.
         role: The role of the sender (system, user, assistant, or data).
-        annotations: Optional list of annotations.
+        metadata: Optional per-message metadata (token usage, CO2 impact...).
         parts: Optional list of UI parts that make up the message content.
     """
 
     id: str
     createdAt: Optional[datetime] = None
-    content: str  # deprecated, use parts instead
-    reasoning: Optional[str] = None  # deprecated, use parts instead
-    experimental_attachments: Optional[List[Attachment]] = None
+    content: Optional[str] = None  # deprecated, use parts instead
     role: Literal["system", "user", "assistant", "data"]
-    # data: Optional[JSONValue] = None
-    annotations: Optional[List[JSONValue]] = None
-    toolInvocations: Optional[List[ToolInvocation]] = None  # deprecated, use parts instead
+    metadata: Optional[Dict[str, Any]] = None
     parts: Optional[List[UIPart]] = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def _upconvert(cls, value):
+        """Accept v4-shaped messages: stored history and older clients send them."""
+        if isinstance(value, dict):
+            return upconvert_v4_message(dict(value))
+        return value
 
 
 class UIMessage(Message):

--- a/src/backend/chat/clients/pydantic_ai.py
+++ b/src/backend/chat/clients/pydantic_ai.py
@@ -13,8 +13,8 @@ changes are needed in views.py or tests.
    If the conversation belongs to a project with custom LLM instructions,
    they are injected as a dynamic agent instruction.
 
-2. **Streaming Entry Points**: `stream_text()` or `stream_data()` are called
-   with user messages. These wrap async generators for sync consumption.
+2. **Streaming Entry Point**: `stream_data()` is called with user messages.
+   It wraps the async generator for sync consumption.
 
 3. **Agent Execution** (`_run_agent`):
    a. Validate last message is from user
@@ -54,13 +54,13 @@ Documents attached to messages go through several stages:
 
 Events flow through several layers:
 
-    _run_agent (yields events)
+    _run_agent (yields v4 events)
         ↓
-    _stream_content (applies encoder)
+    _stream_content (translates to v5, applies encoder)
         ↓
-    stream_text_async / stream_data_async
+    stream_data_async
         ↓
-    stream_text / stream_data (sync wrapper)
+    stream_data (sync wrapper)
 
 The `StreamingState` dataclass tracks mutable state across the streaming process:
 - `tool_is_streaming`: Prevents duplicate tool call events when streaming deltas
@@ -85,7 +85,7 @@ import time
 import uuid
 from contextlib import AsyncExitStack, ExitStack
 from io import BytesIO
-from typing import AsyncGenerator, Callable, Dict, List, Optional, Tuple, Union
+from typing import AsyncGenerator, Dict, List, Optional, Tuple, Union
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -146,8 +146,8 @@ from chat.agents.local_media_url_processors import (
     update_local_urls,
 )
 from chat.ai_sdk_types import (
-    LanguageModelV1Source,
-    SourceUIPart,
+    FileUIPart,
+    SourceUrlUIPart,
     UIMessage,
 )
 from chat.clients.async_to_sync import convert_async_generator_to_sync
@@ -202,6 +202,8 @@ from chat.tools.document_summarize import document_summarize, document_summarize
 from chat.tools.self_documentation import build_self_documentation_payload
 from chat.vercel_ai_sdk.core import events_v4, events_v5
 from chat.vercel_ai_sdk.encoder import CURRENT_EVENT_ENCODER_VERSION, EventEncoder
+from chat.vercel_ai_sdk.encoder.encoder import DONE_FRAME
+from chat.vercel_ai_sdk.encoder.v4_to_v5 import V4ToV5Translator
 
 # Keep at the top of the file to avoid mocking issues
 document_store_backend = import_string(settings.RAG_DOCUMENT_SEARCH_BACKEND)
@@ -254,20 +256,22 @@ def _strip_thinking_parts(history: list[ModelMessage]) -> list[ModelMessage]:
 
 
 def iter_image_attachments(messages: list[UIMessage]):
-    """Yield each image-like attachment across the given messages.
+    """Yield each image-like file part across the given messages.
 
     Single source of truth for the "is this attachment an image?" predicate
     used by readers (``list_images``) and writers (``_mark_image_attachments_skipped``).
     """
     for message in messages:
-        for attachment in message.experimental_attachments or []:
-            if (attachment.contentType or "").startswith(IMAGE_MIME_PREFIX):
-                yield attachment
+        for part in message.parts or []:
+            if isinstance(part, FileUIPart) and (part.mediaType or "").startswith(
+                IMAGE_MIME_PREFIX
+            ):
+                yield part
 
 
 def list_images(messages: list[UIMessage]) -> list[str]:
     """Return names of every image attachment across the message history."""
-    return [a.name for a in iter_image_attachments(messages) if a.name is not None]
+    return [part.filename for part in iter_image_attachments(messages) if part.filename]
 
 
 def _extract_co2_from_usage(usage: RunUsage) -> float:
@@ -315,7 +319,11 @@ class AIAgentService:  # pylint: disable=too-many-instance-attributes
         self._langfuse_available = settings.LANGFUSE_ENABLED
         self._store_analytics = self._langfuse_available and user.allow_conversation_analytics
         self._langfuse_span = None
-        self.event_encoder = EventEncoder(CURRENT_EVENT_ENCODER_VERSION)  # We use v4 for now
+        self.event_encoder = EventEncoder(CURRENT_EVENT_ENCODER_VERSION)
+        # Id of the assistant message of the current stream, announced to the
+        # client in the `start` frame and persisted with the message. Set per
+        # stream by _stream_content.
+        self._model_response_message_id: str | None = None
 
         self._support_streaming = True
         if (streaming := self.model_configuration.supports_streaming) is not None:
@@ -394,10 +402,6 @@ class AIAgentService:  # pylint: disable=too-many-instance-attributes
     # Public streaming API (unchanged signatures)
     # --------------------------------------------------------------------- #
 
-    def stream_text(self, messages: List[UIMessage], force_web_search: bool = False):
-        """Return only the assistant text deltas (legacy text mode)."""
-        return convert_async_generator_to_sync(self.stream_text_async(messages, force_web_search))
-
     def stream_data(self, messages: List[UIMessage], force_web_search: bool = False):
         """Return Vercel-AI-SDK formatted events."""
         return convert_async_generator_to_sync(self.stream_data_async(messages, force_web_search))
@@ -430,7 +434,7 @@ class AIAgentService:  # pylint: disable=too-many-instance-attributes
 
     @staticmethod
     def _mark_image_attachments_skipped(user_message: UIMessage) -> bool:
-        """Stamp a ``skipped`` marker on every image-like attachment.
+        """Stamp a ``skipped`` marker on every image-like file part.
 
         Returns True if at least one attachment was marked. The persisted user
         bubble keeps the image attachments (filenames + URLs) so the frontend
@@ -478,11 +482,29 @@ class AIAgentService:  # pylint: disable=too-many-instance-attributes
                 "can't read images."
             )
 
+    def _new_model_response_message_id(self) -> str:
+        """Build the id of the assistant message about to be streamed.
+
+        Prefixed with the Langfuse trace id when tracing is on: the frontend
+        keys its feedback buttons on that prefix to score the exact trace. The
+        id is minted at stream start because v5 pins the message identity on the
+        `start` frame — changing it mid-stream would fork the message in two.
+        """
+        if not self._langfuse_available:
+            return str(uuid.uuid4())
+        trace_id = get_client().get_current_trace_id()
+        if not trace_id:
+            # No active trace: a `trace-None` id would make the frontend offer
+            # feedback buttons that score a trace which does not exist.
+            return str(uuid.uuid4())
+        return f"trace-{trace_id}"
+
     async def _stream_content(  # noqa: PLR0912  # pylint: disable=too-many-branches
-        self, messages: List[UIMessage], force_web_search: bool = False, encoder_fn: Callable = None
+        self, messages: List[UIMessage], force_web_search: bool = False
     ):
-        """Common streaming logic with configurable encoder."""
+        """Stream the agent run as a Vercel AI SDK UI message stream."""
         await self._clean()
+        translator = V4ToV5Translator()
         with ExitStack() as stack:
             if self._langfuse_available:
                 stack.enter_context(
@@ -498,10 +520,15 @@ class AIAgentService:  # pylint: disable=too-many-instance-attributes
                     get_client().start_as_current_observation(name="conversation", as_type="span")
                 )
 
+            self._model_response_message_id = self._new_model_response_message_id()
+            yield self.event_encoder.encode(
+                events_v5.MessageStartEvent(messageId=self._model_response_message_id)
+            )
+
             try:
                 async for event in self._run_agent(messages, force_web_search):
-                    if stream_text := encoder_fn(event):
-                        yield stream_text
+                    for translated in translator.translate(event):
+                        yield self.event_encoder.encode(translated)
             except (ModelHTTPError, HTTPValidationError, SDKError) as exc:
                 # HTTPValidationError and SDKError are mistral-specific exceptions not
                 # wrapped by pydantic_ai into ModelHTTPError.
@@ -520,10 +547,8 @@ class AIAgentService:  # pylint: disable=too-many-instance-attributes
                 if messages:
                     await self._persist_user_message_on_error(messages[-1])
                 error_event = events_v4.ErrorPart(error=error_code)
-                if encoded := encoder_fn(error_event):
-                    yield encoded
-                else:
-                    raise
+                for translated in translator.translate(error_event):
+                    yield self.event_encoder.encode(translated)
             except ModelAPIError as exc:
                 logger.warning(
                     "LLM provider connection error for conversation %s: %s",
@@ -533,10 +558,8 @@ class AIAgentService:  # pylint: disable=too-many-instance-attributes
                 if messages:
                     await self._persist_user_message_on_error(messages[-1])
                 error_event = events_v4.ErrorPart(error="model_connection_error")
-                if encoded := encoder_fn(error_event):
-                    yield encoded
-                else:
-                    raise
+                for translated in translator.translate(error_event):
+                    yield self.event_encoder.encode(translated)
             except SummarizationRequiredError as exc:
                 logger.error(
                     "Summarization required but failed for conversation %s: %s",
@@ -546,24 +569,17 @@ class AIAgentService:  # pylint: disable=too-many-instance-attributes
                 if messages:
                     await self._persist_user_message_on_error(messages[-1])
                 error_event = events_v4.ErrorPart(error="summarization_failed")
-                if encoded := encoder_fn(error_event):
-                    yield encoded
-                else:
-                    raise
+                for translated in translator.translate(error_event):
+                    yield self.event_encoder.encode(translated)
 
-    async def stream_text_async(self, messages: List[UIMessage], force_web_search: bool = False):
-        """Return only the assistant text deltas (legacy text mode)."""
-        async for chunk in self._stream_content(
-            messages, force_web_search, encoder_fn=self.event_encoder.encode_text
-        ):
-            yield chunk
+            for translated in translator.flush():
+                yield self.event_encoder.encode(translated)
+            yield DONE_FRAME
 
     async def stream_data_async(self, messages: List[UIMessage], force_web_search: bool = False):
         """Return Vercel-AI-SDK formatted events."""
 
-        async for chunk in self._stream_content(
-            messages, force_web_search, encoder_fn=self.event_encoder.encode
-        ):
+        async for chunk in self._stream_content(messages, force_web_search):
             yield chunk
 
     async def _agent_stop_streaming(self, force_cache_check: Optional[bool] = False) -> None:
@@ -938,7 +954,7 @@ class AIAgentService:  # pylint: disable=too-many-instance-attributes
         return False
 
     async def _process_agent_nodes(
-        self, run, state: StreamingState, langfuse
+        self, run, state: StreamingState
     ) -> AsyncGenerator[events_v4.Event, None]:
         """
         Process nodes from the Pydantic-AI agent iteration loop.
@@ -953,8 +969,8 @@ class AIAgentService:  # pylint: disable=too-many-instance-attributes
           - Executes tools and yields results
           - Collects source citations into state.ui_sources
         - **EndNode**: The agent run is complete
-          - Sets state.model_response_message_id for Langfuse linking
-          - Yields StartStepPart with the message ID
+          - Sets state.model_response_message_id (minted at stream start) so
+            the persisted message keeps the id the client was given
 
         This method delegates to specialized handlers for each node type,
         passing the shared StreamingState to track cross-node state.
@@ -982,7 +998,7 @@ class AIAgentService:  # pylint: disable=too-many-instance-attributes
             elif Agent.is_end_node(node):
                 # Once an End node is reached, the agent run is complete
                 logger.debug("v: %s", dataclasses.asdict(node))
-                yield self._handle_end_node(node, langfuse, state)
+                self._handle_end_node(node, state)
 
     async def _fetch_document_data(
         self, document: "BinaryContent | DocumentUrl"
@@ -1510,15 +1526,13 @@ class AIAgentService:  # pylint: disable=too-many-instance-attributes
                     if isinstance(event.part, ToolReturnPart):
                         if event.part.metadata and (sources := event.part.metadata.get("sources")):
                             for source_url in sources:
-                                url_source = LanguageModelV1Source(
-                                    sourceType="url",
-                                    id=str(uuid.uuid4()),
-                                    url=source_url,
-                                    providerMetadata={},
+                                source_id = str(uuid.uuid4())
+                                state.ui_sources.append(
+                                    SourceUrlUIPart(
+                                        type="source-url", sourceId=source_id, url=source_url
+                                    )
                                 )
-                                _new_source_ui = SourceUIPart(type="source", source=url_source)
-                                state.ui_sources.append(_new_source_ui)
-                                yield events_v4.SourcePart(**_new_source_ui.source.model_dump())
+                                yield events_v4.SourcePart(id=source_id, url=source_url)
                         yield events_v4.ToolResultPart(
                             tool_call_id=event.tool_call_id, result=event.part.content
                         )
@@ -1534,17 +1548,14 @@ class AIAgentService:  # pylint: disable=too-many-instance-attributes
                             dataclasses.asdict(event.part),
                         )
 
-    def _handle_end_node(self, node, langfuse, state: StreamingState) -> events_v4.StartStepPart:
+    def _handle_end_node(self, node, state: StreamingState) -> None:
         """Handle end node - set message ID."""
         logger.debug("End node: %s", dataclasses.asdict(node))
         if state.model_response_message_id:
             logger.error("_model_response_message_id already set")
-        state.model_response_message_id = (
-            str(uuid.uuid4())
-            if not self._langfuse_available
-            else f"trace-{langfuse.get_current_trace_id()}"
-        )
-        return events_v4.StartStepPart(message_id=state.model_response_message_id)
+        # Minted (and streamed) by _stream_content: the persisted message must
+        # carry the same id the client already assigned to the live one.
+        state.model_response_message_id = self._model_response_message_id
 
     async def _generate_title_if_needed(self) -> str | None:
         """Generate and set title if auto-title conditions are met."""
@@ -1635,8 +1646,9 @@ class AIAgentService:  # pylint: disable=too-many-instance-attributes
                 ]
             )
         self._update_langfuse_trace(run_output)
-        # Stream the same CO2 annotation _prepare_update_conversation persisted,
-        # so the live message matches what a reload hydrates from the database.
+        # Stream the CO2 annotation _prepare_update_conversation persists, so the
+        # live message carries it like a reload does. Only that key is stored:
+        # the usage in the finish frame below is streamed but never persisted.
         if message_co2_impact:
             yield events_v4.MessageAnnotationPart(annotations=[{"co2_impact": message_co2_impact}])
         # Vercel finish message
@@ -1657,10 +1669,6 @@ class AIAgentService:  # pylint: disable=too-many-instance-attributes
         """Run the Pydantic AI agent and stream events."""
         if not messages or messages[-1].role != "user":
             return
-
-        # Trace-level attributes are propagated by `_stream_content` via
-        # `propagate_attributes`; `langfuse` is kept for downstream helpers.
-        langfuse = get_client() if self._langfuse_available else None
 
         (
             user_prompt,
@@ -1755,7 +1763,7 @@ class AIAgentService:  # pylint: disable=too-many-instance-attributes
                 toolsets=mcp_servers,
             ) as run:
                 state = StreamingState()
-                async for event in self._process_agent_nodes(run, state, langfuse):
+                async for event in self._process_agent_nodes(run, state):
                     yield event
 
                 # Extract values from run before exiting the context manager
@@ -1808,7 +1816,7 @@ class AIAgentService:  # pylint: disable=too-many-instance-attributes
         *,
         final_output: List[ModelRequest | ModelMessage],
         usage: Dict[str, Union[int, float]],
-        ui_sources: Optional[List[SourceUIPart]] = None,
+        ui_sources: Optional[List[SourceUrlUIPart]] = None,
         model_response_message_id: str | None = None,
         image_actions: Optional[ImagePostRunActions] = None,
     ):  # pylint: disable=too-many-arguments
@@ -1823,7 +1831,7 @@ class AIAgentService:  # pylint: disable=too-many-instance-attributes
             usage (Dict[str, Union[int, float]]): Token and CO2 usage statistics
             (mutated in-place to accumulate across turns).
             model_response_message_id (str | None): Message ID
-            ui_sources (List[SourceUIPart]): Optional UI sources to include in the conversation.
+            ui_sources (List[SourceUrlUIPart]): Optional UI sources to include.
             image_actions (ImagePostRunActions | None): Per-turn image-URL
             surgery to apply before persistence (rewrite presigned URLs back
             to durable form for in-message images, drop pinned project
@@ -1854,9 +1862,10 @@ class AIAgentService:  # pylint: disable=too-many-instance-attributes
 
         co2_impact = usage["co2_impact"]
         if co2_impact:
-            if _output_ui_message.annotations is None:
-                _output_ui_message.annotations = []
-            _output_ui_message.annotations.append({"co2_impact": co2_impact})
+            _output_ui_message.metadata = {
+                **(_output_ui_message.metadata or {}),
+                "co2_impact": co2_impact,
+            }
 
         usage["co2_impact"] += self.conversation.agent_usage.get("co2_impact", 0)
         usage["promptTokens"] += self.conversation.agent_usage.get("promptTokens", 0)

--- a/src/backend/chat/clients/pydantic_ai.py
+++ b/src/backend/chat/clients/pydantic_ai.py
@@ -13,8 +13,8 @@ changes are needed in views.py or tests.
    If the conversation belongs to a project with custom LLM instructions,
    they are injected as a dynamic agent instruction.
 
-2. **Streaming Entry Points**: `stream_text()` or `stream_data()` are called
-   with user messages. These wrap async generators for sync consumption.
+2. **Streaming Entry Point**: `stream_data()` is called with user messages.
+   It wraps the async generator for sync consumption.
 
 3. **Agent Execution** (`_run_agent`):
    a. Validate last message is from user
@@ -54,13 +54,13 @@ Documents attached to messages go through several stages:
 
 Events flow through several layers:
 
-    _run_agent (yields events)
+    _run_agent (yields v4 events)
         ↓
-    _stream_content (applies encoder)
+    _stream_content (translates to v5, applies encoder)
         ↓
-    stream_text_async / stream_data_async
+    stream_data_async
         ↓
-    stream_text / stream_data (sync wrapper)
+    stream_data (sync wrapper)
 
 The `StreamingState` dataclass tracks mutable state across the streaming process:
 - `tool_is_streaming`: Prevents duplicate tool call events when streaming deltas
@@ -85,7 +85,7 @@ import time
 import uuid
 from contextlib import AsyncExitStack, ExitStack
 from io import BytesIO
-from typing import AsyncGenerator, Callable, Dict, List, Optional, Tuple, Union
+from typing import AsyncGenerator, Dict, List, Optional, Tuple, Union
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -146,8 +146,8 @@ from chat.agents.local_media_url_processors import (
     update_local_urls,
 )
 from chat.ai_sdk_types import (
-    LanguageModelV1Source,
-    SourceUIPart,
+    FileUIPart,
+    SourceUrlUIPart,
     UIMessage,
 )
 from chat.clients.async_to_sync import convert_async_generator_to_sync
@@ -202,6 +202,8 @@ from chat.tools.document_summarize import document_summarize, document_summarize
 from chat.tools.self_documentation import build_self_documentation_payload
 from chat.vercel_ai_sdk.core import events_v4, events_v5
 from chat.vercel_ai_sdk.encoder import CURRENT_EVENT_ENCODER_VERSION, EventEncoder
+from chat.vercel_ai_sdk.encoder.encoder import DONE_FRAME
+from chat.vercel_ai_sdk.encoder.v4_to_v5 import V4ToV5Translator
 
 # Keep at the top of the file to avoid mocking issues
 document_store_backend = import_string(settings.RAG_DOCUMENT_SEARCH_BACKEND)
@@ -254,20 +256,22 @@ def _strip_thinking_parts(history: list[ModelMessage]) -> list[ModelMessage]:
 
 
 def iter_image_attachments(messages: list[UIMessage]):
-    """Yield each image-like attachment across the given messages.
+    """Yield each image-like file part across the given messages.
 
     Single source of truth for the "is this attachment an image?" predicate
     used by readers (``list_images``) and writers (``_mark_image_attachments_skipped``).
     """
     for message in messages:
-        for attachment in message.experimental_attachments or []:
-            if (attachment.contentType or "").startswith(IMAGE_MIME_PREFIX):
-                yield attachment
+        for part in message.parts or []:
+            if isinstance(part, FileUIPart) and (part.mediaType or "").startswith(
+                IMAGE_MIME_PREFIX
+            ):
+                yield part
 
 
 def list_images(messages: list[UIMessage]) -> list[str]:
     """Return names of every image attachment across the message history."""
-    return [a.name for a in iter_image_attachments(messages) if a.name is not None]
+    return [part.filename for part in iter_image_attachments(messages) if part.filename]
 
 
 def _extract_co2_from_usage(usage: RunUsage) -> float:
@@ -315,7 +319,11 @@ class AIAgentService:  # pylint: disable=too-many-instance-attributes
         self._langfuse_available = settings.LANGFUSE_ENABLED
         self._store_analytics = self._langfuse_available and user.allow_conversation_analytics
         self._langfuse_span = None
-        self.event_encoder = EventEncoder(CURRENT_EVENT_ENCODER_VERSION)  # We use v4 for now
+        self.event_encoder = EventEncoder(CURRENT_EVENT_ENCODER_VERSION)
+        # Id of the assistant message of the current stream, announced to the
+        # client in the `start` frame and persisted with the message. Set per
+        # stream by _stream_content.
+        self._model_response_message_id: str | None = None
 
         self._support_streaming = True
         if (streaming := self.model_configuration.supports_streaming) is not None:
@@ -394,10 +402,6 @@ class AIAgentService:  # pylint: disable=too-many-instance-attributes
     # Public streaming API (unchanged signatures)
     # --------------------------------------------------------------------- #
 
-    def stream_text(self, messages: List[UIMessage], force_web_search: bool = False):
-        """Return only the assistant text deltas (legacy text mode)."""
-        return convert_async_generator_to_sync(self.stream_text_async(messages, force_web_search))
-
     def stream_data(self, messages: List[UIMessage], force_web_search: bool = False):
         """Return Vercel-AI-SDK formatted events."""
         return convert_async_generator_to_sync(self.stream_data_async(messages, force_web_search))
@@ -430,7 +434,7 @@ class AIAgentService:  # pylint: disable=too-many-instance-attributes
 
     @staticmethod
     def _mark_image_attachments_skipped(user_message: UIMessage) -> bool:
-        """Stamp a ``skipped`` marker on every image-like attachment.
+        """Stamp a ``skipped`` marker on every image-like file part.
 
         Returns True if at least one attachment was marked. The persisted user
         bubble keeps the image attachments (filenames + URLs) so the frontend
@@ -478,11 +482,29 @@ class AIAgentService:  # pylint: disable=too-many-instance-attributes
                 "can't read images."
             )
 
+    def _new_model_response_message_id(self) -> str:
+        """Build the id of the assistant message about to be streamed.
+
+        Prefixed with the Langfuse trace id when tracing is on: the frontend
+        keys its feedback buttons on that prefix to score the exact trace. The
+        id is minted at stream start because v5 pins the message identity on the
+        `start` frame — changing it mid-stream would fork the message in two.
+        """
+        if not self._langfuse_available:
+            return str(uuid.uuid4())
+        trace_id = get_client().get_current_trace_id()
+        if not trace_id:
+            # No active trace: a `trace-None` id would make the frontend offer
+            # feedback buttons that score a trace which does not exist.
+            return str(uuid.uuid4())
+        return f"trace-{trace_id}"
+
     async def _stream_content(  # noqa: PLR0912  # pylint: disable=too-many-branches
-        self, messages: List[UIMessage], force_web_search: bool = False, encoder_fn: Callable = None
+        self, messages: List[UIMessage], force_web_search: bool = False
     ):
-        """Common streaming logic with configurable encoder."""
+        """Stream the agent run as a Vercel AI SDK UI message stream."""
         await self._clean()
+        translator = V4ToV5Translator()
         with ExitStack() as stack:
             if self._langfuse_available:
                 stack.enter_context(
@@ -498,10 +520,15 @@ class AIAgentService:  # pylint: disable=too-many-instance-attributes
                     get_client().start_as_current_observation(name="conversation", as_type="span")
                 )
 
+            self._model_response_message_id = self._new_model_response_message_id()
+            yield self.event_encoder.encode(
+                events_v5.MessageStartEvent(messageId=self._model_response_message_id)
+            )
+
             try:
                 async for event in self._run_agent(messages, force_web_search):
-                    if stream_text := encoder_fn(event):
-                        yield stream_text
+                    for translated in translator.translate(event):
+                        yield self.event_encoder.encode(translated)
             except (ModelHTTPError, HTTPValidationError, SDKError) as exc:
                 # HTTPValidationError and SDKError are mistral-specific exceptions not
                 # wrapped by pydantic_ai into ModelHTTPError.
@@ -520,10 +547,8 @@ class AIAgentService:  # pylint: disable=too-many-instance-attributes
                 if messages:
                     await self._persist_user_message_on_error(messages[-1])
                 error_event = events_v4.ErrorPart(error=error_code)
-                if encoded := encoder_fn(error_event):
-                    yield encoded
-                else:
-                    raise
+                for translated in translator.translate(error_event):
+                    yield self.event_encoder.encode(translated)
             except ModelAPIError as exc:
                 logger.warning(
                     "LLM provider connection error for conversation %s: %s",
@@ -533,10 +558,8 @@ class AIAgentService:  # pylint: disable=too-many-instance-attributes
                 if messages:
                     await self._persist_user_message_on_error(messages[-1])
                 error_event = events_v4.ErrorPart(error="model_connection_error")
-                if encoded := encoder_fn(error_event):
-                    yield encoded
-                else:
-                    raise
+                for translated in translator.translate(error_event):
+                    yield self.event_encoder.encode(translated)
             except SummarizationRequiredError as exc:
                 logger.error(
                     "Summarization required but failed for conversation %s: %s",
@@ -546,24 +569,17 @@ class AIAgentService:  # pylint: disable=too-many-instance-attributes
                 if messages:
                     await self._persist_user_message_on_error(messages[-1])
                 error_event = events_v4.ErrorPart(error="summarization_failed")
-                if encoded := encoder_fn(error_event):
-                    yield encoded
-                else:
-                    raise
+                for translated in translator.translate(error_event):
+                    yield self.event_encoder.encode(translated)
 
-    async def stream_text_async(self, messages: List[UIMessage], force_web_search: bool = False):
-        """Return only the assistant text deltas (legacy text mode)."""
-        async for chunk in self._stream_content(
-            messages, force_web_search, encoder_fn=self.event_encoder.encode_text
-        ):
-            yield chunk
+            for translated in translator.flush():
+                yield self.event_encoder.encode(translated)
+            yield DONE_FRAME
 
     async def stream_data_async(self, messages: List[UIMessage], force_web_search: bool = False):
         """Return Vercel-AI-SDK formatted events."""
 
-        async for chunk in self._stream_content(
-            messages, force_web_search, encoder_fn=self.event_encoder.encode
-        ):
+        async for chunk in self._stream_content(messages, force_web_search):
             yield chunk
 
     async def _agent_stop_streaming(self, force_cache_check: Optional[bool] = False) -> None:
@@ -938,7 +954,7 @@ class AIAgentService:  # pylint: disable=too-many-instance-attributes
         return False
 
     async def _process_agent_nodes(
-        self, run, state: StreamingState, langfuse
+        self, run, state: StreamingState
     ) -> AsyncGenerator[events_v4.Event, None]:
         """
         Process nodes from the Pydantic-AI agent iteration loop.
@@ -953,8 +969,8 @@ class AIAgentService:  # pylint: disable=too-many-instance-attributes
           - Executes tools and yields results
           - Collects source citations into state.ui_sources
         - **EndNode**: The agent run is complete
-          - Sets state.model_response_message_id for Langfuse linking
-          - Yields StartStepPart with the message ID
+          - Sets state.model_response_message_id (minted at stream start) so
+            the persisted message keeps the id the client was given
 
         This method delegates to specialized handlers for each node type,
         passing the shared StreamingState to track cross-node state.
@@ -982,7 +998,7 @@ class AIAgentService:  # pylint: disable=too-many-instance-attributes
             elif Agent.is_end_node(node):
                 # Once an End node is reached, the agent run is complete
                 logger.debug("v: %s", dataclasses.asdict(node))
-                yield self._handle_end_node(node, langfuse, state)
+                self._handle_end_node(node, state)
 
     async def _fetch_document_data(
         self, document: "BinaryContent | DocumentUrl"
@@ -1510,15 +1526,13 @@ class AIAgentService:  # pylint: disable=too-many-instance-attributes
                     if isinstance(event.part, ToolReturnPart):
                         if event.part.metadata and (sources := event.part.metadata.get("sources")):
                             for source_url in sources:
-                                url_source = LanguageModelV1Source(
-                                    sourceType="url",
-                                    id=str(uuid.uuid4()),
-                                    url=source_url,
-                                    providerMetadata={},
+                                source_id = str(uuid.uuid4())
+                                state.ui_sources.append(
+                                    SourceUrlUIPart(
+                                        type="source-url", sourceId=source_id, url=source_url
+                                    )
                                 )
-                                _new_source_ui = SourceUIPart(type="source", source=url_source)
-                                state.ui_sources.append(_new_source_ui)
-                                yield events_v4.SourcePart(**_new_source_ui.source.model_dump())
+                                yield events_v4.SourcePart(id=source_id, url=source_url)
                         yield events_v4.ToolResultPart(
                             tool_call_id=event.tool_call_id, result=event.part.content
                         )
@@ -1534,17 +1548,14 @@ class AIAgentService:  # pylint: disable=too-many-instance-attributes
                             dataclasses.asdict(event.part),
                         )
 
-    def _handle_end_node(self, node, langfuse, state: StreamingState) -> events_v4.StartStepPart:
+    def _handle_end_node(self, node, state: StreamingState) -> None:
         """Handle end node - set message ID."""
         logger.debug("End node: %s", dataclasses.asdict(node))
         if state.model_response_message_id:
             logger.error("_model_response_message_id already set")
-        state.model_response_message_id = (
-            str(uuid.uuid4())
-            if not self._langfuse_available
-            else f"trace-{langfuse.get_current_trace_id()}"
-        )
-        return events_v4.StartStepPart(message_id=state.model_response_message_id)
+        # Minted (and streamed) by _stream_content: the persisted message must
+        # carry the same id the client already assigned to the live one.
+        state.model_response_message_id = self._model_response_message_id
 
     async def _generate_title_if_needed(self) -> str | None:
         """Generate and set title if auto-title conditions are met."""
@@ -1635,8 +1646,9 @@ class AIAgentService:  # pylint: disable=too-many-instance-attributes
                 ]
             )
         self._update_langfuse_trace(run_output)
-        # Stream the same CO2 annotation _prepare_update_conversation persisted,
-        # so the live message matches what a reload hydrates from the database.
+        # Stream the CO2 annotation _prepare_update_conversation persists, so the
+        # live message carries it like a reload does. Only that key is stored:
+        # the usage in the finish frame below is streamed but never persisted.
         if message_co2_impact:
             yield events_v4.MessageAnnotationPart(annotations=[{"co2_impact": message_co2_impact}])
         # Vercel finish message
@@ -1657,10 +1669,6 @@ class AIAgentService:  # pylint: disable=too-many-instance-attributes
         """Run the Pydantic AI agent and stream events."""
         if not messages or messages[-1].role != "user":
             return
-
-        # Trace-level attributes are propagated by `_stream_content` via
-        # `propagate_attributes`; `langfuse` is kept for downstream helpers.
-        langfuse = get_client() if self._langfuse_available else None
 
         (
             user_prompt,
@@ -1755,7 +1763,7 @@ class AIAgentService:  # pylint: disable=too-many-instance-attributes
                 toolsets=mcp_servers,
             ) as run:
                 state = StreamingState()
-                async for event in self._process_agent_nodes(run, state, langfuse):
+                async for event in self._process_agent_nodes(run, state):
                     yield event
 
                 # Extract values from run before exiting the context manager
@@ -1808,7 +1816,7 @@ class AIAgentService:  # pylint: disable=too-many-instance-attributes
         *,
         final_output: List[ModelRequest | ModelMessage],
         usage: Dict[str, Union[int, float]],
-        ui_sources: Optional[List[SourceUIPart]] = None,
+        ui_sources: Optional[List[SourceUrlUIPart]] = None,
         model_response_message_id: str | None = None,
         image_actions: Optional[ImagePostRunActions] = None,
     ):  # pylint: disable=too-many-arguments
@@ -1823,7 +1831,7 @@ class AIAgentService:  # pylint: disable=too-many-instance-attributes
             usage (Dict[str, Union[int, float]]): Token and CO2 usage statistics
             (mutated in-place to accumulate across turns).
             model_response_message_id (str | None): Message ID
-            ui_sources (List[SourceUIPart]): Optional UI sources to include in the conversation.
+            ui_sources (List[SourceUrlUIPart]): Optional UI sources to include.
             image_actions (ImagePostRunActions | None): Per-turn image-URL
             surgery to apply before persistence (rewrite presigned URLs back
             to durable form for in-message images, drop pinned project
@@ -1854,9 +1862,10 @@ class AIAgentService:  # pylint: disable=too-many-instance-attributes
 
         co2_impact = usage["co2_impact"]
         if co2_impact:
-            if _output_ui_message.annotations is None:
-                _output_ui_message.annotations = []
-            _output_ui_message.annotations.append({"co2_impact": co2_impact})
+            _output_ui_message.metadata = {
+                **(_output_ui_message.metadata or {}),
+                "co2_impact": co2_impact,
+            }
 
         usage["co2_impact"] += self.conversation.agent_usage.get("co2_impact", 0)
         usage["promptTokens"] += self.conversation.agent_usage.get("promptTokens", 0)
@@ -1865,9 +1874,11 @@ class AIAgentService:  # pylint: disable=too-many-instance-attributes
         self.conversation.agent_usage = usage
 
         if not (self.conversation.messages and self.conversation.messages[-1].role == "user"):
-            self.conversation.messages += [
-                model_message_to_ui_message(_merged_final_output_request)
-            ]
+            _request_ui_message = model_message_to_ui_message(_merged_final_output_request)
+            # None when the request holds nothing renderable (system prompt or
+            # tool return only): there is no user bubble to rebuild.
+            if _request_ui_message:
+                self.conversation.messages += [_request_ui_message]
         self.conversation.messages += [_output_ui_message]
 
         final_output_json = json.loads(

--- a/src/backend/chat/clients/pydantic_ui_message_converter.py
+++ b/src/backend/chat/clients/pydantic_ui_message_converter.py
@@ -28,13 +28,13 @@ from pydantic_ai.messages import (
 )
 
 from chat.ai_sdk_types import (
-    Attachment,
+    TOOL_PART_PREFIX,
     FileUIPart,
-    ReasoningDetailText,
     ReasoningUIPart,
+    SourceUrlUIPart,
+    StepStartUIPart,
     TextUIPart,
-    ToolInvocationCall,
-    ToolInvocationUIPart,
+    ToolUIPart,
     UIMessage,
     UIPart,
 )
@@ -50,55 +50,35 @@ def ui_message_to_user_content(message: UIMessage) -> List[UserContent]:
         if isinstance(part, TextUIPart):
             user_contents.append(part.text)
         elif isinstance(part, FileUIPart):
-            user_contents.append(
-                BinaryContent(data=part.data.encode("utf-8"), media_type=part.mimeType)
-            )
-        elif isinstance(part, ToolInvocationUIPart):
-            # Tool invocations are not directly mapped to UserContent, skip or handle as needed
-            continue
-        elif isinstance(part, ReasoningUIPart):
-            # Reasoning parts are not directly mapped to UserContent, skip or handle as needed
+            user_contents.append(_file_part_to_user_content(part))
+        elif isinstance(part, (ToolUIPart, ReasoningUIPart, SourceUrlUIPart, StepStartUIPart)):
+            # Nothing the model consumes as user content.
             continue
         else:
             raise ValueError(f"Unsupported UIPart type: {type(part)}")
-    for experimental_attachment in message.experimental_attachments or []:
-        if experimental_attachment.url.startswith("data:"):
-            # Handle data URLs
-            raw_data = base64.b64decode(experimental_attachment.url.split(",")[1])
-            user_contents.append(
-                BinaryContent(
-                    data=raw_data,
-                    media_type=experimental_attachment.contentType,
-                    identifier=experimental_attachment.name,
-                )
-            )
-        elif experimental_attachment.contentType.startswith(IMAGE_MIME_PREFIX):
-            user_contents.append(
-                ImageUrl(
-                    url=experimental_attachment.url,
-                    media_type=experimental_attachment.contentType,
-                    identifier=experimental_attachment.name,
-                )
-            )
-        else:
-            user_contents.append(
-                DocumentUrl(
-                    url=experimental_attachment.url,
-                    media_type=experimental_attachment.contentType,
-                    identifier=experimental_attachment.name,
-                )
-            )
 
     return user_contents
 
 
-def model_message_to_ui_message(model_message: ModelMessage) -> UIMessage:  # noqa: PLR0912, PLR0915  # pylint: disable=too-many-statements
+def _file_part_to_user_content(part: FileUIPart) -> UserContent:
+    """Turn a file part into the content type Pydantic-AI expects for it."""
+    if part.url.startswith("data:"):
+        return BinaryContent(
+            data=base64.b64decode(part.url.split(",")[1]),
+            media_type=part.mediaType,
+            identifier=part.filename,
+        )
+    if (part.mediaType or "").startswith(IMAGE_MIME_PREFIX):
+        return ImageUrl(url=part.url, media_type=part.mediaType, identifier=part.filename)
+    return DocumentUrl(url=part.url, media_type=part.mediaType, identifier=part.filename)
+
+
+def model_message_to_ui_message(model_message: ModelMessage) -> UIMessage:  # noqa: PLR0912  # pylint: disable=too-many-statements
     """
     Convert a ModelMessage (ModelRequest or ModelResponse) to a UIMessage.
     """
     # pylint: disable=too-many-nested-blocks,too-many-branches
     parts: List[UIPart] = []
-    experimental_attachments: List[Attachment] = []
 
     logging.getLogger(__name__).debug(
         "Converting ModelMessage to UIMessage: %s %s",
@@ -123,27 +103,21 @@ def model_message_to_ui_message(model_message: ModelMessage) -> UIMessage:  # no
                         if isinstance(c, str):
                             parts.append(TextUIPart(type="text", text=c))
                         elif isinstance(c, BinaryContent):
-                            experimental_attachments.append(
-                                Attachment(
-                                    contentType=c.media_type,
+                            parts.append(
+                                FileUIPart(
+                                    type="file",
+                                    mediaType=c.media_type,
                                     url=f"data:{c.media_type};base64,"
                                     + base64.b64encode(c.data).decode("utf-8"),
                                 )
                             )
-                        elif isinstance(c, ImageUrl):
-                            experimental_attachments.append(
-                                Attachment(
-                                    contentType=c.media_type,
+                        elif isinstance(c, (ImageUrl, DocumentUrl)):
+                            parts.append(
+                                FileUIPart(
+                                    type="file",
+                                    mediaType=c.media_type,
                                     url=c.url,
-                                    name=c.identifier,
-                                )
-                            )
-                        elif isinstance(c, DocumentUrl):
-                            experimental_attachments.append(
-                                Attachment(
-                                    contentType=c.media_type,
-                                    url=c.url,
-                                    name=c.identifier,
+                                    filename=c.identifier,
                                 )
                             )
                         else:  # AudioUrl, VideoUrl
@@ -165,19 +139,7 @@ def model_message_to_ui_message(model_message: ModelMessage) -> UIMessage:  # no
                 #     )
                 # ))
             elif isinstance(part, ThinkingPart):
-                parts.append(
-                    ReasoningUIPart(
-                        type="reasoning",
-                        reasoning=part.content,
-                        details=[
-                            ReasoningDetailText(
-                                type="text",
-                                text=part.content,
-                                signature=part.signature,
-                            )
-                        ],
-                    )
-                )
+                parts.append(ReasoningUIPart(type="reasoning", text=part.content))
             elif isinstance(part, RetryPromptPart):
                 # Retry prompts are not included in UIMessage parts
                 continue
@@ -192,7 +154,6 @@ def model_message_to_ui_message(model_message: ModelMessage) -> UIMessage:  # no
             role="user",
             content="".join(part.text for part in parts if isinstance(part, TextUIPart)),
             parts=parts,
-            experimental_attachments=experimental_attachments or None,
             createdAt=message_timestamp,
         )
 
@@ -213,32 +174,17 @@ def model_message_to_ui_message(model_message: ModelMessage) -> UIMessage:  # no
                 parts.append(TextUIPart(type="text", text=part.content))
             elif isinstance(part, ToolCallPart):
                 parts.append(
-                    ToolInvocationUIPart(
-                        type="tool-invocation",
-                        toolInvocation=ToolInvocationCall(
-                            state="call",
-                            toolCallId=part.tool_call_id,
-                            toolName=part.tool_name,
-                            args=json.loads(part.args)
-                            if isinstance(part.args, str)
-                            else part.args or {},
-                        ),
+                    ToolUIPart(
+                        type=f"{TOOL_PART_PREFIX}{part.tool_name}",
+                        toolCallId=part.tool_call_id,
+                        state="input-available",
+                        input=json.loads(part.args)
+                        if isinstance(part.args, str)
+                        else part.args or {},
                     )
                 )
             elif isinstance(part, ThinkingPart):
-                parts.append(
-                    ReasoningUIPart(
-                        type="reasoning",
-                        reasoning=part.content,
-                        details=[
-                            ReasoningDetailText(
-                                type="text",
-                                text=part.content,
-                                signature=part.signature,
-                            )
-                        ],
-                    )
-                )
+                parts.append(ReasoningUIPart(type="reasoning", text=part.content))
             else:
                 raise ValueError(f"Unsupported ModelMessage part type: {type(part)}")
 

--- a/src/backend/chat/clients/pydantic_ui_message_converter.py
+++ b/src/backend/chat/clients/pydantic_ui_message_converter.py
@@ -8,7 +8,7 @@ import json
 import logging
 import uuid
 from dataclasses import asdict
-from typing import List
+from typing import List, Optional
 
 from pydantic_ai.messages import (
     BinaryContent,
@@ -16,7 +16,9 @@ from pydantic_ai.messages import (
     ImageUrl,
     ModelMessage,
     ModelRequest,
+    ModelRequestPart,
     ModelResponse,
+    ModelResponsePart,
     RetryPromptPart,
     SystemPromptPart,
     TextPart,
@@ -28,13 +30,13 @@ from pydantic_ai.messages import (
 )
 
 from chat.ai_sdk_types import (
-    Attachment,
+    TOOL_PART_PREFIX,
     FileUIPart,
-    ReasoningDetailText,
     ReasoningUIPart,
+    SourceUrlUIPart,
+    StepStartUIPart,
     TextUIPart,
-    ToolInvocationCall,
-    ToolInvocationUIPart,
+    ToolUIPart,
     UIMessage,
     UIPart,
 )
@@ -50,204 +52,183 @@ def ui_message_to_user_content(message: UIMessage) -> List[UserContent]:
         if isinstance(part, TextUIPart):
             user_contents.append(part.text)
         elif isinstance(part, FileUIPart):
-            user_contents.append(
-                BinaryContent(data=part.data.encode("utf-8"), media_type=part.mimeType)
-            )
-        elif isinstance(part, ToolInvocationUIPart):
-            # Tool invocations are not directly mapped to UserContent, skip or handle as needed
-            continue
-        elif isinstance(part, ReasoningUIPart):
-            # Reasoning parts are not directly mapped to UserContent, skip or handle as needed
+            user_contents.append(_file_part_to_user_content(part))
+        elif isinstance(part, (ToolUIPart, ReasoningUIPart, SourceUrlUIPart, StepStartUIPart)):
+            # Nothing the model consumes as user content.
             continue
         else:
             raise ValueError(f"Unsupported UIPart type: {type(part)}")
-    for experimental_attachment in message.experimental_attachments or []:
-        if experimental_attachment.url.startswith("data:"):
-            # Handle data URLs
-            raw_data = base64.b64decode(experimental_attachment.url.split(",")[1])
-            user_contents.append(
-                BinaryContent(
-                    data=raw_data,
-                    media_type=experimental_attachment.contentType,
-                    identifier=experimental_attachment.name,
-                )
-            )
-        elif experimental_attachment.contentType.startswith(IMAGE_MIME_PREFIX):
-            user_contents.append(
-                ImageUrl(
-                    url=experimental_attachment.url,
-                    media_type=experimental_attachment.contentType,
-                    identifier=experimental_attachment.name,
-                )
-            )
-        else:
-            user_contents.append(
-                DocumentUrl(
-                    url=experimental_attachment.url,
-                    media_type=experimental_attachment.contentType,
-                    identifier=experimental_attachment.name,
-                )
-            )
 
     return user_contents
 
 
-def model_message_to_ui_message(model_message: ModelMessage) -> UIMessage:  # noqa: PLR0912, PLR0915  # pylint: disable=too-many-statements
+def _file_part_to_user_content(part: FileUIPart) -> UserContent:
+    """Turn a file part into the content type Pydantic-AI expects for it."""
+    if part.url.startswith("data:"):
+        return BinaryContent(
+            data=base64.b64decode(part.url.split(",")[1]),
+            media_type=part.mediaType,
+            identifier=part.filename,
+        )
+    if (part.mediaType or "").startswith(IMAGE_MIME_PREFIX):
+        return ImageUrl(url=part.url, media_type=part.mediaType, identifier=part.filename)
+    return DocumentUrl(url=part.url, media_type=part.mediaType, identifier=part.filename)
+
+
+def model_message_to_ui_message(model_message: ModelMessage) -> Optional[UIMessage]:
     """
     Convert a ModelMessage (ModelRequest or ModelResponse) to a UIMessage.
-    """
-    # pylint: disable=too-many-nested-blocks,too-many-branches
-    parts: List[UIPart] = []
-    experimental_attachments: List[Attachment] = []
 
+    Returns None for a request holding nothing the UI renders (a system prompt
+    or a tool return on its own); callers must skip it rather than store it.
+    """
     logging.getLogger(__name__).debug(
         "Converting ModelMessage to UIMessage: %s %s",
         type(model_message),
         asdict(model_message),
     )
+
+    # Unused: kept from the Pydantic AI rewrite as the intended place to carry
+    # tool-call state across the parts of one message (pairing a ToolCallPart
+    # with the ToolReturnPart that answers it, which is dropped today).
     _states = {"tool-calls": {}}
 
     if isinstance(model_message, ModelRequest):
-        message_timestamp = None
-
-        for part in model_message.parts:
-            if isinstance(part, SystemPromptPart):
-                # System prompts are not included in UIMessage parts
-                continue
-            if isinstance(part, UserPromptPart):
-                message_timestamp = part.timestamp
-                if isinstance(part.content, str):
-                    parts.append(TextUIPart(type="text", text=part.content))
-                elif isinstance(part.content, list):
-                    for c in part.content:
-                        if isinstance(c, str):
-                            parts.append(TextUIPart(type="text", text=c))
-                        elif isinstance(c, BinaryContent):
-                            experimental_attachments.append(
-                                Attachment(
-                                    contentType=c.media_type,
-                                    url=f"data:{c.media_type};base64,"
-                                    + base64.b64encode(c.data).decode("utf-8"),
-                                )
-                            )
-                        elif isinstance(c, ImageUrl):
-                            experimental_attachments.append(
-                                Attachment(
-                                    contentType=c.media_type,
-                                    url=c.url,
-                                    name=c.identifier,
-                                )
-                            )
-                        elif isinstance(c, DocumentUrl):
-                            experimental_attachments.append(
-                                Attachment(
-                                    contentType=c.media_type,
-                                    url=c.url,
-                                    name=c.identifier,
-                                )
-                            )
-                        else:  # AudioUrl, VideoUrl
-                            raise ValueError(
-                                f"Unsupported UserContent in UserPromptPart: {type(c)}"
-                            )
-            elif isinstance(part, TextPart) and part.content:
-                parts.append(TextUIPart(type="text", text=part.content))
-            elif isinstance(part, ToolReturnPart):
-                pass
-                # parts.append(ToolInvocationUIPart(
-                #     type="tool-invocation",
-                #     toolInvocation=ToolInvocationResult(
-                #         state="result",
-                #         toolCallId=part.tool_call_id,
-                #         toolName=part.tool_name,
-                #         args={},
-                #         result=part.content,
-                #     )
-                # ))
-            elif isinstance(part, ThinkingPart):
-                parts.append(
-                    ReasoningUIPart(
-                        type="reasoning",
-                        reasoning=part.content,
-                        details=[
-                            ReasoningDetailText(
-                                type="text",
-                                text=part.content,
-                                signature=part.signature,
-                            )
-                        ],
-                    )
-                )
-            elif isinstance(part, RetryPromptPart):
-                # Retry prompts are not included in UIMessage parts
-                continue
-            else:
-                raise ValueError(f"Unsupported ModelRequest part type: {type(part)}")
-
-        if not parts:
-            return None
-
-        return UIMessage(
-            id=str(uuid.uuid4()),
-            role="user",
-            content="".join(part.text for part in parts if isinstance(part, TextUIPart)),
-            parts=parts,
-            experimental_attachments=experimental_attachments or None,
-            createdAt=message_timestamp,
-        )
+        return _model_request_to_ui_message(model_message)
 
     if isinstance(model_message, ModelResponse):
-        for part in model_message.parts:
-            if isinstance(part, UserPromptPart):
-                if isinstance(part.content, str):
-                    parts.append(TextUIPart(type="text", text=part.content))
-                elif isinstance(part.content, list):
-                    for c in part.content:
-                        if isinstance(c, str):
-                            parts.append(TextUIPart(type="text", text=c))
-                        else:  # ImageUrl, AudioUrl, VideoUrl, DocumentUrl, BinaryContent
-                            raise ValueError(
-                                f"Unsupported UserContent in UserPromptPart: {type(c)}"
-                            )
-            elif isinstance(part, TextPart):
-                parts.append(TextUIPart(type="text", text=part.content))
-            elif isinstance(part, ToolCallPart):
-                parts.append(
-                    ToolInvocationUIPart(
-                        type="tool-invocation",
-                        toolInvocation=ToolInvocationCall(
-                            state="call",
-                            toolCallId=part.tool_call_id,
-                            toolName=part.tool_name,
-                            args=json.loads(part.args)
-                            if isinstance(part.args, str)
-                            else part.args or {},
-                        ),
-                    )
-                )
-            elif isinstance(part, ThinkingPart):
-                parts.append(
-                    ReasoningUIPart(
-                        type="reasoning",
-                        reasoning=part.content,
-                        details=[
-                            ReasoningDetailText(
-                                type="text",
-                                text=part.content,
-                                signature=part.signature,
-                            )
-                        ],
-                    )
-                )
-            else:
-                raise ValueError(f"Unsupported ModelMessage part type: {type(part)}")
-
-        return UIMessage(
-            id=str(uuid.uuid4()),
-            role="assistant",
-            content="".join(part.text for part in parts if isinstance(part, TextUIPart)),
-            parts=parts,
-            createdAt=model_message.timestamp,
-        )
+        return _model_response_to_ui_message(model_message)
 
     raise ValueError(f"Unsupported ModelMessage part type: {type(model_message)}")
+
+
+def _model_request_to_ui_message(model_request: ModelRequest) -> Optional[UIMessage]:
+    """Build the user-side UIMessage, or None when the request has nothing to show."""
+    parts: List[UIPart] = []
+    message_timestamp = None
+
+    for part in model_request.parts:
+        if isinstance(part, UserPromptPart):
+            message_timestamp = part.timestamp
+        parts.extend(_request_part_to_ui_parts(part))
+
+    if not parts:
+        return None
+
+    return UIMessage(
+        id=str(uuid.uuid4()),
+        role="user",
+        content="".join(part.text for part in parts if isinstance(part, TextUIPart)),
+        parts=parts,
+        createdAt=message_timestamp,
+    )
+
+
+def _request_part_to_ui_parts(part: ModelRequestPart) -> List[UIPart]:
+    """The UI parts a single ModelRequest part contributes, if any."""
+    if isinstance(part, (SystemPromptPart, RetryPromptPart, ToolReturnPart)):
+        # System prompts, retry prompts and tool returns are not included in
+        # UIMessage parts. Tool returns used to be rendered as:
+        # ToolInvocationUIPart(
+        #     type="tool-invocation",
+        #     toolInvocation=ToolInvocationResult(
+        #         state="result",
+        #         toolCallId=part.tool_call_id,
+        #         toolName=part.tool_name,
+        #         args={},
+        #         result=part.content,
+        #     )
+        # )
+        return []
+
+    if isinstance(part, UserPromptPart):
+        if isinstance(part.content, str):
+            return [TextUIPart(type="text", text=part.content)]
+        if isinstance(part.content, list):
+            return [_user_content_to_ui_part(content) for content in part.content]
+        return []
+
+    if isinstance(part, TextPart) and part.content:
+        return [TextUIPart(type="text", text=part.content)]
+
+    if isinstance(part, ThinkingPart):
+        return [ReasoningUIPart(type="reasoning", text=part.content)]
+
+    raise ValueError(f"Unsupported ModelRequest part type: {type(part)}")
+
+
+def _user_content_to_ui_part(content: UserContent) -> UIPart:
+    """The UI part carrying one piece of user content."""
+    if isinstance(content, str):
+        return TextUIPart(type="text", text=content)
+
+    if isinstance(content, BinaryContent):
+        return FileUIPart(
+            type="file",
+            mediaType=content.media_type,
+            url=f"data:{content.media_type};base64,"
+            + base64.b64encode(content.data).decode("utf-8"),
+        )
+
+    if isinstance(content, (ImageUrl, DocumentUrl)):
+        return FileUIPart(
+            type="file",
+            mediaType=content.media_type,
+            url=content.url,
+            filename=content.identifier,
+        )
+
+    # AudioUrl, VideoUrl
+    raise ValueError(f"Unsupported UserContent in UserPromptPart: {type(content)}")
+
+
+def _model_response_to_ui_message(model_response: ModelResponse) -> UIMessage:
+    """Build the assistant-side UIMessage."""
+    parts: List[UIPart] = []
+    for part in model_response.parts:
+        parts.extend(_response_part_to_ui_parts(part))
+
+    return UIMessage(
+        id=str(uuid.uuid4()),
+        role="assistant",
+        content="".join(part.text for part in parts if isinstance(part, TextUIPart)),
+        parts=parts,
+        createdAt=model_response.timestamp,
+    )
+
+
+def _response_part_to_ui_parts(part: ModelResponsePart) -> List[UIPart]:
+    """The UI parts a single ModelResponse part contributes, if any."""
+    if isinstance(part, UserPromptPart):
+        if isinstance(part.content, str):
+            return [TextUIPart(type="text", text=part.content)]
+        if isinstance(part.content, list):
+            return [_response_user_content_to_ui_part(content) for content in part.content]
+        return []
+
+    if isinstance(part, TextPart):
+        return [TextUIPart(type="text", text=part.content)]
+
+    if isinstance(part, ToolCallPart):
+        return [
+            ToolUIPart(
+                type=f"{TOOL_PART_PREFIX}{part.tool_name}",
+                toolCallId=part.tool_call_id,
+                state="input-available",
+                input=json.loads(part.args) if isinstance(part.args, str) else part.args or {},
+            )
+        ]
+
+    if isinstance(part, ThinkingPart):
+        return [ReasoningUIPart(type="reasoning", text=part.content)]
+
+    raise ValueError(f"Unsupported ModelMessage part type: {type(part)}")
+
+
+def _response_user_content_to_ui_part(content: UserContent) -> UIPart:
+    """A response only ever carries text back; anything else is unexpected."""
+    if isinstance(content, str):
+        return TextUIPart(type="text", text=content)
+
+    # ImageUrl, AudioUrl, VideoUrl, DocumentUrl, BinaryContent
+    raise ValueError(f"Unsupported UserContent in UserPromptPart: {type(content)}")

--- a/src/backend/chat/clients/schema.py
+++ b/src/backend/chat/clients/schema.py
@@ -8,7 +8,7 @@ from typing import Dict, List, Optional
 from django.contrib.auth import get_user_model
 
 from chat import models
-from chat.ai_sdk_types import SourceUIPart
+from chat.ai_sdk_types import SourceUrlUIPart
 
 User = get_user_model()
 
@@ -47,7 +47,7 @@ class StreamingState:
     """
 
     tool_is_streaming: bool = False
-    ui_sources: List[SourceUIPart] = dataclasses.field(default_factory=list)
+    ui_sources: List[SourceUrlUIPart] = dataclasses.field(default_factory=list)
     model_response_message_id: Optional[str] = None
 
 

--- a/src/backend/chat/keepalive.py
+++ b/src/backend/chat/keepalive.py
@@ -15,23 +15,20 @@ from typing import AsyncIterator, Iterator
 
 from django.conf import settings
 
-from .vercel_ai_sdk.core.events_v4 import DataPart as V4DataPart
 from .vercel_ai_sdk.core.events_v5 import DataPart as V5DataPart
-from .vercel_ai_sdk.encoder import (
-    CURRENT_EVENT_ENCODER_VERSION,
-    EventEncoder,
-    EventEncoderVersion,
-)
+from .vercel_ai_sdk.encoder import CURRENT_EVENT_ENCODER_VERSION, EventEncoder
+from .vercel_ai_sdk.encoder.v4_to_v5 import data_part_type
 
 logger = logging.getLogger(__name__)
 
 
 def get_keepalive_message() -> str:
-    """Generate a keepalive message based on encoder/SDK version."""
-    if CURRENT_EVENT_ENCODER_VERSION == EventEncoderVersion.V4:
-        event = V4DataPart(data=[{"status": "WAITING"}])
-    else:
-        event = V5DataPart(data={"status": "WAITING"})
+    """Generate a keepalive message.
+
+    Transient, so the client hands it to `onData` and never adds it to the
+    message: it exists only to keep the connection warm.
+    """
+    event = V5DataPart(type=data_part_type("keepalive"), data={"status": "WAITING"})
     encoder = EventEncoder(CURRENT_EVENT_ENCODER_VERSION)
     return encoder.encode(event)
 
@@ -163,6 +160,12 @@ def stream_with_keepalive_sync(stream: Iterator[str]) -> Iterator[str]:
             # Re-raise from consume_stream
             if isinstance(item, Exception):
                 raise item
+
+            # The keepalive thread can queue a message while the source stream is
+            # finishing, which would put it after the terminator frame. Nothing
+            # needs keeping alive once the stream is done, so drop it.
+            if item == keepalive_message and stream_done.is_set():
+                continue
 
             yield item
             last_yield_time[0] = get_current_time()

--- a/src/backend/chat/serializers.py
+++ b/src/backend/chat/serializers.py
@@ -135,14 +135,6 @@ class ChatConversationRequestSerializer(serializers.Serializer):
     See ChatViewSet().post_conversation(...) method for more details.
     """
 
-    protocol = serializers.CharField(
-        required=False,
-        default="data",
-        help_text="Protocol version to use for the conversation (text or data).",
-        allow_blank=True,
-        trim_whitespace=True,
-    )
-
     force_web_search = serializers.BooleanField(
         required=False,
         default=False,
@@ -163,12 +155,6 @@ class ChatConversationRequestSerializer(serializers.Serializer):
     def create(self, validated_data):
         """Create method is not applicable in this context."""
         raise NotImplementedError("`create()` should not be used in this context.")
-
-    def validate_protocol(self, value):
-        """Validate the protocol field."""
-        if value not in ["text", "data"]:
-            raise serializers.ValidationError("Protocol must be either 'text' or 'data'.")
-        return value
 
     def validate_model_hrid(self, value):
         """Validate the model_hrid field."""

--- a/src/backend/chat/tests/clients/pydantic_ai/test_langfuse_tracing.py
+++ b/src/backend/chat/tests/clients/pydantic_ai/test_langfuse_tracing.py
@@ -13,6 +13,7 @@ from core.factories import UserFactory
 from chat.ai_sdk_types import TextUIPart, UIMessage
 from chat.clients.pydantic_ai import AIAgentService
 from chat.factories import ChatConversationFactory
+from chat.tests.utils import stream_text
 
 pytestmark = pytest.mark.django_db()
 
@@ -102,11 +103,11 @@ async def test_langfuse_span_created_when_enabled_and_analytics_allowed(
     service = AIAgentService(conversation, user=user)
     results = []
     with service.conversation_agent.override(model=agent_model):
-        async for result in service.stream_text_async(ui_messages):
+        async for result in service.stream_data_async(ui_messages):
             results.append(result)
 
     # Verify that results were generated
-    assert results == ["Hello! I'm doing well, thank you for asking."]
+    assert stream_text(results) == "Hello! I'm doing well, thank you for asking."
 
     langfuse_client.flush()
 
@@ -153,11 +154,11 @@ async def test_langfuse_span_created_when_enabled_and_analytics_disabled(
     service = AIAgentService(conversation, user=user)
     results = []
     with service.conversation_agent.override(model=agent_model):
-        async for result in service.stream_text_async(ui_messages):
+        async for result in service.stream_data_async(ui_messages):
             results.append(result)
 
     # Verify that results were generated
-    assert results == ["Hello! I'm doing well, thank you for asking."]
+    assert stream_text(results) == "Hello! I'm doing well, thank you for asking."
 
     langfuse_client.flush()
 
@@ -191,11 +192,11 @@ async def test_no_langfuse_span_when_disabled(agent_model, ui_messages, langfuse
     service = AIAgentService(conversation, user=user)
     results = []
     with service.conversation_agent.override(model=agent_model):
-        async for result in service.stream_text_async(ui_messages):
+        async for result in service.stream_data_async(ui_messages):
             results.append(result)
 
     # Verify that results were generated
-    assert results == ["Hello! I'm doing well, thank you for asking."]
+    assert stream_text(results) == "Hello! I'm doing well, thank you for asking."
 
     langfuse_client.flush()
 

--- a/src/backend/chat/tests/clients/pydantic_ai/test_prepare_update_conversation.py
+++ b/src/backend/chat/tests/clients/pydantic_ai/test_prepare_update_conversation.py
@@ -1,0 +1,81 @@
+"""Tests for the messages AIAgentService._prepare_update_conversation stores."""
+
+# pylint: disable=protected-access
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from pydantic_ai.messages import (
+    ModelRequest,
+    ModelResponse,
+    SystemPromptPart,
+    TextPart,
+    UserPromptPart,
+)
+
+from chat.clients.pydantic_ai import AIAgentService
+from chat.llm_configuration import LLModel
+
+USAGE = {"promptTokens": 10, "completionTokens": 5, "co2_impact": 0}
+
+
+@pytest.fixture(name="conversation")
+def conversation_fixture():
+    """Return a minimal mock conversation (no DB required)."""
+    conv = MagicMock()
+    conv.messages = []
+    conv.pydantic_messages = []
+    conv.agent_usage = {}
+    return conv
+
+
+@pytest.fixture(name="service")
+def service_fixture(conversation):
+    """Instantiate AIAgentService without __init__, injecting what the method needs."""
+    service = object.__new__(AIAgentService)
+    service.conversation = conversation
+    service.user = SimpleNamespace(pk=1)
+    service.conversation_agent = SimpleNamespace(
+        configuration=LLModel(
+            hrid="m",
+            model_name="test:model",
+            human_readable_name="M",
+            is_active=True,
+            system_prompt="hi",
+            tools=[],
+        )
+    )
+    return service
+
+
+def test_stores_the_rebuilt_user_message(conversation, service):
+    """The user bubble is rebuilt from the request the agent ran on."""
+    service._prepare_update_conversation(
+        final_output=[
+            ModelRequest(parts=[UserPromptPart(content="Hello?")], kind="request"),
+            ModelResponse(parts=[TextPart(content="Hi!")], kind="response"),
+        ],
+        usage=dict(USAGE),
+        model_response_message_id="msg-1",
+    )
+
+    assert [(message.role, message.content) for message in conversation.messages] == [
+        ("user", "Hello?"),
+        ("assistant", "Hi!"),
+    ]
+
+
+def test_stores_no_user_message_when_the_request_has_nothing_to_render(conversation, service):
+    """A request the UI cannot render is skipped, not stored as an empty message."""
+    service._prepare_update_conversation(
+        final_output=[
+            ModelRequest(parts=[SystemPromptPart(content="You are a bot")], kind="request"),
+            ModelResponse(parts=[TextPart(content="Hi!")], kind="response"),
+        ],
+        usage=dict(USAGE),
+        model_response_message_id="msg-1",
+    )
+
+    assert [(message.role, message.content) for message in conversation.messages] == [
+        ("assistant", "Hi!")
+    ]

--- a/src/backend/chat/tests/clients/pydantic_ai/test_stream_methods.py
+++ b/src/backend/chat/tests/clients/pydantic_ai/test_stream_methods.py
@@ -11,6 +11,7 @@ from pydantic_ai.exceptions import ModelAPIError, ModelHTTPError
 from chat.ai_sdk_types import UIMessage
 from chat.clients.pydantic_ai import AIAgentService
 from chat.factories import ChatConversationFactory
+from chat.tests.utils import stream_body
 from chat.vercel_ai_sdk.core import events_v4
 
 pytestmark = pytest.mark.django_db()
@@ -36,56 +37,16 @@ def ui_messages_fixture():
 
 
 @patch("chat.clients.pydantic_ai.convert_async_generator_to_sync")
-def test_stream_text_delegates_to_async(mock_convert, ui_messages):
-    """Test stream_text method delegates to async version."""
-    conversation = ChatConversationFactory()
-    service = AIAgentService(conversation, user=conversation.owner)
-    mock_convert.return_value = iter(["Hello", " world"])
-
-    result = service.stream_text(ui_messages, force_web_search=True)
-
-    mock_convert.assert_called_once()
-    assert result == mock_convert.return_value
-
-
-@patch("chat.clients.pydantic_ai.convert_async_generator_to_sync")
 def test_stream_data_delegates_to_async(mock_convert, ui_messages):
     """Test stream_data method delegates to async version."""
     conversation = ChatConversationFactory()
     service = AIAgentService(conversation, user=conversation.owner)
-    mock_convert.return_value = iter(['0:"Hello"\n', 'd:{"finishReason":"stop"}\n'])
+    mock_convert.return_value = iter(['data: {"type":"text-delta"}\n\n', "data: [DONE]\n\n"])
 
     result = service.stream_data(ui_messages, force_web_search=False)
 
     mock_convert.assert_called_once()
     assert result == mock_convert.return_value
-
-
-@pytest.mark.asyncio
-async def test_stream_text_async_filters_text_deltas(ui_messages):
-    """Test stream_text_async only yields text deltas."""
-    conversation = await sync_to_async(ChatConversationFactory)()
-    service = AIAgentService(conversation, user=conversation.owner)
-
-    # Mock _run_agent to return various delta types
-    async def mock_run_agent(*args, **kwargs):
-        yield events_v4.TextPart(text="Hello")
-        yield events_v4.ToolCallStreamingStartPart(tool_call_id="123", tool_name="search")
-        yield events_v4.TextPart(text=" world")
-        yield events_v4.FinishMessagePart(
-            finish_reason=events_v4.FinishReason.STOP,
-            usage=events_v4.Usage(
-                prompt_tokens=120,
-                completion_tokens=456,
-            ),
-        )
-
-    with patch.object(service, "_run_agent", side_effect=mock_run_agent):
-        results = []
-        async for result in service.stream_text_async(ui_messages):
-            results.append(result)
-
-        assert results == ["Hello", " world"]
 
 
 @pytest.mark.asyncio
@@ -110,10 +71,12 @@ async def test_stream_data_async_formats_as_sdk_events(ui_messages):
         async for result in service.stream_data_async(ui_messages):
             results.append(result)
 
-        assert results == [
-            '0:"Hello"\n',
-            'd:{"finishReason":"stop","usage":{"promptTokens":120,"completionTokens":456,'
-            '"co2Impact":0.0}}\n',
+        assert stream_body(results) == [
+            '{"type":"text-start","id":"0"}',
+            '{"type":"text-delta","id":"0","delta":"Hello"}',
+            '{"type":"text-end","id":"0"}',
+            '{"type":"finish","messageMetadata":{"usage":{"promptTokens":120,'
+            '"completionTokens":456,"co2Impact":0.0}}}',
         ]
 
 
@@ -131,7 +94,7 @@ async def test_stream_data_async_emits_model_busy_on_503():
         async for result in service.stream_data_async([]):
             results.append(result)
 
-    assert results == ['3:"model_busy"\n']
+    assert stream_body(results) == ['{"type":"error","errorText":"model_busy"}']
 
 
 @pytest.mark.asyncio
@@ -148,7 +111,7 @@ async def test_stream_data_async_emits_model_unavailable_on_5xx():
         async for result in service.stream_data_async([]):
             results.append(result)
 
-    assert results == ['3:"model_unavailable"\n']
+    assert stream_body(results) == ['{"type":"error","errorText":"model_unavailable"}']
 
 
 @pytest.mark.asyncio
@@ -165,7 +128,7 @@ async def test_stream_data_async_emits_model_rate_limited_on_429():
         async for result in service.stream_data_async([]):
             results.append(result)
 
-    assert results == ['3:"model_rate_limited"\n']
+    assert stream_body(results) == ['{"type":"error","errorText":"model_rate_limited"}']
 
 
 @pytest.mark.asyncio
@@ -184,7 +147,7 @@ async def test_stream_data_async_emits_model_connection_error_on_api_error():
         async for result in service.stream_data_async([]):
             results.append(result)
 
-    assert results == ['3:"model_connection_error"\n']
+    assert stream_body(results) == ['{"type":"error","errorText":"model_connection_error"}']
 
 
 @pytest.mark.asyncio
@@ -208,7 +171,7 @@ async def test_stream_data_async_emits_model_busy_on_sdk_error_503():
         async for result in service.stream_data_async([]):
             results.append(result)
 
-    assert results == ['3:"model_busy"\n']
+    assert stream_body(results) == ['{"type":"error","errorText":"model_busy"}']
 
 
 @pytest.mark.asyncio
@@ -232,7 +195,7 @@ async def test_stream_data_async_emits_model_wrong_type_on_http_validation_error
         async for result in service.stream_data_async([]):
             results.append(result)
 
-    assert results == ['3:"model_wrong_type"\n']
+    assert stream_body(results) == ['{"type":"error","errorText":"model_wrong_type"}']
 
 
 @pytest.mark.asyncio
@@ -247,39 +210,6 @@ async def test_stream_data_async_reraises_unknown_exceptions():
     with patch.object(service, "_run_agent", side_effect=mock_run_agent):
         with pytest.raises(ValueError, match="unexpected"):
             async for _ in service.stream_data_async([]):
-                pass
-
-
-@pytest.mark.asyncio
-async def test_stream_text_async_reraises_http_error():
-    """ModelHTTPError is re-raised on text protocol path
-    (encode_text returns None for ErrorPart)."""
-    conversation = await sync_to_async(ChatConversationFactory)()
-    service = AIAgentService(conversation, user=conversation.owner)
-
-    def mock_run_agent(*args, **kwargs):
-        return AsyncRaiseIterator(ModelHTTPError(status_code=503, model_name="test-model"))
-
-    with patch.object(service, "_run_agent", side_effect=mock_run_agent):
-        with pytest.raises(ModelHTTPError):
-            async for _ in service.stream_text_async([]):
-                pass
-
-
-@pytest.mark.asyncio
-async def test_stream_text_async_reraises_connection_error():
-    """ModelAPIError is re-raised on text protocol path (encode_text returns None for ErrorPart)."""
-    conversation = await sync_to_async(ChatConversationFactory)()
-    service = AIAgentService(conversation, user=conversation.owner)
-
-    def mock_run_agent(*args, **kwargs):
-        return AsyncRaiseIterator(
-            ModelAPIError(model_name="test-model", message="Connection error.")
-        )
-
-    with patch.object(service, "_run_agent", side_effect=mock_run_agent):
-        with pytest.raises(ModelAPIError):
-            async for _ in service.stream_text_async([]):
                 pass
 
 

--- a/src/backend/chat/tests/clients/pydantic_ui_message_converter/test_model_message_to_ui_message.py
+++ b/src/backend/chat/tests/clients/pydantic_ui_message_converter/test_model_message_to_ui_message.py
@@ -26,12 +26,10 @@ from pydantic_ai.messages import (
 )
 
 from chat.ai_sdk_types import (
-    Attachment,
-    ReasoningDetailText,
+    FileUIPart,
     ReasoningUIPart,
     TextUIPart,
-    ToolInvocationCall,
-    ToolInvocationUIPart,
+    ToolUIPart,
     UIMessage,
 )
 from chat.clients.pydantic_ui_message_converter import model_message_to_ui_message
@@ -86,14 +84,11 @@ def test_model_message_to_ui_message_tool_call_full():
         role="assistant",
         content="",
         parts=[
-            ToolInvocationUIPart(
-                type="tool-invocation",
-                toolInvocation=ToolInvocationCall(
-                    state="call",
-                    toolCallId="id1",
-                    toolName="tool",
-                    args=args,
-                ),
+            ToolUIPart(
+                type="tool-tool",
+                toolCallId="id1",
+                state="input-available",
+                input=args,
             )
         ],
         createdAt=timezone.now(),
@@ -110,13 +105,7 @@ def test_model_message_to_ui_message_reasoning_full():
         id=str(uuid.uuid4()),  # not used in comparison
         role="assistant",
         content="",
-        parts=[
-            ReasoningUIPart(
-                type="reasoning",
-                reasoning="reason",
-                details=[ReasoningDetailText(type="text", text="reason", signature="sig")],
-            )
-        ],
+        parts=[ReasoningUIPart(type="reasoning", text="reason")],
         createdAt=timezone.now(),
     )
     result = model_message_to_ui_message(model_message)
@@ -128,10 +117,7 @@ def test_model_message_to_ui_message_reasoning_full():
     parts_list = list(result.parts)
     part = parts_list[0]
     assert isinstance(part, ReasoningUIPart)
-    assert part.reasoning == "reason"
-    assert part.details[0].type == "text"
-    assert part.details[0].text == "reason"
-    assert part.details[0].signature == "sig"
+    assert part.text == "reason"
 
 
 def test_model_message_to_ui_message_binary_content():
@@ -151,11 +137,11 @@ def test_model_message_to_ui_message_binary_content():
 
     result = model_message_to_ui_message(model_message)
     assert result.role == "user"
-    assert result.parts == [TextUIPart(type="text", text="What do you see?")]
-    assert result.experimental_attachments == [
-        Attachment(
-            name=None,
-            contentType="application/octet-stream",
+    assert result.parts == [
+        TextUIPart(type="text", text="What do you see?"),
+        FileUIPart(
+            type="file",
+            mediaType="application/octet-stream",
             url="data:application/octet-stream;base64,Ymlu",
         ),
     ]
@@ -177,12 +163,13 @@ def test_model_message_to_ui_message_image_url():
 
     result = model_message_to_ui_message(model_message)
     assert result.role == "user"
-    assert result.parts == [TextUIPart(type="text", text="What do you see?")]
-    assert result.experimental_attachments == [
-        Attachment(
-            name="doc1.png",
-            contentType="image/png",
+    assert result.parts == [
+        TextUIPart(type="text", text="What do you see?"),
+        FileUIPart(
+            type="file",
+            mediaType="image/png",
             url="/media/documents/doc1.png",
+            filename="doc1.png",
         ),
     ]
 
@@ -207,12 +194,13 @@ def test_model_message_to_ui_message_document_url():
 
     result = model_message_to_ui_message(model_message)
     assert result.role == "user"
-    assert result.parts == [TextUIPart(type="text", text="Summarize this")]
-    assert result.experimental_attachments == [
-        Attachment(
-            name="doc1.pdf",
-            contentType="application/pdf",
+    assert result.parts == [
+        TextUIPart(type="text", text="Summarize this"),
+        FileUIPart(
+            type="file",
+            mediaType="application/pdf",
             url="/media/documents/doc1.pdf",
+            filename="doc1.pdf",
         ),
     ]
 
@@ -306,8 +294,8 @@ def test_model_message_to_ui_message_tool_call_args_str():
     result = model_message_to_ui_message(model_message)
     parts_list = list(result.parts)
     part = parts_list[0]
-    assert isinstance(part, ToolInvocationUIPart)
-    assert part.toolInvocation.args == args
+    assert isinstance(part, ToolUIPart)
+    assert part.input == args
 
 
 def test_model_message_to_ui_message_with_reasoning_signature_none():
@@ -317,7 +305,7 @@ def test_model_message_to_ui_message_with_reasoning_signature_none():
     parts_list = list(result.parts)
     part = parts_list[0]
     assert isinstance(part, ReasoningUIPart)
-    assert part.details[0].signature is None
+    assert part.text == "reason"
 
 
 def test_model_message_to_ui_message_created_at_response():

--- a/src/backend/chat/tests/clients/pydantic_ui_message_converter/test_ui_message_to_user_content.py
+++ b/src/backend/chat/tests/clients/pydantic_ui_message_converter/test_ui_message_to_user_content.py
@@ -6,12 +6,10 @@ import datetime
 from pydantic_ai.messages import BinaryContent, DocumentUrl
 
 from chat.ai_sdk_types import (
-    Attachment,
     FileUIPart,
     ReasoningUIPart,
     TextUIPart,
-    ToolInvocationCall,
-    ToolInvocationUIPart,
+    ToolUIPart,
     UIMessage,
 )
 from chat.clients.pydantic_ui_message_converter import ui_message_to_user_content
@@ -58,8 +56,9 @@ def test_user_message_with_multiple_text_parts():
 
 def test_user_message_with_file():
     """Test conversion of a user message with a file part."""
-    file_content = "This is a text file content"
+    file_content = b"This is a text file content"
     mime_type = "text/plain"
+    data_url = f"data:{mime_type};base64,{base64.b64encode(file_content).decode()}"
 
     ui_message = UIMessage(
         id="msg3",
@@ -67,7 +66,7 @@ def test_user_message_with_file():
         content="Check this file",
         parts=[
             TextUIPart(type="text", text="Check this file"),
-            FileUIPart(type="file", data=file_content, mimeType=mime_type, name="example.txt"),
+            FileUIPart(type="file", url=data_url, mediaType=mime_type, filename="example.txt"),
         ],
     )
 
@@ -77,28 +76,26 @@ def test_user_message_with_file():
     assert len(result) == 2
     assert result[0] == "Check this file"
     assert isinstance(result[1], BinaryContent)
-    assert result[1].data == file_content.encode("utf-8")
+    assert result[1].data == file_content
     assert result[1].media_type == mime_type
 
 
-def test_user_message_with_experimental_attachment():
-    """Test conversion of a user message with an experimental attachment."""
+def test_user_message_with_v4_experimental_attachment():
+    """A message stored before the v5 upgrade still converts: the shim moves its
+    ``experimental_attachments`` onto file parts."""
     content_type = "image/png"
     sample_data = b"sample image data"
     base64_data = base64.b64encode(sample_data).decode("utf-8")
     data_url = f"data:{content_type};base64,{base64_data}"
 
-    ui_message = UIMessage(
-        id="msg4",
-        role="user",
-        content="Check this image",
-        parts=[TextUIPart(type="text", text="Check this image")],
-        experimental_attachments=[
-            Attachment(
-                contentType=content_type,
-                url=data_url,
-            )
-        ],
+    ui_message = UIMessage.model_validate(
+        {
+            "id": "msg4",
+            "role": "user",
+            "content": "Check this image",
+            "parts": [{"type": "text", "text": "Check this image"}],
+            "experimental_attachments": [{"contentType": content_type, "url": data_url}],
+        }
     )
 
     result = ui_message_to_user_content(ui_message)
@@ -123,19 +120,22 @@ def test_user_message_with_multiple_attachments():
     base64_image = base64.b64encode(image_data).decode("utf-8")
     image_data_url = f"data:{image_content_type};base64,{base64_image}"
 
+    file_data_url = (
+        f"data:{file_mime_type};base64,{base64.b64encode(file_content.encode()).decode()}"
+    )
     ui_message = UIMessage(
         id="msg5",
         role="user",
         content="Check these files",
         parts=[
             TextUIPart(type="text", text="Check these files"),
-            FileUIPart(type="file", data=file_content, mimeType=file_mime_type, name="example.txt"),
-        ],
-        experimental_attachments=[
-            Attachment(
-                contentType=image_content_type,
-                url=image_data_url,
-            )
+            FileUIPart(
+                type="file",
+                url=file_data_url,
+                mediaType=file_mime_type,
+                filename="example.txt",
+            ),
+            FileUIPart(type="file", url=image_data_url, mediaType=image_content_type),
         ],
     )
 
@@ -163,14 +163,11 @@ def test_user_message_with_tool_invocation():
         content="Check the weather",
         parts=[
             TextUIPart(type="text", text="Check the weather"),
-            ToolInvocationUIPart(
-                type="tool-invocation",
-                toolInvocation=ToolInvocationCall(
-                    state="call",
-                    toolCallId="call123",
-                    toolName="get_weather",
-                    args=tool_args,
-                ),
+            ToolUIPart(
+                type="tool-get_weather",
+                toolCallId="call123",
+                state="input-available",
+                input=tool_args,
             ),
         ],
     )
@@ -192,11 +189,7 @@ def test_user_message_with_reasoning():
         content="Let me think",
         parts=[
             TextUIPart(type="text", text="Let me think"),
-            ReasoningUIPart(
-                type="reasoning",
-                reasoning=reasoning_text,
-                details=[],
-            ),
+            ReasoningUIPart(type="reasoning", text=reasoning_text),
         ],
     )
 
@@ -208,18 +201,19 @@ def test_user_message_with_reasoning():
     assert result[0] == "Let me think"
 
 
-def test_experimental_attachment_url():
-    """Test conversion of a user message with an experimental attachment URL."""
+def test_hosted_file_url():
+    """Test conversion of a user message with a hosted (non data URL) file part."""
     ui_message = UIMessage(
         id="msg8",
         role="user",
         content="Check this file",
-        parts=[TextUIPart(type="text", text="Check this file")],
-        experimental_attachments=[
-            Attachment(
-                contentType="text/plain",
+        parts=[
+            TextUIPart(type="text", text="Check this file"),
+            FileUIPart(
+                type="file",
                 url="https://example.com/file.txt",  # Not a data URL
-            )
+                mediaType="text/plain",
+            ),
         ],
     )
 

--- a/src/backend/chat/tests/serializers/test_chat_conversation_input_serializer.py
+++ b/src/backend/chat/tests/serializers/test_chat_conversation_input_serializer.py
@@ -9,12 +9,10 @@ from rest_framework.exceptions import ErrorDetail
 
 from chat import serializers
 from chat.ai_sdk_types import (
-    Attachment,
-    LanguageModelV1Source,
-    SourceUIPart,
+    FileUIPart,
+    SourceUrlUIPart,
     TextUIPart,
-    ToolInvocationResult,
-    ToolInvocationUIPart,
+    ToolUIPart,
     UIMessage,
 )
 from chat.llm_configuration import LLModel, LLMProvider
@@ -76,11 +74,7 @@ def test_chat_conversation_input_serializer_simple_message():
                 id="yuPoOuBkKA4FnKvk",
                 createdAt=_created_at,
                 content="Hello",
-                reasoning=None,
-                experimental_attachments=None,
                 role="user",
-                annotations=None,
-                toolInvocations=None,
                 parts=[TextUIPart(type="text", text="Hello")],
             )
         ]
@@ -180,7 +174,7 @@ def test_chat_conversation_input_serializer_invalid_created_at():
 
 def test_chat_conversation_input_serializer_missing_parts():
     """
-    Ensure serializer fails validation if the 'parts' field is missing from a message.
+    A message with no parts is accepted: its deprecated `content` becomes a text part.
     """
     serializer = serializers.ChatConversationInputSerializer(
         data={
@@ -194,24 +188,8 @@ def test_chat_conversation_input_serializer_missing_parts():
             ]
         }
     )
-    assert not serializer.is_valid()
-    assert serializer.errors["messages"] == [
-        {
-            "input": {
-                "content": ErrorDetail(string="Hello", code="invalid"),
-                "createdAt": ErrorDetail(string="2025-07-03T15:22:17.105Z", code="invalid"),
-                "id": ErrorDetail(string="1", code="invalid"),
-                "role": ErrorDetail(string="user", code="invalid"),
-            },
-            "loc": [
-                ErrorDetail(string="0", code="invalid"),
-                ErrorDetail(string="parts", code="invalid"),
-            ],
-            "msg": ErrorDetail(string="Field required", code="invalid"),
-            "type": ErrorDetail(string="missing", code="invalid"),
-            "url": ErrorDetail(string="https://errors.pydantic.dev/2.13/v/missing", code="invalid"),
-        }
-    ]
+    assert serializer.is_valid()
+    assert serializer.validated_data["messages"][0].parts == [TextUIPart(type="text", text="Hello")]
 
 
 def test_chat_conversation_input_serializer_multiple_messages():
@@ -330,23 +308,22 @@ def test_chat_conversation_input_serializer_with_attachments():
         }
     )
     assert serializer.is_valid()
+    # The v4 attachment is upconverted to a v5 file part.
     assert serializer.validated_data["messages"] == [
         UIMessage(
             id="7x3hLsq6rB3xp91T",
             createdAt=_created_at,
             content="How's the weather in this image?",
-            reasoning=None,
-            experimental_attachments=[
-                Attachment(
-                    name="weather.jpg",
-                    contentType="image/png",
-                    url="data:image/png;base64,iVBORw0KGgoAAAAN...",
-                )
-            ],
             role="user",
-            annotations=None,
-            toolInvocations=None,
-            parts=[TextUIPart(type="text", text="How's the weather in this image?")],
+            parts=[
+                TextUIPart(type="text", text="How's the weather in this image?"),
+                FileUIPart(
+                    type="file",
+                    filename="weather.jpg",
+                    mediaType="image/png",
+                    url="data:image/png;base64,iVBORw0KGgoAAAAN...",
+                ),
+            ],
         )
     ]
 
@@ -403,32 +380,19 @@ def test_chat_conversation_input_serializer_with_source():
             id="e7K0fIPCfsMHr72C",
             createdAt=_created_at,
             content="Qui est Jean Valjean ?",
-            reasoning=None,
-            experimental_attachments=None,
             role="user",
-            annotations=None,
-            toolInvocations=None,
             parts=[TextUIPart(type="text", text="Qui est Jean Valjean ?")],
         ),
         UIMessage(
             id="ni646jbPmW8fQ9zm",
             createdAt=_created_at,
             content="Jean Valjean est génial.",
-            reasoning=None,
-            experimental_attachments=None,
             role="assistant",
-            annotations=None,
-            toolInvocations=None,
             parts=[
-                SourceUIPart(
-                    type="source",
-                    source=LanguageModelV1Source(
-                        sourceType="url",
-                        id="c2b834e7-0cdf-4dfb-b0ce-4e0a50d0fa5a",
-                        url="https://touslesjeans.example.com/",
-                        title=None,
-                        providerMetadata={},
-                    ),
+                SourceUrlUIPart(
+                    type="source-url",
+                    sourceId="c2b834e7-0cdf-4dfb-b0ce-4e0a50d0fa5a",
+                    url="https://touslesjeans.example.com/",
                 ),
                 TextUIPart(type="text", text="Jean Valjean est génial."),
             ],
@@ -437,11 +401,7 @@ def test_chat_conversation_input_serializer_with_source():
             id="JKiIRnWwFE9hL2Cb",
             createdAt=_created_at,
             content="Quel est son parcours ?",
-            reasoning=None,
-            experimental_attachments=None,
             role="user",
-            annotations=None,
-            toolInvocations=None,
             parts=[TextUIPart(type="text", text="Quel est son parcours ?")],
         ),
     ]
@@ -498,33 +458,21 @@ def test_chat_conversation_input_serializer_with_tool():
             id="e7K0fIPCfsMHr72C",
             createdAt=_created_at,
             content="Weather in Paris?",
-            reasoning=None,
-            experimental_attachments=None,
             role="user",
-            annotations=None,
-            toolInvocations=None,
             parts=[TextUIPart(type="text", text="Weather in Paris?")],
         ),
         UIMessage(
             id="ni646jbPmW8fQ9zm",
             createdAt=_created_at,
             content="It beautiful.",
-            reasoning=None,
-            experimental_attachments=None,
             role="assistant",
-            annotations=None,
-            toolInvocations=None,
             parts=[
-                ToolInvocationUIPart(
-                    type="tool-invocation",
-                    toolInvocation=ToolInvocationResult(
-                        toolCallId="tool-invocation-id",
-                        toolName="weather",
-                        args={"location": "Paris, France"},
-                        result={"temperature": "25", "condition": "sunny"},
-                        state="result",
-                        step=None,
-                    ),
+                ToolUIPart(
+                    type="tool-weather",
+                    toolCallId="tool-invocation-id",
+                    state="output-available",
+                    input={"location": "Paris, France"},
+                    output={"temperature": "25", "condition": "sunny"},
                 )
             ],
         ),
@@ -532,11 +480,7 @@ def test_chat_conversation_input_serializer_with_tool():
             id="JKiIRnWwFE9hL2Cb",
             createdAt=_created_at,
             content="Nice",
-            reasoning=None,
-            experimental_attachments=None,
             role="user",
-            annotations=None,
-            toolInvocations=None,
             parts=[TextUIPart(type="text", text="Nice")],
         ),
     ]

--- a/src/backend/chat/tests/serializers/test_chat_conversation_request_serializer.py
+++ b/src/backend/chat/tests/serializers/test_chat_conversation_request_serializer.py
@@ -38,32 +38,6 @@ def test_chat_conversation_request_serializer_default():
     assert serializer.validated_data == {
         "force_web_search": False,
         "model_hrid": None,
-        "protocol": "data",
-    }
-
-
-@pytest.mark.parametrize(
-    "protocol",
-    ["data", "text"],
-)
-def test_chat_conversation_request_serializer_protocol_valid(protocol):
-    """
-    Test that the serializer accepts valid protocol values ('data', 'text').
-    """
-    serializer = serializers.ChatConversationRequestSerializer(data={"protocol": protocol})
-    assert serializer.is_valid()
-
-
-def test_chat_conversation_request_serializer_protocol_invalid():
-    """
-    Test that the serializer rejects invalid protocol values.
-    """
-    serializer = serializers.ChatConversationRequestSerializer(data={"protocol": "invalid"})
-    assert not serializer.is_valid()
-    assert serializer.errors == {
-        "protocol": [
-            ErrorDetail(string="Protocol must be either 'text' or 'data'.", code="invalid")
-        ]
     }
 
 

--- a/src/backend/chat/tests/serializers/test_chat_conversation_serializer.py
+++ b/src/backend/chat/tests/serializers/test_chat_conversation_serializer.py
@@ -7,7 +7,7 @@ import pytest
 from core.file_upload.enums import AttachmentStatus
 
 from chat import serializers
-from chat.ai_sdk_types import Attachment, TextUIPart, UIMessage
+from chat.ai_sdk_types import FileUIPart, TextUIPart, UIMessage
 from chat.factories import (
     ChatConversationFactory,
     ChatProjectAttachmentFactory,
@@ -22,10 +22,9 @@ def _image_message(name: str, msg_id: str = "1") -> UIMessage:
     return UIMessage(
         id=msg_id,
         role="user",
-        content="here",
-        parts=[TextUIPart(text="here", type="text")],
-        experimental_attachments=[
-            Attachment(name=name, contentType="image/png", url=f"/media-key/{name}")
+        parts=[
+            TextUIPart(text="here", type="text"),
+            FileUIPart(type="file", filename=name, mediaType="image/png", url=f"/media-key/{name}"),
         ],
     )
 

--- a/src/backend/chat/tests/test_ai_agent_service_co2.py
+++ b/src/backend/chat/tests/test_ai_agent_service_co2.py
@@ -62,12 +62,12 @@ def final_output_fixture():
     return [ModelResponse(parts=[TextPart(content="Hello")], kind="response")]
 
 
-# --- _prepare_update_conversation: per-message annotation ---
+# --- _prepare_update_conversation: per-message metadata ---
 
 
 @pytest.mark.parametrize("co2_impact", [500, 123])
-def test_co2_annotation_added_when_nonzero(conversation, service, final_output, co2_impact):
-    """An annotation with the co2_impact value is added to the assistant message."""
+def test_co2_metadata_added_when_nonzero(conversation, service, final_output, co2_impact):
+    """The co2_impact value is added to the assistant message metadata."""
     service._prepare_update_conversation(
         final_output=final_output,
         usage={"promptTokens": 10, "completionTokens": 5, "co2_impact": co2_impact},
@@ -75,11 +75,11 @@ def test_co2_annotation_added_when_nonzero(conversation, service, final_output, 
     )
 
     assistant_msg = conversation.messages[-1]
-    assert {"co2_impact": pytest.approx(float(co2_impact))} in (assistant_msg.annotations or [])
+    assert assistant_msg.metadata == {"co2_impact": pytest.approx(float(co2_impact))}
 
 
-def test_no_co2_annotation_when_zero(conversation, service, final_output):
-    """No co2_impact annotation is added when co2_impact is 0."""
+def test_no_co2_metadata_when_zero(conversation, service, final_output):
+    """No co2_impact metadata is added when co2_impact is 0."""
     service._prepare_update_conversation(
         final_output=final_output,
         usage={"promptTokens": 10, "completionTokens": 5, "co2_impact": 0},
@@ -87,8 +87,7 @@ def test_no_co2_annotation_when_zero(conversation, service, final_output):
     )
 
     assistant_msg = conversation.messages[-1]
-    co2_annotations = [a for a in (assistant_msg.annotations or []) if "co2_impact" in a]
-    assert co2_annotations == []
+    assert "co2_impact" not in (assistant_msg.metadata or {})
 
 
 # --- _prepare_update_conversation: cumulative usage across runs ---

--- a/src/backend/chat/tests/test_ai_sdk_upconvert.py
+++ b/src/backend/chat/tests/test_ai_sdk_upconvert.py
@@ -1,0 +1,188 @@
+"""Tests for the v4 -> v5 upconversion of stored (and inbound) messages.
+
+Conversations written before the SDK v5 upgrade are never migrated in the
+database: they are brought up to shape when parsed. These fixtures mirror what
+the v4 backend actually stored.
+"""
+
+import pytest
+
+from chat.ai_sdk_types import DEFAULT_MEDIA_TYPE, UIMessage, upconvert_v4_message
+from chat.clients.pydantic_ui_message_converter import ui_message_to_user_content
+
+# An assistant turn as `_prepare_update_conversation` stored it under v4.
+V4_ASSISTANT_MESSAGE = {
+    "id": "trace-1234",
+    "role": "assistant",
+    "content": "Here is what I found.",
+    "createdAt": "2026-07-25T10:36:35.297675Z",
+    "annotations": [{"co2_impact": 1.5e-9}],
+    "parts": [
+        {"type": "step-start"},
+        {
+            "type": "tool-invocation",
+            "toolInvocation": {
+                "state": "result",
+                "toolCallId": "call-1",
+                "toolName": "document_search_rag",
+                "args": {"query": "what?"},
+                "result": [{"url": "doc.pdf", "content": "..."}],
+            },
+        },
+        {"type": "text", "text": "Here is what I found."},
+        {
+            "type": "source",
+            "source": {
+                "sourceType": "url",
+                "id": "src-1",
+                "url": "doc.pdf",
+                "title": None,
+                "providerMetadata": {},
+            },
+        },
+        {
+            "type": "reasoning",
+            "reasoning": "thinking out loud",
+            "details": [{"type": "text", "text": "thinking out loud", "signature": "sig"}],
+        },
+    ],
+}
+
+# A user turn with an image the model could not read.
+V4_USER_MESSAGE = {
+    "id": "user-1",
+    "role": "user",
+    "content": "What is in this image?",
+    "parts": [{"type": "text", "text": "What is in this image?"}],
+    "experimental_attachments": [
+        {
+            "name": "sample.png",
+            "contentType": "image/png",
+            "url": "/media-key/sample.png",
+            "skipped": {"reason": "model_text_only"},
+        }
+    ],
+}
+
+
+def test_upconverts_a_stored_assistant_message():
+    """Every v4 part shape becomes its v5 equivalent."""
+    message = UIMessage.model_validate(V4_ASSISTANT_MESSAGE)
+
+    assert message.metadata == {"co2_impact": 1.5e-9}
+    assert [part.model_dump(exclude_none=True) for part in message.parts] == [
+        {"type": "step-start"},
+        {
+            "type": "tool-document_search_rag",
+            "toolCallId": "call-1",
+            "state": "output-available",
+            "input": {"query": "what?"},
+            "output": [{"url": "doc.pdf", "content": "..."}],
+        },
+        {"type": "text", "text": "Here is what I found."},
+        {"type": "source-url", "sourceId": "src-1", "url": "doc.pdf"},
+        {"type": "reasoning", "text": "thinking out loud"},
+    ]
+
+
+def test_upconverts_attachments_to_file_parts():
+    """Attachments move onto the parts, keeping the `skipped` stamp the UI reads."""
+    message = UIMessage.model_validate(V4_USER_MESSAGE)
+
+    assert [part.model_dump(exclude_none=True) for part in message.parts] == [
+        {"type": "text", "text": "What is in this image?"},
+        {
+            "type": "file",
+            "mediaType": "image/png",
+            "url": "/media-key/sample.png",
+            "filename": "sample.png",
+            "skipped": {"reason": "model_text_only"},
+        },
+    ]
+
+
+def test_upconverts_an_attachment_stored_without_a_content_type():
+    """`contentType` was optional in v4; a missing one must not fail the read."""
+    message = UIMessage.model_validate(
+        {
+            "id": "user-2",
+            "role": "user",
+            "parts": [],
+            "experimental_attachments": [{"url": "/media-key/unknown.bin"}],
+        }
+    )
+
+    assert [part.model_dump(exclude_none=True) for part in message.parts] == [
+        {"type": "file", "mediaType": DEFAULT_MEDIA_TYPE, "url": "/media-key/unknown.bin"}
+    ]
+
+
+def test_upconverts_a_tool_invocation_stored_without_a_state():
+    """Without a state, only a stored result says the invocation completed."""
+    message = UIMessage.model_validate(
+        {
+            "id": "assistant-2",
+            "role": "assistant",
+            "parts": [
+                {
+                    "type": "tool-invocation",
+                    "toolInvocation": {"toolCallId": "call-1", "toolName": "search", "args": {}},
+                }
+            ],
+        }
+    )
+
+    assert [part.model_dump(exclude_none=True) for part in message.parts] == [
+        {
+            "type": "tool-search",
+            "toolCallId": "call-1",
+            "state": "input-available",
+            "input": {},
+        }
+    ]
+
+
+def test_synthesizes_a_text_part_from_a_bare_content():
+    """The oldest messages have no parts at all, only the deprecated `content`."""
+    message = UIMessage.model_validate(
+        {"id": "old-1", "role": "user", "content": "Hello", "parts": []}
+    )
+
+    assert [part.model_dump(exclude_none=True) for part in message.parts] == [
+        {"type": "text", "text": "Hello"}
+    ]
+
+
+@pytest.mark.parametrize("raw", [V4_ASSISTANT_MESSAGE, V4_USER_MESSAGE], ids=["assistant", "user"])
+def test_upconversion_is_idempotent(raw):
+    """A v5 message passes through untouched, so re-parsing is safe."""
+    once = UIMessage.model_validate(raw)
+    twice = UIMessage.model_validate(once.model_dump(exclude_none=True))
+
+    assert twice.model_dump() == once.model_dump()
+    assert upconvert_v4_message(once.model_dump(exclude_none=True)) == once.model_dump(
+        exclude_none=True
+    )
+
+
+def test_llm_history_is_unchanged_by_the_upconversion():
+    """A stored v4 turn hands the model the same content as its v5 equivalent."""
+    # The same turn as `V4_USER_MESSAGE`, written the way v5 stores it.
+    v5_message = {
+        "id": "user-1",
+        "role": "user",
+        "parts": [
+            {"type": "text", "text": "What is in this image?"},
+            {
+                "type": "file",
+                "mediaType": "image/png",
+                "url": "/media-key/sample.png",
+                "filename": "sample.png",
+                "skipped": {"reason": "model_text_only"},
+            },
+        ],
+    }
+
+    assert ui_message_to_user_content(UIMessage.model_validate(V4_USER_MESSAGE)) == (
+        ui_message_to_user_content(UIMessage.model_validate(v5_message))
+    )

--- a/src/backend/chat/tests/test_ai_sdk_upconvert.py
+++ b/src/backend/chat/tests/test_ai_sdk_upconvert.py
@@ -1,0 +1,149 @@
+"""Tests for the v4 -> v5 upconversion of stored (and inbound) messages.
+
+Conversations written before the SDK v5 upgrade are never migrated in the
+database: they are brought up to shape when parsed. These fixtures mirror what
+the v4 backend actually stored.
+"""
+
+import pytest
+
+from chat.ai_sdk_types import DEFAULT_MEDIA_TYPE, UIMessage, upconvert_v4_message
+from chat.clients.pydantic_ui_message_converter import ui_message_to_user_content
+
+# An assistant turn as `_prepare_update_conversation` stored it under v4.
+V4_ASSISTANT_MESSAGE = {
+    "id": "trace-1234",
+    "role": "assistant",
+    "content": "Here is what I found.",
+    "createdAt": "2026-07-25T10:36:35.297675Z",
+    "annotations": [{"co2_impact": 1.5e-9}],
+    "parts": [
+        {"type": "step-start"},
+        {
+            "type": "tool-invocation",
+            "toolInvocation": {
+                "state": "result",
+                "toolCallId": "call-1",
+                "toolName": "document_search_rag",
+                "args": {"query": "what?"},
+                "result": [{"url": "doc.pdf", "content": "..."}],
+            },
+        },
+        {"type": "text", "text": "Here is what I found."},
+        {
+            "type": "source",
+            "source": {
+                "sourceType": "url",
+                "id": "src-1",
+                "url": "doc.pdf",
+                "title": None,
+                "providerMetadata": {},
+            },
+        },
+        {
+            "type": "reasoning",
+            "reasoning": "thinking out loud",
+            "details": [{"type": "text", "text": "thinking out loud", "signature": "sig"}],
+        },
+    ],
+}
+
+# A user turn with an image the model could not read.
+V4_USER_MESSAGE = {
+    "id": "user-1",
+    "role": "user",
+    "content": "What is in this image?",
+    "parts": [{"type": "text", "text": "What is in this image?"}],
+    "experimental_attachments": [
+        {
+            "name": "sample.png",
+            "contentType": "image/png",
+            "url": "/media-key/sample.png",
+            "skipped": {"reason": "model_text_only"},
+        }
+    ],
+}
+
+
+def test_upconverts_a_stored_assistant_message():
+    """Every v4 part shape becomes its v5 equivalent."""
+    message = UIMessage.model_validate(V4_ASSISTANT_MESSAGE)
+
+    assert message.metadata == {"co2_impact": 1.5e-9}
+    assert [part.model_dump(exclude_none=True) for part in message.parts] == [
+        {"type": "step-start"},
+        {
+            "type": "tool-document_search_rag",
+            "toolCallId": "call-1",
+            "state": "output-available",
+            "input": {"query": "what?"},
+            "output": [{"url": "doc.pdf", "content": "..."}],
+        },
+        {"type": "text", "text": "Here is what I found."},
+        {"type": "source-url", "sourceId": "src-1", "url": "doc.pdf"},
+        {"type": "reasoning", "text": "thinking out loud"},
+    ]
+
+
+def test_upconverts_attachments_to_file_parts():
+    """Attachments move onto the parts, keeping the `skipped` stamp the UI reads."""
+    message = UIMessage.model_validate(V4_USER_MESSAGE)
+
+    assert [part.model_dump(exclude_none=True) for part in message.parts] == [
+        {"type": "text", "text": "What is in this image?"},
+        {
+            "type": "file",
+            "mediaType": "image/png",
+            "url": "/media-key/sample.png",
+            "filename": "sample.png",
+            "skipped": {"reason": "model_text_only"},
+        },
+    ]
+
+
+def test_upconverts_an_attachment_stored_without_a_content_type():
+    """`contentType` was optional in v4; a missing one must not fail the read."""
+    message = UIMessage.model_validate(
+        {
+            "id": "user-2",
+            "role": "user",
+            "parts": [],
+            "experimental_attachments": [{"url": "/media-key/unknown.bin"}],
+        }
+    )
+
+    assert [part.model_dump(exclude_none=True) for part in message.parts] == [
+        {"type": "file", "mediaType": DEFAULT_MEDIA_TYPE, "url": "/media-key/unknown.bin"}
+    ]
+
+
+def test_synthesizes_a_text_part_from_a_bare_content():
+    """The oldest messages have no parts at all, only the deprecated `content`."""
+    message = UIMessage.model_validate(
+        {"id": "old-1", "role": "user", "content": "Hello", "parts": []}
+    )
+
+    assert [part.model_dump(exclude_none=True) for part in message.parts] == [
+        {"type": "text", "text": "Hello"}
+    ]
+
+
+@pytest.mark.parametrize("raw", [V4_ASSISTANT_MESSAGE, V4_USER_MESSAGE], ids=["assistant", "user"])
+def test_upconversion_is_idempotent(raw):
+    """A v5 message passes through untouched, so re-parsing is safe."""
+    once = UIMessage.model_validate(raw)
+    twice = UIMessage.model_validate(once.model_dump(exclude_none=True))
+
+    assert twice.model_dump() == once.model_dump()
+    assert upconvert_v4_message(once.model_dump(exclude_none=True)) == once.model_dump(
+        exclude_none=True
+    )
+
+
+def test_llm_history_is_unchanged_by_the_upconversion():
+    """The content handed to the model is the same before and after the shim."""
+    upconverted = UIMessage.model_validate(upconvert_v4_message(dict(V4_USER_MESSAGE)))
+
+    assert ui_message_to_user_content(UIMessage.model_validate(V4_USER_MESSAGE)) == (
+        ui_message_to_user_content(upconverted)
+    )

--- a/src/backend/chat/tests/test_legacy_message_formats.py
+++ b/src/backend/chat/tests/test_legacy_message_formats.py
@@ -1,0 +1,206 @@
+"""Read surfaces against a database that holds both AI SDK message formats.
+
+Conversations written before the v5 upgrade are never migrated: ``upconvert_v4_message``
+brings them up to shape as they are parsed. The stored history therefore mixes both
+shapes - across conversations, and inside a single one as soon as an old conversation is
+continued. These tests plant genuine v4 rows with raw SQL: assigning them through the ORM
+would upconvert them on the way in, leaving nothing legacy to read back.
+"""
+
+import json
+
+from django.contrib.admin.sites import AdminSite
+from django.db import connection
+from django.test import RequestFactory
+
+import pytest
+from rest_framework import status
+
+from core.factories import UserFactory
+
+from chat.admin import ChatConversationAdmin
+from chat.ai_sdk_types import TextUIPart, UIMessage
+from chat.factories import ChatConversationFactory
+from chat.models import ChatConversation
+
+pytestmark = pytest.mark.django_db
+
+# A user turn as the v4 backend stored it: an attachment list beside the parts.
+V4_USER_MESSAGE = {
+    "id": "user-1",
+    "role": "user",
+    "content": "What is in this image?",
+    "parts": [{"type": "text", "text": "What is in this image?"}],
+    "experimental_attachments": [
+        {"name": "sample.png", "contentType": "image/png", "url": "/media-key/sample.png"}
+    ],
+}
+
+# An assistant turn as the v4 backend stored it: tool call, source and reasoning in
+# their old shapes, and the CO2 impact carried as an annotation.
+V4_ASSISTANT_MESSAGE = {
+    "id": "trace-1",
+    "role": "assistant",
+    "content": "Here is what I found.",
+    "annotations": [{"co2_impact": 1.5e-9}],
+    "parts": [
+        {"type": "step-start"},
+        {
+            "type": "tool-invocation",
+            "toolInvocation": {
+                "state": "result",
+                "toolCallId": "call-1",
+                "toolName": "document_search_rag",
+                "args": {"query": "what?"},
+                "result": [{"url": "doc.pdf", "content": "..."}],
+            },
+        },
+        {"type": "text", "text": "Here is what I found."},
+        {"type": "source", "source": {"sourceType": "url", "id": "src-1", "url": "doc.pdf"}},
+        {"type": "reasoning", "reasoning": "thinking out loud"},
+    ],
+}
+
+# The next turn of that same conversation, written after the upgrade.
+V5_ASSISTANT_MESSAGE = {
+    "id": "trace-2",
+    "role": "assistant",
+    "metadata": {"co2_impact": 2.5e-9},
+    "parts": [{"type": "text", "text": "And this is the follow-up."}],
+}
+
+UPCONVERTED_V4_USER_PARTS = [
+    {"type": "text", "text": "What is in this image?"},
+    {
+        "type": "file",
+        "mediaType": "image/png",
+        "url": "/media-key/sample.png",
+        "filename": "sample.png",
+        "skipped": None,
+    },
+]
+
+UPCONVERTED_V4_ASSISTANT_PARTS = [
+    {"type": "step-start"},
+    {
+        "type": "tool-document_search_rag",
+        "toolCallId": "call-1",
+        "state": "output-available",
+        "input": {"query": "what?"},
+        "output": [{"url": "doc.pdf", "content": "..."}],
+        "errorText": None,
+    },
+    {"type": "text", "text": "Here is what I found."},
+    {"type": "source-url", "sourceId": "src-1", "url": "doc.pdf", "title": None},
+    {"type": "reasoning", "text": "thinking out loud"},
+]
+
+
+def store_raw_messages(conversation, messages):
+    """Write raw JSON straight into the column, bypassing the field's pydantic dump.
+
+    Assigning ``conversation.messages`` would validate the list on the way out,
+    which upconverts it - exactly what must not happen when planting a row that
+    predates the upgrade.
+    """
+    with connection.cursor() as cursor:
+        cursor.execute(
+            f"UPDATE {ChatConversation._meta.db_table} SET messages = %s WHERE id = %s",
+            [json.dumps(messages), str(conversation.pk)],
+        )
+
+
+@pytest.fixture(name="text_only_model")
+def text_only_model_fixture(settings):
+    """Pin a model that cannot read images, so `images_skipped` inspects the history."""
+    configurations = dict(settings.LLM_CONFIGURATIONS)
+    hrid = "default-model"
+    configurations[hrid] = configurations[hrid].model_copy(update={"supports_image": False})
+    settings.LLM_CONFIGURATIONS = configurations
+    return hrid
+
+
+def test_retrieve_upconverts_a_conversation_mixing_both_formats(api_client):
+    """The conversation GET view hands the client a v5 history, whatever is stored."""
+    conversation = ChatConversationFactory()
+    store_raw_messages(conversation, [V4_USER_MESSAGE, V4_ASSISTANT_MESSAGE, V5_ASSISTANT_MESSAGE])
+
+    api_client.force_login(conversation.owner)
+    response = api_client.get(f"/api/v1.0/chats/{conversation.pk}/")
+
+    assert response.status_code == status.HTTP_200_OK
+    messages = response.json()["messages"]
+    assert [message["parts"] for message in messages] == [
+        UPCONVERTED_V4_USER_PARTS,
+        UPCONVERTED_V4_ASSISTANT_PARTS,
+        V5_ASSISTANT_MESSAGE["parts"],
+    ]
+    # The v4 annotation became metadata; the v5 turn kept the metadata it was stored with.
+    assert [message["metadata"] for message in messages] == [
+        None,
+        {"co2_impact": 1.5e-9},
+        {"co2_impact": 2.5e-9},
+    ]
+    # Nothing v4-shaped reaches the client.
+    assert not any("experimental_attachments" in message for message in messages)
+
+
+def test_sidebar_lists_conversations_stored_in_both_formats(api_client):
+    """The sidebar serializes every conversation's history, so one legacy row
+    left unparsed would take the whole list down, not just its own entry."""
+    owner = UserFactory()
+    legacy = ChatConversationFactory(owner=owner)
+    store_raw_messages(legacy, [V4_USER_MESSAGE, V4_ASSISTANT_MESSAGE])
+    current = ChatConversationFactory(
+        owner=owner,
+        messages=[UIMessage(id="new-1", role="user", parts=[TextUIPart(type="text", text="hi")])],
+    )
+
+    api_client.force_login(owner)
+    response = api_client.get("/api/v1.0/chats/?project=none")
+
+    assert response.status_code == status.HTTP_200_OK
+    histories = {result["id"]: result["messages"] for result in response.json()["results"]}
+    assert [message["parts"] for message in histories[str(legacy.pk)]] == [
+        UPCONVERTED_V4_USER_PARTS,
+        UPCONVERTED_V4_ASSISTANT_PARTS,
+    ]
+    assert [message["parts"] for message in histories[str(current.pk)]] == [
+        [{"type": "text", "text": "hi"}]
+    ]
+
+
+def test_sidebar_flags_images_skipped_on_a_v4_attachment(api_client, text_only_model):
+    """`images_skipped` reads v5 file parts only: a legacy image has to be
+    upconverted for the banner to still show on an old conversation."""
+    conversation = ChatConversationFactory(model_hrid=text_only_model)
+    store_raw_messages(conversation, [V4_USER_MESSAGE])
+
+    api_client.force_login(conversation.owner)
+    response = api_client.get("/api/v1.0/chats/?project=none")
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["results"][0]["images_skipped"] is True
+
+
+def test_admin_change_form_loads_a_conversation_mixing_both_formats():
+    """The changelist defers `messages`; the change form is where the admin first
+    parses them, one lazy query on the object it edits."""
+    conversation = ChatConversationFactory()
+    store_raw_messages(conversation, [V4_USER_MESSAGE, V4_ASSISTANT_MESSAGE, V5_ASSISTANT_MESSAGE])
+
+    admin_instance = ChatConversationAdmin(ChatConversation, AdminSite())
+    request = RequestFactory().get("/")
+    request.user = UserFactory(is_staff=True, is_superuser=True)
+    deferred = admin_instance.get_queryset(request).get(pk=conversation.pk)
+    assert "messages" in deferred.get_deferred_fields()
+
+    form = admin_instance.get_form(request, deferred)(instance=deferred)
+
+    # Part shapes are asserted by the retrieve test; here what matters is that the
+    # lazy load parses the legacy turns instead of raising on them.
+    assert [[part.type for part in message.parts] for message in form.initial["messages"]] == [
+        ["text", "file"],
+        ["step-start", "tool-document_search_rag", "text", "source-url", "reasoning"],
+        ["text"],
+    ]

--- a/src/backend/chat/tests/utils.py
+++ b/src/backend/chat/tests/utils.py
@@ -1,8 +1,11 @@
 """tools for testing chat functionality"""
 
+import json
 import re
 
 from rest_framework import status
+
+UI_MESSAGE_STREAM_HEADER = "x-vercel-ai-ui-message-stream"
 
 ZERO_USAGE = {
     "cache_audio_read_tokens": 0,
@@ -17,11 +20,34 @@ ZERO_USAGE = {
 
 
 def assert_data_stream_response(response):
-    """Assert a response is a valid Vercel AI SDK data-stream SSE response."""
+    """Assert a response is a valid Vercel AI SDK UI message stream response."""
     assert response.status_code == status.HTTP_200_OK
     assert response.get("Content-Type") == "text/event-stream"
-    assert response.get("x-vercel-ai-data-stream") == "v1"
+    assert response.get(UI_MESSAGE_STREAM_HEADER) == "v1"
     assert response.streaming
+
+
+def stream_frames(chunks):
+    """Split a UI message stream into its SSE payloads, terminator included."""
+    stream = chunks if isinstance(chunks, str) else "".join(chunks)
+    return [frame.removeprefix("data: ") for frame in stream.split("\n\n") if frame]
+
+
+def stream_body(chunks):
+    """The stream payloads, without the opening `start` frame and the terminator."""
+    frames = stream_frames(chunks)
+    assert frames[0].startswith('{"type":"start"'), frames[0]
+    assert frames[-1] == "[DONE]", frames[-1]
+    return frames[1:-1]
+
+
+def stream_text(chunks):
+    """Concatenate the text deltas of a UI message stream."""
+    return "".join(
+        event["delta"]
+        for event in map(json.loads, stream_body(chunks))
+        if event["type"] == "text-delta"
+    )
 
 
 def replace_uuids_with_placeholder(text):

--- a/src/backend/chat/tests/vercel_ai_sdk/test_v4_to_v5.py
+++ b/src/backend/chat/tests/vercel_ai_sdk/test_v4_to_v5.py
@@ -1,0 +1,170 @@
+"""Golden tests for the v4 -> v5 stream translation.
+
+These assert the exact SSE bytes the frontend receives: they are the contract
+with the Vercel AI SDK's ``processUIMessageStream``.
+"""
+
+import pytest
+
+from chat.vercel_ai_sdk.core import events_v4, events_v5
+from chat.vercel_ai_sdk.encoder.encoder import DONE_FRAME, EventEncoder, EventEncoderVersion
+from chat.vercel_ai_sdk.encoder.v4_to_v5 import V4ToV5Translator, data_part_type
+
+
+def encode_stream(events, message_id="trace-abc"):
+    """Run v4 events through the translator and return the full SSE stream."""
+    encoder = EventEncoder(EventEncoderVersion.V5)
+    translator = V4ToV5Translator()
+    chunks = [encoder.encode(events_v5.MessageStartEvent(messageId=message_id))]
+    for event in events:
+        chunks += [encoder.encode(translated) for translated in translator.translate(event)]
+    chunks += [encoder.encode(translated) for translated in translator.flush()]
+    chunks.append(DONE_FRAME)
+    return "".join(chunks)
+
+
+def frames(stream):
+    """Split an SSE stream into its ``data:`` payloads."""
+    return [frame[len("data: ") :] for frame in stream.split("\n\n") if frame]
+
+
+def test_translates_a_full_turn():
+    """A complete text turn translates to the exact expected SSE stream."""
+    stream = encode_stream(
+        [
+            events_v4.TextPart(text="Hello"),
+            events_v4.TextPart(text=" there"),
+            events_v4.StartStepPart(message_id="trace-abc"),
+            events_v4.MessageAnnotationPart(annotations=[{"co2_impact": 0.5}]),
+            events_v4.FinishMessagePart(
+                finish_reason=events_v4.FinishReason.STOP,
+                usage=events_v4.Usage(prompt_tokens=10, completion_tokens=3, co2_impact=0.5),
+            ),
+        ]
+    )
+
+    assert stream == (
+        'data: {"type":"start","messageId":"trace-abc"}\n\n'
+        'data: {"type":"text-start","id":"0"}\n\n'
+        'data: {"type":"text-delta","id":"0","delta":"Hello"}\n\n'
+        'data: {"type":"text-delta","id":"0","delta":" there"}\n\n'
+        'data: {"type":"text-end","id":"0"}\n\n'
+        'data: {"type":"start-step"}\n\n'
+        'data: {"type":"finish","messageMetadata":'
+        '{"usage":{"promptTokens":10,"completionTokens":3,"co2Impact":0.5},"co2_impact":0.5}}\n\n'
+        "data: [DONE]\n\n"
+    )
+
+
+def test_translates_a_tool_call_turn():
+    """Streamed tool input, result and sources map to their v5 counterparts."""
+    stream = encode_stream(
+        [
+            events_v4.ToolCallStreamingStartPart(tool_call_id="c1", tool_name="document_search"),
+            events_v4.ToolCallDeltaPart(tool_call_id="c1", args_text_delta='{"q":'),
+            events_v4.ToolCallPart(tool_call_id="c1", tool_name="document_search", args={"q": "x"}),
+            events_v4.SourcePart(id="s1", url="https://example.test", title="Example"),
+            events_v4.ToolResultPart(tool_call_id="c1", result={"state": "done"}),
+        ]
+    )
+
+    assert frames(stream) == [
+        '{"type":"start","messageId":"trace-abc"}',
+        '{"type":"tool-input-start","toolCallId":"c1","toolName":"document_search"}',
+        '{"type":"tool-input-delta","toolCallId":"c1","inputTextDelta":"{\\"q\\":"}',
+        '{"type":"tool-input-available","toolCallId":"c1","toolName":"document_search",'
+        '"input":{"q":"x"}}',
+        '{"type":"source-url","sourceId":"s1","url":"https://example.test","title":"Example"}',
+        '{"type":"tool-output-available","toolCallId":"c1","output":{"state":"done"}}',
+        "[DONE]",
+    ]
+
+
+def test_text_and_reasoning_blocks_are_opened_and_closed():
+    """Switching between text and reasoning closes the previous block."""
+    stream = encode_stream(
+        [
+            events_v4.ReasoningPart(reasoning="thinking"),
+            events_v4.TextPart(text="answer"),
+            events_v4.ReasoningPart(reasoning="more"),
+        ]
+    )
+
+    assert frames(stream) == [
+        '{"type":"start","messageId":"trace-abc"}',
+        '{"type":"reasoning-start","id":"0"}',
+        '{"type":"reasoning-delta","id":"0","delta":"thinking"}',
+        '{"type":"reasoning-end","id":"0"}',
+        '{"type":"text-start","id":"1"}',
+        '{"type":"text-delta","id":"1","delta":"answer"}',
+        '{"type":"text-end","id":"1"}',
+        '{"type":"reasoning-start","id":"2"}',
+        '{"type":"reasoning-delta","id":"2","delta":"more"}',
+        '{"type":"reasoning-end","id":"2"}',
+        "[DONE]",
+    ]
+
+
+def test_data_parts_are_named_and_transient():
+    """Each data item becomes its own named, transient part."""
+    stream = encode_stream(
+        [
+            events_v4.DataPart(
+                data=[
+                    {"type": "cooldown", "seconds": 12},
+                    {
+                        "type": "conversation_metadata",
+                        "conversationId": "c-1",
+                        "title": "A title",
+                    },
+                ]
+            ),
+            events_v4.DataPart(data=[{"type": "keep_alive"}]),
+        ]
+    )
+
+    assert frames(stream)[1:] == [
+        '{"type":"data-cooldown","data":{"type":"cooldown","seconds":12},"transient":true}',
+        '{"type":"data-conversation-metadata","data":{"type":"conversation_metadata",'
+        '"conversationId":"c-1","title":"A title"},"transient":true}',
+        '{"type":"data-keep-alive","data":{"type":"keep_alive"},"transient":true}',
+        "[DONE]",
+    ]
+
+
+def test_error_part_keeps_the_error_code():
+    """The frontend keys its error handling on the code, so it must survive."""
+    stream = encode_stream([events_v4.TextPart(text="oops"), events_v4.ErrorPart(error="llm_429")])
+
+    assert frames(stream)[-2:] == ['{"type":"error","errorText":"llm_429"}', "[DONE]"]
+    # The dangling text block is closed before the error.
+    assert '{"type":"text-end","id":"0"}' in frames(stream)
+
+
+def test_flush_closes_a_dangling_block():
+    """A stream cut short after text still closes its block."""
+    translator = V4ToV5Translator()
+    translator.translate(events_v4.TextPart(text="partial"))
+
+    assert [event.type for event in translator.flush()] == [events_v5.EventType.TEXT_END]
+    assert not translator.flush()
+
+
+def test_data_item_without_a_type_is_dropped():
+    """An unnamed data item cannot be routed by the client, so it is not emitted."""
+    translator = V4ToV5Translator()
+
+    assert translator.translate(events_v4.DataPart(data=[{"status": "WAITING"}])) == []
+
+
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [
+        ("cooldown", "data-cooldown"),
+        ("keep_alive", "data-keep-alive"),
+        ("images_skipped", "data-images-skipped"),
+    ],
+)
+def test_data_part_type_is_kebab_cased(name, expected):
+    """Data part names are kebab-cased on the wire."""
+    assert data_part_type(name) == expected

--- a/src/backend/chat/tests/views/chat/conversations/test_conversation.py
+++ b/src/backend/chat/tests/views/chat/conversations/test_conversation.py
@@ -19,10 +19,9 @@ from core.factories import UserFactory
 
 from chat.agents.conversation import PREVENT_URL_HALLUCINATION_INSTRUCTION
 from chat.ai_sdk_types import (
-    Attachment,
+    FileUIPart,
     TextUIPart,
-    ToolInvocationCall,
-    ToolInvocationUIPart,
+    ToolUIPart,
     UIMessage,
 )
 from chat.factories import ChatConversationFactory
@@ -66,11 +65,7 @@ def _assert_hello_messages(chat_conversation, frozen_now):
         id=chat_conversation.messages[0].id,
         createdAt=frozen_now,
         content="Hello",
-        reasoning=None,
-        experimental_attachments=None,
         role="user",
-        annotations=None,
-        toolInvocations=None,
         parts=[TextUIPart(type="text", text="Hello")],
     )
     assert chat_conversation.messages[1].id == IsUUID(4)
@@ -78,11 +73,7 @@ def _assert_hello_messages(chat_conversation, frozen_now):
         id=chat_conversation.messages[1].id,
         createdAt=frozen_now,
         content="Hello there",
-        reasoning=None,
-        experimental_attachments=None,
         role="assistant",
-        annotations=None,
-        toolInvocations=None,
         parts=[TextUIPart(type="text", text="Hello there")],
     )
 
@@ -160,11 +151,14 @@ def _decode_stream(response):
 
 
 HELLO_STREAM_CONTENT = (
-    '0:"Hello"\n'
-    '0:" there"\n'
-    'f:{"messageId":"<mocked_uuid>"}\n'
-    'd:{"finishReason":"stop","usage":{"promptTokens":0,"completionTokens":0'
-    ',"co2Impact":0.0}}\n'
+    'data: {"type":"start","messageId":"<mocked_uuid>"}\n\n'
+    'data: {"type":"text-start","id":"0"}\n\n'
+    'data: {"type":"text-delta","id":"0","delta":"Hello"}\n\n'
+    'data: {"type":"text-delta","id":"0","delta":" there"}\n\n'
+    'data: {"type":"text-end","id":"0"}\n\n'
+    'data: {"type":"finish","messageMetadata":{"usage":{"promptTokens":0,"completionTokens":0'
+    ',"co2Impact":0.0}}}\n\n'
+    "data: [DONE]\n\n"
 )
 
 
@@ -209,25 +203,13 @@ def test_post_conversation_no_messages(api_client):
     assert response.status_code == status.HTTP_400_BAD_REQUEST
 
 
-def test_post_conversation_invalid_protocol(api_client):
-    """Test posting with an invalid protocol returns a 400 error."""
-    chat_conversation = ChatConversationFactory()
-    url = f"/api/v1.0/chats/{chat_conversation.pk}/conversation/?protocol=invalid"
-    data = {"messages": [{"role": "user", "content": "Hello there"}]}
-    api_client.force_login(chat_conversation.owner)
-    response = api_client.post(url, data, format="json")
-
-    assert response.status_code == status.HTTP_400_BAD_REQUEST
-    assert response.json() == {"protocol": ["Protocol must be either 'text' or 'data'."]}
-
-
 @freeze_time("2025-07-25T10:36:35.297675Z")
 @respx.mock
 def test_post_conversation_data_protocol(api_client, mock_openai_stream, hello_conversation_data):
     """Test posting messages to a conversation using the 'data' protocol."""
     chat_conversation = ChatConversationFactory(owner__language="en-us")
 
-    url = f"/api/v1.0/chats/{chat_conversation.pk}/conversation/?protocol=data"
+    url = f"/api/v1.0/chats/{chat_conversation.pk}/conversation/"
     api_client.force_login(chat_conversation.owner)
 
     response = api_client.post(url, hello_conversation_data, format="json")
@@ -256,13 +238,19 @@ def test_post_conversation_data_protocol(api_client, mock_openai_stream, hello_c
 @freeze_time("2025-07-25T10:36:35.297675Z")
 @respx.mock
 @patch("chat.keepalive.get_current_time")
-def test_post_conversation_data_protocol_triggers_keepalives(
+def test_post_conversation_data_protocol_drops_keepalive_after_the_terminator(
     mock_time, api_client, mock_openai_stream, hello_conversation_data
 ):
-    """Test streaming response contains keepalive messages"""
+    """A keepalive queued as the stream ends is dropped, not sent after `[DONE]`.
+
+    The mocked clock makes every keepalive check trip, so one is queued; the
+    stream itself never pauses, so the only place it could land is past the
+    terminator. A real mid-stream keepalive is covered by
+    ``test_post_conversation_async_triggers_keepalive``.
+    """
     chat_conversation = ChatConversationFactory(owner__language="en-us")
-    mock_time.side_effect = [float(i * 60) for i in range(10)]
-    url = f"/api/v1.0/chats/{chat_conversation.pk}/conversation/?protocol=data"
+    mock_time.side_effect = [float(i * 60) for i in range(20)]
+    url = f"/api/v1.0/chats/{chat_conversation.pk}/conversation/"
     api_client.force_login(chat_conversation.owner)
 
     response = api_client.post(url, hello_conversation_data, format="json")
@@ -272,12 +260,14 @@ def test_post_conversation_data_protocol_triggers_keepalives(
     response_content = _decode_stream(response)
 
     assert response_content == (
-        '0:"Hello"\n'
-        '0:" there"\n'
-        'f:{"messageId":"<mocked_uuid>"}\n'
-        'd:{"finishReason":"stop","usage":{"promptTokens":0,"completionTokens":0'
-        ',"co2Impact":0.0}}\n'
-        '2:[{"status": "WAITING"}]\n'
+        'data: {"type":"start","messageId":"<mocked_uuid>"}\n\n'
+        'data: {"type":"text-start","id":"0"}\n\n'
+        'data: {"type":"text-delta","id":"0","delta":"Hello"}\n\n'
+        'data: {"type":"text-delta","id":"0","delta":" there"}\n\n'
+        'data: {"type":"text-end","id":"0"}\n\n'
+        'data: {"type":"finish","messageMetadata":{"usage":{"promptTokens":0,"completionToken'
+        's":0,"co2Impact":0.0}}}\n\n'
+        "data: [DONE]\n\n"
     )
 
     assert mock_openai_stream.called
@@ -295,42 +285,10 @@ def test_post_conversation_data_protocol_triggers_keepalives(
 
 @freeze_time("2025-07-25T10:36:35.297675Z")
 @respx.mock
-def test_post_conversation_text_protocol(api_client, mock_openai_stream, hello_conversation_data):
-    """Test posting messages to a conversation using the 'text' protocol."""
-    chat_conversation = ChatConversationFactory(owner__language="en-us")
-
-    url = f"/api/v1.0/chats/{chat_conversation.pk}/conversation/?protocol=text"
-    api_client.force_login(chat_conversation.owner)
-
-    response = api_client.post(url, hello_conversation_data, format="json")
-
-    assert response.status_code == status.HTTP_200_OK
-    assert response.get("Content-Type") == "text/event-stream"
-    assert response.streaming
-
-    response_content = b"".join(response.streaming_content).decode("utf-8")
-    assert response_content == "Hello there"
-
-    assert mock_openai_stream.called
-    _assert_english_system_prompts(json.loads(respx.calls.last.request.content))
-
-    chat_conversation.refresh_from_db()
-    _assert_hello_ui_messages(chat_conversation)
-    _assert_hello_messages(chat_conversation, timezone.now())
-
-    _run_id = chat_conversation.pydantic_messages[0]["run_id"]
-    assert chat_conversation.pydantic_messages == [
-        _make_pydantic_request(_run_id, ENGLISH_INSTRUCTIONS, ["Hello"]),
-        _make_pydantic_text_response(_run_id, "Hello there"),
-    ]
-
-
-@freeze_time("2025-07-25T10:36:35.297675Z")
-@respx.mock
 def test_post_conversation_with_image(api_client, mock_openai_stream_image):
     """Ensure an image URL is correctly forwarded to the AI service."""
     chat_conversation = ChatConversationFactory(owner__language="en-us")
-    url = f"/api/v1.0/chats/{chat_conversation.pk}/conversation/?protocol=data"
+    url = f"/api/v1.0/chats/{chat_conversation.pk}/conversation/"
 
     data = {
         "messages": [
@@ -363,11 +321,14 @@ def test_post_conversation_with_image(api_client, mock_openai_stream_image):
     response_content = _decode_stream(response)
 
     assert response_content == (
-        '0:"I see a cat"\n'
-        '0:" in the picture."\n'
-        'f:{"messageId":"<mocked_uuid>"}\n'
-        'd:{"finishReason":"stop","usage":{"promptTokens":0,"completionTokens":0'
-        ',"co2Impact":0.0}}\n'
+        'data: {"type":"start","messageId":"<mocked_uuid>"}\n\n'
+        'data: {"type":"text-start","id":"0"}\n\n'
+        'data: {"type":"text-delta","id":"0","delta":"I see a cat"}\n\n'
+        'data: {"type":"text-delta","id":"0","delta":" in the picture."}\n\n'
+        'data: {"type":"text-end","id":"0"}\n\n'
+        'data: {"type":"finish","messageMetadata":{"usage":{"promptTokens":0,"completionToken'
+        's":0,"co2Impact":0.0}}}\n\n'
+        "data: [DONE]\n\n"
     )
 
     # --- Verify the outgoing HTTP request body contains the image ---
@@ -426,22 +387,19 @@ def test_post_conversation_with_image(api_client, mock_openai_stream_image):
         id=chat_conversation.messages[0].id,  # don't test the message ID here
         createdAt=timezone.now(),  # Mocked timestamp
         content="Hello, what do you see on this picture?",
-        reasoning=None,
-        experimental_attachments=[
-            Attachment(
-                name=None,
-                contentType="image/png",
+        role="user",
+        parts=[
+            TextUIPart(type="text", text="Hello, what do you see on this picture?"),
+            FileUIPart(
+                type="file",
+                mediaType="image/png",
                 url=(
                     "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+w"
                     "SzIAAAABlBMVEX///+/v7+jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEA"
                     "AAAASUVORK5CYII="
                 ),
-            )
+            ),
         ],
-        role="user",
-        annotations=None,
-        toolInvocations=None,
-        parts=[TextUIPart(type="text", text="Hello, what do you see on this picture?")],
     )
 
     assert chat_conversation.messages[1].id == IsUUID(4)
@@ -449,11 +407,7 @@ def test_post_conversation_with_image(api_client, mock_openai_stream_image):
         id=chat_conversation.messages[1].id,  # don't test the message ID here
         createdAt=timezone.now(),  # Mocked timestamp
         content="I see a cat in the picture.",
-        reasoning=None,
-        experimental_attachments=None,
         role="assistant",
-        annotations=None,
-        toolInvocations=None,
         parts=[TextUIPart(type="text", text="I see a cat in the picture.")],
     )
 
@@ -487,7 +441,7 @@ def test_post_conversation_tool_call(api_client, mock_openai_stream_tool, settin
     settings.AI_AGENT_TOOLS = ["get_current_weather"]
 
     chat_conversation = ChatConversationFactory(owner__language="en-us")
-    url = f"/api/v1.0/chats/{chat_conversation.pk}/conversation/?protocol=data"
+    url = f"/api/v1.0/chats/{chat_conversation.pk}/conversation/"
 
     data = {
         "messages": [
@@ -509,16 +463,20 @@ def test_post_conversation_tool_call(api_client, mock_openai_stream_tool, settin
     response_content = _decode_stream(response)
 
     assert response_content == (
-        'b:{"toolCallId":"xLDcIljdsDrz0idal7tATWSMm2jhMj47","toolName":'
-        '"get_current_weather"}\n'
-        'c:{"toolCallId":"xLDcIljdsDrz0idal7tATWSMm2jhMj47","argsTextDelta":'
-        '"{\\"location\\":\\"Paris\\", \\"unit\\":\\"celsius\\"}"}\n'
-        'a:{"toolCallId":"xLDcIljdsDrz0idal7tATWSMm2jhMj47","result":{"location":'
-        '"Paris","temperature":22,"unit":"celsius"}}\n'
-        '0:"The current weather in Paris is nice"\n'
-        'f:{"messageId":"<mocked_uuid>"}\n'
-        'd:{"finishReason":"stop","usage":{"promptTokens":0,"completionTokens":0'
-        ',"co2Impact":0.0}}\n'
+        'data: {"type":"start","messageId":"<mocked_uuid>"}\n\n'
+        'data: {"type":"tool-input-start","toolCallId":"xLDcIljdsDrz0idal7tATWSMm2jhMj47","to'
+        'olName":"get_current_weather"}\n\n'
+        'data: {"type":"tool-input-delta","toolCallId":"xLDcIljdsDrz0idal7tATWSMm2jhMj47","in'
+        'putTextDelta":"{\\"location\\":\\"Paris\\", \\"unit\\":\\"celsius\\"}"}\n\n'
+        'data: {"type":"tool-output-available","toolCallId":"xLDcIljdsDrz0idal7tATWSMm2jhMj47'
+        '","output":{"location":"Paris","temperature":22,"unit":"celsius"}}\n\n'
+        'data: {"type":"text-start","id":"0"}\n\n'
+        'data: {"type":"text-delta","id":"0","delta":"The current weather in Paris is nice"}'
+        "\n\n"
+        'data: {"type":"text-end","id":"0"}\n\n'
+        'data: {"type":"finish","messageMetadata":{"usage":{"promptTokens":0,"completionToken'
+        's":0,"co2Impact":0.0}}}\n\n'
+        "data: [DONE]\n\n"
     )
 
     # --- Verify the outgoing HTTP request body ---
@@ -547,11 +505,7 @@ def test_post_conversation_tool_call(api_client, mock_openai_stream_tool, settin
         id=chat_conversation.messages[0].id,  # don't test the message ID here
         createdAt=timezone.now(),  # Mocked timestamp
         content="Weather in Paris?",
-        reasoning=None,
-        experimental_attachments=None,
         role="user",
-        annotations=None,
-        toolInvocations=None,
         parts=[TextUIPart(type="text", text="Weather in Paris?")],
     )
 
@@ -560,21 +514,13 @@ def test_post_conversation_tool_call(api_client, mock_openai_stream_tool, settin
         id=chat_conversation.messages[1].id,  # don't test the message ID here
         createdAt=timezone.now(),  # Mocked timestamp
         content="The current weather in Paris is nice",
-        reasoning=None,
-        experimental_attachments=None,
         role="assistant",
-        annotations=None,
-        toolInvocations=None,
         parts=[
-            ToolInvocationUIPart(
-                type="tool-invocation",
-                toolInvocation=ToolInvocationCall(
-                    toolCallId="xLDcIljdsDrz0idal7tATWSMm2jhMj47",
-                    toolName="get_current_weather",
-                    args={"unit": "celsius", "location": "Paris"},
-                    state="call",
-                    step=None,
-                ),
+            ToolUIPart(
+                type="tool-get_current_weather",
+                toolCallId="xLDcIljdsDrz0idal7tATWSMm2jhMj47",
+                state="input-available",
+                input={"unit": "celsius", "location": "Paris"},
             ),
             TextUIPart(type="text", text="The current weather in Paris is nice"),
         ],
@@ -648,7 +594,7 @@ def test_post_conversation_tool_call_fails(api_client, mock_openai_stream_tool):
     """Ensure tool calls are correctly forwarded and streamed back when failing."""
 
     chat_conversation = ChatConversationFactory(owner__language="fr-fr")
-    url = f"/api/v1.0/chats/{chat_conversation.pk}/conversation/?protocol=data"
+    url = f"/api/v1.0/chats/{chat_conversation.pk}/conversation/"
 
     data = {
         "messages": [
@@ -670,15 +616,21 @@ def test_post_conversation_tool_call_fails(api_client, mock_openai_stream_tool):
     response_content = _decode_stream(response)
 
     assert response_content == (
-        'b:{"toolCallId":"xLDcIljdsDrz0idal7tATWSMm2jhMj47","toolName":"get_current_weather"}\n'
-        'c:{"toolCallId":"xLDcIljdsDrz0idal7tATWSMm2jhMj47","argsTextDelta":'
-        '"{\\"location\\":\\"Paris\\", \\"unit\\":\\"celsius\\"}"}\n'
-        'a:{"toolCallId":"xLDcIljdsDrz0idal7tATWSMm2jhMj47","result":"Unknown tool '
-        "name: 'get_current_weather'. Available tools: 'self_documentation'\"}\n"
-        '0:"I cannot give you an answer to that."\n'
-        'f:{"messageId":"<mocked_uuid>"}\n'
-        'd:{"finishReason":"stop","usage":{"promptTokens":0,"completionTokens":0'
-        ',"co2Impact":0.0}}\n'
+        'data: {"type":"start","messageId":"<mocked_uuid>"}\n\n'
+        'data: {"type":"tool-input-start","toolCallId":"xLDcIljdsDrz0idal7tATWSMm2jhMj47","to'
+        'olName":"get_current_weather"}\n\n'
+        'data: {"type":"tool-input-delta","toolCallId":"xLDcIljdsDrz0idal7tATWSMm2jhMj47","in'
+        'putTextDelta":"{\\"location\\":\\"Paris\\", \\"unit\\":\\"celsius\\"}"}\n\n'
+        'data: {"type":"tool-output-available","toolCallId":"xLDcIljdsDrz0idal7tATWSMm2jhMj47'
+        '","output":"Unknown tool name: \'get_current_weather\'. Available tools: \'self_doc'
+        "umentation'\"}\n\n"
+        'data: {"type":"text-start","id":"0"}\n\n'
+        'data: {"type":"text-delta","id":"0","delta":"I cannot give you an answer to that."}'
+        "\n\n"
+        'data: {"type":"text-end","id":"0"}\n\n'
+        'data: {"type":"finish","messageMetadata":{"usage":{"promptTokens":0,"completionToken'
+        's":0,"co2Impact":0.0}}}\n\n'
+        "data: [DONE]\n\n"
     )
 
     # --- Verify the outgoing HTTP request body ---
@@ -707,11 +659,7 @@ def test_post_conversation_tool_call_fails(api_client, mock_openai_stream_tool):
         id=chat_conversation.messages[0].id,  # don't test the message ID here
         createdAt=timezone.now(),  # Mocked timestamp
         content="Weather in Paris?",
-        reasoning=None,
-        experimental_attachments=None,
         role="user",
-        annotations=None,
-        toolInvocations=None,
         parts=[TextUIPart(type="text", text="Weather in Paris?")],
     )
 
@@ -720,21 +668,13 @@ def test_post_conversation_tool_call_fails(api_client, mock_openai_stream_tool):
         id=chat_conversation.messages[1].id,  # don't test the message ID here
         createdAt=timezone.now(),  # Mocked timestamp
         content="I cannot give you an answer to that.",
-        reasoning=None,
-        experimental_attachments=None,
         role="assistant",
-        annotations=None,
-        toolInvocations=None,
         parts=[
-            ToolInvocationUIPart(
-                type="tool-invocation",
-                toolInvocation=ToolInvocationCall(
-                    toolCallId="xLDcIljdsDrz0idal7tATWSMm2jhMj47",
-                    toolName="get_current_weather",
-                    args={"unit": "celsius", "location": "Paris"},
-                    state="call",
-                    step=None,
-                ),
+            ToolUIPart(
+                type="tool-get_current_weather",
+                toolCallId="xLDcIljdsDrz0idal7tATWSMm2jhMj47",
+                state="input-available",
+                input={"unit": "celsius", "location": "Paris"},
             ),
             TextUIPart(type="text", text="I cannot give you an answer to that."),
         ],
@@ -809,7 +749,7 @@ def test_post_conversation_model_selection_invalid(api_client):
     """Test the user cannot select a different model if it does not exist."""
     chat_conversation = ChatConversationFactory()
 
-    url = f"/api/v1.0/chats/{chat_conversation.pk}/conversation/?protocol=data&model_hrid=plop"
+    url = f"/api/v1.0/chats/{chat_conversation.pk}/conversation/?model_hrid=plop"
     data = {
         "messages": [
             {
@@ -855,7 +795,7 @@ def test_post_conversation_model_selection_new(
 
     chat_conversation = ChatConversationFactory()
 
-    url = f"/api/v1.0/chats/{chat_conversation.pk}/conversation/?protocol=data&model_hrid=plop"
+    url = f"/api/v1.0/chats/{chat_conversation.pk}/conversation/?model_hrid=plop"
     api_client.force_login(chat_conversation.owner)
 
     response = api_client.post(url, hello_conversation_data, format="json")
@@ -903,7 +843,7 @@ def test_post_conversation_data_protocol_no_stream(
 
     chat_conversation = ChatConversationFactory(owner__language="en-us")
 
-    url = f"/api/v1.0/chats/{chat_conversation.pk}/conversation/?protocol=data"
+    url = f"/api/v1.0/chats/{chat_conversation.pk}/conversation/"
     data = {
         "messages": [
             {
@@ -925,33 +865,40 @@ def test_post_conversation_data_protocol_no_stream(
 
     if stream_delay:
         assert response_content == (
-            '0:"The "\n'
-            '0:"sky "\n'
-            '0:"appe"\n'
-            '0:"ars "\n'
-            '0:"blue"\n'
-            '0:" due"\n'
-            '0:" to "\n'
-            '0:"a ph"\n'
-            '0:"enom"\n'
-            '0:"enon"\n'
-            '0:" cal"\n'
-            '0:"led "\n'
-            '0:"Rayl"\n'
-            '0:"eigh"\n'
-            '0:" sca"\n'
-            '0:"tter"\n'
-            '0:"ing."\n'
-            'f:{"messageId":"<mocked_uuid>"}\n'
-            'd:{"finishReason":"stop","usage":{"promptTokens":0,"completionTokens":135'
-            ',"co2Impact":0.0}}\n'
+            'data: {"type":"start","messageId":"<mocked_uuid>"}\n\n'
+            'data: {"type":"text-start","id":"0"}\n\n'
+            'data: {"type":"text-delta","id":"0","delta":"The "}\n\n'
+            'data: {"type":"text-delta","id":"0","delta":"sky "}\n\n'
+            'data: {"type":"text-delta","id":"0","delta":"appe"}\n\n'
+            'data: {"type":"text-delta","id":"0","delta":"ars "}\n\n'
+            'data: {"type":"text-delta","id":"0","delta":"blue"}\n\n'
+            'data: {"type":"text-delta","id":"0","delta":" due"}\n\n'
+            'data: {"type":"text-delta","id":"0","delta":" to "}\n\n'
+            'data: {"type":"text-delta","id":"0","delta":"a ph"}\n\n'
+            'data: {"type":"text-delta","id":"0","delta":"enom"}\n\n'
+            'data: {"type":"text-delta","id":"0","delta":"enon"}\n\n'
+            'data: {"type":"text-delta","id":"0","delta":" cal"}\n\n'
+            'data: {"type":"text-delta","id":"0","delta":"led "}\n\n'
+            'data: {"type":"text-delta","id":"0","delta":"Rayl"}\n\n'
+            'data: {"type":"text-delta","id":"0","delta":"eigh"}\n\n'
+            'data: {"type":"text-delta","id":"0","delta":" sca"}\n\n'
+            'data: {"type":"text-delta","id":"0","delta":"tter"}\n\n'
+            'data: {"type":"text-delta","id":"0","delta":"ing."}\n\n'
+            'data: {"type":"text-end","id":"0"}\n\n'
+            'data: {"type":"finish","messageMetadata":{"usage":{"promptTokens":0,"completionT'
+            'okens":135,"co2Impact":0.0}}}\n\n'
+            "data: [DONE]\n\n"
         )
     else:
         assert response_content == (
-            '0:"The sky appears blue due to a phenomenon called Rayleigh scattering."\n'
-            'f:{"messageId":"<mocked_uuid>"}\n'
-            'd:{"finishReason":"stop","usage":{"promptTokens":0,"completionTokens":135'
-            ',"co2Impact":0.0}}\n'
+            'data: {"type":"start","messageId":"<mocked_uuid>"}\n\n'
+            'data: {"type":"text-start","id":"0"}\n\n'
+            'data: {"type":"text-delta","id":"0","delta":"The sky appears blue due to a pheno'
+            'menon called Rayleigh scattering."}\n\n'
+            'data: {"type":"text-end","id":"0"}\n\n'
+            'data: {"type":"finish","messageMetadata":{"usage":{"promptTokens":0,"completionT'
+            'okens":135,"co2Impact":0.0}}}\n\n'
+            "data: [DONE]\n\n"
         )
 
     assert mock_openai_no_stream.called
@@ -974,11 +921,7 @@ def test_post_conversation_data_protocol_no_stream(
         id=chat_conversation.messages[0].id,
         createdAt=timezone.now(),  # Mocked timestamp
         content="Why the sky is blue?",
-        reasoning=None,
-        experimental_attachments=None,
         role="user",
-        annotations=None,
-        toolInvocations=None,
         parts=[TextUIPart(type="text", text="Why the sky is blue?")],
     )
 
@@ -987,11 +930,7 @@ def test_post_conversation_data_protocol_no_stream(
         id=chat_conversation.messages[1].id,  # don't test the message ID here
         createdAt=timezone.now(),  # Mocked timestamp
         content="The sky appears blue due to a phenomenon called Rayleigh scattering.",
-        reasoning=None,
-        experimental_attachments=None,
         role="assistant",
-        annotations=None,
-        toolInvocations=None,
         parts=[
             TextUIPart(
                 type="text",
@@ -1038,7 +977,7 @@ async def test_post_conversation_async(api_client, mock_openai_stream, monkeypat
 
     chat_conversation = await sync_to_async(ChatConversationFactory)(owner__language="en-us")
 
-    url = f"/api/v1.0/chats/{chat_conversation.pk}/conversation/?protocol=data"
+    url = f"/api/v1.0/chats/{chat_conversation.pk}/conversation/"
     data = {
         "messages": [
             {
@@ -1083,11 +1022,7 @@ async def test_post_conversation_async(api_client, mock_openai_stream, monkeypat
         id=chat_conversation.messages[0].id,  # don't test the message ID here
         createdAt=timezone.now(),  # Mocked timestamp
         content="Hello",
-        reasoning=None,
-        experimental_attachments=None,
         role="user",
-        annotations=None,
-        toolInvocations=None,
         parts=[TextUIPart(type="text", text="Hello")],
     )
 
@@ -1096,11 +1031,7 @@ async def test_post_conversation_async(api_client, mock_openai_stream, monkeypat
         id=chat_conversation.messages[1].id,  # don't test the message ID here
         createdAt=timezone.now(),  # Mocked timestamp
         content="Hello there",
-        reasoning=None,
-        experimental_attachments=None,
         role="assistant",
-        annotations=None,
-        toolInvocations=None,
         parts=[TextUIPart(type="text", text="Hello there")],
     )
 
@@ -1124,7 +1055,7 @@ async def test_post_conversation_async_triggers_keepalive(
 
     chat_conversation = await sync_to_async(ChatConversationFactory)(owner__language="en-us")
 
-    url = f"/api/v1.0/chats/{chat_conversation.pk}/conversation/?protocol=data"
+    url = f"/api/v1.0/chats/{chat_conversation.pk}/conversation/"
     data = {
         "messages": [
             {
@@ -1156,12 +1087,15 @@ async def test_post_conversation_async_triggers_keepalive(
     response_content = replace_uuids_with_placeholder(response_content)
 
     assert response_content == (
-        '0:"Hello"\n'
-        '2:[{"status": "WAITING"}]\n'
-        '0:" there"\n'
-        'f:{"messageId":"<mocked_uuid>"}\n'
-        'd:{"finishReason":"stop","usage":{"promptTokens":0,"completionTokens":0'
-        ',"co2Impact":0.0}}\n'
+        'data: {"type":"start","messageId":"<mocked_uuid>"}\n\n'
+        'data: {"type":"text-start","id":"0"}\n\n'
+        'data: {"type":"text-delta","id":"0","delta":"Hello"}\n\n'
+        'data: {"type":"data-keepalive","data":{"status":"WAITING"},"transient":true}\n\n'
+        'data: {"type":"text-delta","id":"0","delta":" there"}\n\n'
+        'data: {"type":"text-end","id":"0"}\n\n'
+        'data: {"type":"finish","messageMetadata":{"usage":{"promptTokens":0,"completionToken'
+        's":0,"co2Impact":0.0}}}\n\n'
+        "data: [DONE]\n\n"
     )
 
     assert mock_openai_stream_slow.called
@@ -1176,11 +1110,7 @@ async def test_post_conversation_async_triggers_keepalive(
         id=chat_conversation.messages[0].id,  # don't test the message ID here
         createdAt=chat_conversation.messages[0].createdAt,  # Mocked timestamp
         content="Hello",
-        reasoning=None,
-        experimental_attachments=None,
         role="user",
-        annotations=None,
-        toolInvocations=None,
         parts=[TextUIPart(type="text", text="Hello")],
     )
 
@@ -1189,11 +1119,7 @@ async def test_post_conversation_async_triggers_keepalive(
         id=chat_conversation.messages[1].id,  # don't test the message ID here
         createdAt=chat_conversation.messages[1].createdAt,  # Mocked timestamp
         content="Hello there",
-        reasoning=None,
-        experimental_attachments=None,
         role="assistant",
-        annotations=None,
-        toolInvocations=None,
         parts=[TextUIPart(type="text", text="Hello there")],
     )
 
@@ -1212,7 +1138,7 @@ def test_post_conversation_oidc_refresh_enabled_unrefreshed(  # pylint: disable=
     """Test posting messages to a conversation without fresh access token should be forbidden."""
     chat_conversation = ChatConversationFactory(owner__language="en-us")
 
-    url = f"/api/v1.0/chats/{chat_conversation.pk}/conversation/?protocol=data"
+    url = f"/api/v1.0/chats/{chat_conversation.pk}/conversation/"
     data = {
         "messages": [
             {
@@ -1241,7 +1167,7 @@ def test_post_conversation_oidc_refresh_enabled(  # pylint: disable=unused-argum
     """Test posting messages to a conversation using the 'data' protocol."""
     chat_conversation = ChatConversationFactory(owner__language="en-us")
 
-    url = f"/api/v1.0/chats/{chat_conversation.pk}/conversation/?protocol=data"
+    url = f"/api/v1.0/chats/{chat_conversation.pk}/conversation/"
     api_client.force_login(
         chat_conversation.owner, backend="core.authentication.backends.OIDCAuthenticationBackend"
     )

--- a/src/backend/chat/tests/views/chat/conversations/test_conversation_concatenate_system_messages.py
+++ b/src/backend/chat/tests/views/chat/conversations/test_conversation_concatenate_system_messages.py
@@ -81,7 +81,7 @@ def test_post_conversation_concatenate(
     else:
         chat_conversation = ChatConversationFactory(owner__language="en-us")
 
-    url = f"/api/v1.0/chats/{chat_conversation.pk}/conversation/?protocol=data"
+    url = f"/api/v1.0/chats/{chat_conversation.pk}/conversation/"
     api_client.force_login(chat_conversation.owner)
 
     response = api_client.post(url, hello_conversation_data, format="json")

--- a/src/backend/chat/tests/views/chat/conversations/test_conversation_image_guard.py
+++ b/src/backend/chat/tests/views/chat/conversations/test_conversation_image_guard.py
@@ -20,7 +20,7 @@ from pydantic_ai.messages import (
 from pydantic_ai.models.function import AgentInfo, FunctionModel
 from rest_framework import status
 
-from chat.ai_sdk_types import Attachment, TextUIPart, UIMessage
+from chat.ai_sdk_types import FileUIPart, TextUIPart, UIMessage
 from chat.factories import (
     ChatConversationFactory,
     ChatProjectAttachmentFactory,
@@ -102,9 +102,7 @@ def _image_message(text, *, attachments=None, msg_id="1") -> UIMessage:
     return UIMessage(
         id=msg_id,
         role="user",
-        content=text,
-        parts=[TextUIPart(text=text, type="text")],
-        experimental_attachments=attachments,
+        parts=[TextUIPart(text=text, type="text"), *(attachments or [])],
     )
 
 
@@ -121,18 +119,14 @@ def _run_turn(api_client, mock_ai_agent_service, conversation, message, model):
 
 
 def _images_skipped_events(streaming_content: bytes, kind: str) -> list[dict]:
-    """Parse `images_skipped` data events of the given kind from an SSE stream."""
+    """Parse `data-images-skipped` parts of the given kind from a UI message stream."""
     events = []
     for line in streaming_content.decode("utf-8").splitlines():
-        if not line.startswith("2:"):
+        if not line.startswith('data: {"type":"data-images-skipped"'):
             continue
-        for item in json.loads(line[2:]):
-            if (
-                isinstance(item, dict)
-                and item.get("type") == "images_skipped"
-                and item.get("kind") == kind
-            ):
-                events.append(item)
+        item = json.loads(line.removeprefix("data: "))["data"]
+        if item.get("kind") == kind:
+            events.append(item)
     return events
 
 
@@ -157,7 +151,9 @@ def test_image_kept_and_instruction_added_for_text_only_model(
     image_url = f"/media-key/{chat_conversation.pk}/sample.png"
     message = _image_message(
         "What is in this image?",
-        attachments=[Attachment(name="sample.png", contentType="image/png", url=image_url)],
+        attachments=[
+            FileUIPart(type="file", filename="sample.png", mediaType="image/png", url=image_url)
+        ],
     )
 
     captured: dict = {}
@@ -176,8 +172,8 @@ def test_image_kept_and_instruction_added_for_text_only_model(
     # attachment with a `skipped` marker for the "image ignored" chip.
     chat_conversation.refresh_from_db()
     [user_message] = [m for m in chat_conversation.messages if m.role == "user"]
-    [skipped_attachment] = user_message.experimental_attachments or []
-    assert skipped_attachment.skipped == {"reason": "model_text_only"}
+    [skipped_file] = [p for p in user_message.parts if p.type == "file"]
+    assert skipped_file.skipped == {"reason": "model_text_only"}
 
     # The image is persisted to history (durable local URL form) so a later
     # vision-capable turn can read it.
@@ -235,7 +231,9 @@ def test_image_capable_model_has_no_unreadable_instruction(
     image_url = f"/media-key/{chat_conversation.pk}/sample.png"
     message = _image_message(
         "What is in this image?",
-        attachments=[Attachment(name="sample.png", contentType="image/png", url=image_url)],
+        attachments=[
+            FileUIPart(type="file", filename="sample.png", mediaType="image/png", url=image_url)
+        ],
     )
 
     captured: dict = {}
@@ -274,7 +272,9 @@ def test_switch_text_only_to_vision_reads_in_message_image(
     image_url = f"/media-key/{chat_conversation.pk}/sample.png"
     turn1 = _image_message(
         "What is in this image?",
-        attachments=[Attachment(name="sample.png", contentType="image/png", url=image_url)],
+        attachments=[
+            FileUIPart(type="file", filename="sample.png", mediaType="image/png", url=image_url)
+        ],
         msg_id="1",
     )
     _run_turn(api_client, mock_ai_agent_service, chat_conversation, turn1, _capturing_model({}))
@@ -365,7 +365,9 @@ def test_chat_notice_event_emitted_for_text_only_model(
     image_url = f"/media-key/{chat_conversation.pk}/sample.png"
     message = _image_message(
         "What is in this image?",
-        attachments=[Attachment(name="sample.png", contentType="image/png", url=image_url)],
+        attachments=[
+            FileUIPart(type="file", filename="sample.png", mediaType="image/png", url=image_url)
+        ],
     )
 
     with mock_ai_agent_service(_capturing_model({})):
@@ -391,7 +393,9 @@ def test_no_chat_notice_event_for_image_capable_model(api_client, mock_ai_agent_
     image_url = f"/media-key/{chat_conversation.pk}/sample.png"
     message = _image_message(
         "What is in this image?",
-        attachments=[Attachment(name="sample.png", contentType="image/png", url=image_url)],
+        attachments=[
+            FileUIPart(type="file", filename="sample.png", mediaType="image/png", url=image_url)
+        ],
     )
 
     with mock_ai_agent_service(_capturing_model({})):
@@ -416,7 +420,9 @@ def test_last_message_marked_event_emitted_for_text_only_model(
     image_url = f"/media-key/{chat_conversation.pk}/sample.png"
     message = _image_message(
         "What is in this image?",
-        attachments=[Attachment(name="sample.png", contentType="image/png", url=image_url)],
+        attachments=[
+            FileUIPart(type="file", filename="sample.png", mediaType="image/png", url=image_url)
+        ],
     )
 
     with mock_ai_agent_service(_capturing_model({})):
@@ -444,7 +450,9 @@ def test_no_last_message_marked_event_for_image_capable_model(
     image_url = f"/media-key/{chat_conversation.pk}/sample.png"
     message = _image_message(
         "What is in this image?",
-        attachments=[Attachment(name="sample.png", contentType="image/png", url=image_url)],
+        attachments=[
+            FileUIPart(type="file", filename="sample.png", mediaType="image/png", url=image_url)
+        ],
     )
 
     with mock_ai_agent_service(_capturing_model({})):

--- a/src/backend/chat/tests/views/chat/conversations/test_conversation_model_routing.py
+++ b/src/backend/chat/tests/views/chat/conversations/test_conversation_model_routing.py
@@ -65,7 +65,7 @@ def test_new_conversation_pins_default_when_main_is_healthy(
     conversation = ChatConversationFactory(owner__language="en-us")
     assert not conversation.model_hrid
 
-    url = f"/api/v1.0/chats/{conversation.pk}/conversation/?protocol=data"
+    url = f"/api/v1.0/chats/{conversation.pk}/conversation/"
     api_client.force_login(conversation.owner)
     response = api_client.post(url, hello_conversation_data, format="json")
 
@@ -85,7 +85,7 @@ def test_new_conversation_pins_fallback_when_main_is_red(
     health_cache.set(model_health_cache_key("main-model-provider", "main-llm"), "red")
 
     conversation = ChatConversationFactory(owner__language="en-us")
-    url = f"/api/v1.0/chats/{conversation.pk}/conversation/?protocol=data"
+    url = f"/api/v1.0/chats/{conversation.pk}/conversation/"
     api_client.force_login(conversation.owner)
     response = api_client.post(url, hello_conversation_data, format="json")
 
@@ -106,7 +106,7 @@ def test_existing_conversation_keeps_pinned_model_even_if_param_changes(
     # request asks for "main-model" (or anything else).
     conversation = ChatConversationFactory(owner__language="en-us", model_hrid="fallback-1")
 
-    url = f"/api/v1.0/chats/{conversation.pk}/conversation/?protocol=data&model_hrid=main-model"
+    url = f"/api/v1.0/chats/{conversation.pk}/conversation/?model_hrid=main-model"
     api_client.force_login(conversation.owner)
     response = api_client.post(url, hello_conversation_data, format="json")
 
@@ -126,7 +126,7 @@ def test_explicit_non_default_model_in_request_is_pinned(
 ):
     # Picker selection in dev/staging: explicit non-default request goes through.
     conversation = ChatConversationFactory(owner__language="en-us")
-    url = f"/api/v1.0/chats/{conversation.pk}/conversation/?protocol=data&model_hrid=fallback-1"
+    url = f"/api/v1.0/chats/{conversation.pk}/conversation/?model_hrid=fallback-1"
     api_client.force_login(conversation.owner)
     response = api_client.post(url, hello_conversation_data, format="json")
 
@@ -146,7 +146,7 @@ def test_main_yellow_stays_on_main_under_default_threshold(
     health_cache.set(model_health_cache_key("main-model-provider", "main-llm"), "yellow")
 
     conversation = ChatConversationFactory(owner__language="en-us")
-    url = f"/api/v1.0/chats/{conversation.pk}/conversation/?protocol=data"
+    url = f"/api/v1.0/chats/{conversation.pk}/conversation/"
     api_client.force_login(conversation.owner)
     response = api_client.post(url, hello_conversation_data, format="json")
 
@@ -170,7 +170,7 @@ def test_main_yellow_stays_on_main_when_threshold_raised_to_red(
     health_cache.set(model_health_cache_key("main-model-provider", "main-llm"), "yellow")
 
     conversation = ChatConversationFactory(owner__language="en-us")
-    url = f"/api/v1.0/chats/{conversation.pk}/conversation/?protocol=data"
+    url = f"/api/v1.0/chats/{conversation.pk}/conversation/"
     api_client.force_login(conversation.owner)
     response = api_client.post(url, hello_conversation_data, format="json")
 
@@ -198,7 +198,7 @@ def test_main_red_with_yellow_fb1_stays_on_fb1_under_default_fallback_threshold(
     health_cache.set(model_health_cache_key("fallback-2-provider", "fb2-llm"), "green")
 
     conversation = ChatConversationFactory(owner__language="en-us")
-    url = f"/api/v1.0/chats/{conversation.pk}/conversation/?protocol=data"
+    url = f"/api/v1.0/chats/{conversation.pk}/conversation/"
     api_client.force_login(conversation.owner)
     response = api_client.post(url, hello_conversation_data, format="json")
 
@@ -221,7 +221,7 @@ def test_fallback_threshold_red_accepts_yellow_fb1(
     health_cache.set(model_health_cache_key("fallback-1-provider", "fb1-llm"), "yellow")
 
     conversation = ChatConversationFactory(owner__language="en-us")
-    url = f"/api/v1.0/chats/{conversation.pk}/conversation/?protocol=data"
+    url = f"/api/v1.0/chats/{conversation.pk}/conversation/"
     api_client.force_login(conversation.owner)
     response = api_client.post(url, hello_conversation_data, format="json")
 

--- a/src/backend/chat/tests/views/chat/conversations/test_conversation_with_document_upload.py
+++ b/src/backend/chat/tests/views/chat/conversations/test_conversation_with_document_upload.py
@@ -26,12 +26,10 @@ from core.feature_flags.flags import FeatureToggle
 from chat.agents.conversation import PREVENT_URL_HALLUCINATION_INSTRUCTION
 from chat.agents.summarize import SummarizationAgent
 from chat.ai_sdk_types import (
-    Attachment,
-    LanguageModelV1Source,
-    SourceUIPart,
+    FileUIPart,
+    SourceUrlUIPart,
     TextUIPart,
-    ToolInvocationCall,
-    ToolInvocationUIPart,
+    ToolUIPart,
     UIMessage,
 )
 from chat.constants import ACCESS_TOOL_CALL_ONLY
@@ -369,13 +367,9 @@ def test_post_conversation_with_document_upload(
                 text="What does the document say?",
                 type="text",
             ),
-        ],
-        experimental_attachments=[
-            Attachment(
-                name="sample.pdf",
-                contentType="application/pdf",
-                url=document_url,
-            )
+            FileUIPart(
+                type="file", filename="sample.pdf", mediaType="application/pdf", url=document_url
+            ),
         ],
     )
 
@@ -400,7 +394,7 @@ def test_post_conversation_with_document_upload(
 
     assert response.status_code == status.HTTP_200_OK
     assert response.get("Content-Type") == "text/event-stream"
-    assert response.get("x-vercel-ai-data-stream") == "v1"
+    assert response.get("x-vercel-ai-ui-message-stream") == "v1"
     assert response.streaming
 
     # Wait for the streaming content to be fully received
@@ -410,20 +404,25 @@ def test_post_conversation_with_document_upload(
     response_content = replace_uuids_with_placeholder(response_content)
 
     assert response_content == (
-        '9:{"toolCallId":"XXX","toolName":"document_parsing",'
-        '"args":{"documents":[{"identifier":"sample.pdf"}]}}\n'
-        'a:{"toolCallId":"XXX","result":{"state":"done"}}\n'
-        'b:{"toolCallId":"pyd_ai_YYY","toolName":"document_search_rag"}\n'
-        '9:{"toolCallId":"pyd_ai_YYY","toolName":"document_search_rag",'
-        '"args":{"query":"What does the document say?"}}\n'
-        'h:{"sourceType":"url","id":"<mocked_uuid>","url":"sample.pdf","title":null,'
-        '"providerMetadata":{}}\n'
-        'a:{"toolCallId":"pyd_ai_YYY","result":[{"url":"sample.pdf","content":"This '
-        'is the content of the PDF.","score":0.9}]}\n'
-        "0:\"From the document, I can see that it says 'Hello PDF'.\"\n"
-        'f:{"messageId":"<mocked_uuid>"}\n'
-        'd:{"finishReason":"stop","usage":{"promptTokens":100,"completionTokens":20,'
-        '"co2Impact":0.0}}\n'
+        'data: {"type":"start","messageId":"<mocked_uuid>"}\n\n'
+        'data: {"type":"tool-input-available","toolCallId":"XXX","toolName":"document_parsing'
+        '","input":{"documents":[{"identifier":"sample.pdf"}]}}\n\n'
+        'data: {"type":"tool-output-available","toolCallId":"XXX","output":{"state":"done"}}'
+        "\n\n"
+        'data: {"type":"tool-input-start","toolCallId":"pyd_ai_YYY","toolName":"document_sear'
+        'ch_rag"}\n\n'
+        'data: {"type":"tool-input-available","toolCallId":"pyd_ai_YYY","toolName":"document_'
+        'search_rag","input":{"query":"What does the document say?"}}\n\n'
+        'data: {"type":"source-url","sourceId":"<mocked_uuid>","url":"sample.pdf"}\n\n'
+        'data: {"type":"tool-output-available","toolCallId":"pyd_ai_YYY","output":[{"url":"sa'
+        'mple.pdf","content":"This is the content of the PDF.","score":0.9}]}\n\n'
+        'data: {"type":"text-start","id":"0"}\n\n'
+        'data: {"type":"text-delta","id":"0","delta":"From the document, I can see that it sa'
+        "ys 'Hello PDF'.\"}\n\n"
+        'data: {"type":"text-end","id":"0"}\n\n'
+        'data: {"type":"finish","messageMetadata":{"usage":{"promptTokens":100,"completionTok'
+        'ens":20,"co2Impact":0.0}}}\n\n'
+        "data: [DONE]\n\n"
     )
 
     # Check that the conversation was updated
@@ -435,11 +434,7 @@ def test_post_conversation_with_document_upload(
         id=chat_conversation.messages[0].id,
         createdAt=timezone.now(),
         content="What does the document say?",
-        reasoning=None,
-        experimental_attachments=None,
         role="user",
-        annotations=None,
-        toolInvocations=None,
         parts=[TextUIPart(type="text", text="What does the document say?")],
     )
 
@@ -448,32 +443,19 @@ def test_post_conversation_with_document_upload(
         id=chat_conversation.messages[1].id,
         createdAt=timezone.now(),
         content="From the document, I can see that it says 'Hello PDF'.",
-        reasoning=None,
-        experimental_attachments=None,
         role="assistant",
-        annotations=None,
-        toolInvocations=None,
         parts=[
-            ToolInvocationUIPart(
-                type="tool-invocation",
-                toolInvocation=ToolInvocationCall(
-                    toolCallId=chat_conversation.messages[1].parts[0].toolInvocation.toolCallId,
-                    toolName="document_search_rag",
-                    args={"query": "What does the document say?"},
-                    state="call",
-                    step=None,
-                ),
+            ToolUIPart(
+                type="tool-document_search_rag",
+                toolCallId=chat_conversation.messages[1].parts[0].toolCallId,
+                state="input-available",
+                input={"query": "What does the document say?"},
             ),
             TextUIPart(type="text", text="From the document, I can see that it says 'Hello PDF'."),
-            SourceUIPart(
-                type="source",
-                source=LanguageModelV1Source(
-                    sourceType="url",
-                    id=chat_conversation.messages[1].parts[2].source.id,
-                    url="sample.pdf",
-                    title=None,
-                    providerMetadata={},
-                ),
+            SourceUrlUIPart(
+                type="source-url",
+                sourceId=chat_conversation.messages[1].parts[2].sourceId,
+                url="sample.pdf",
             ),
         ],
     )
@@ -637,13 +619,9 @@ def test_post_conversation_with_document_upload_feature_disabled(
                 text="What does the document say?",
                 type="text",
             ),
-        ],
-        experimental_attachments=[
-            Attachment(
-                name="sample.pdf",
-                contentType="application/pdf",
-                url=document_url,
-            )
+            FileUIPart(
+                type="file", filename="sample.pdf", mediaType="application/pdf", url=document_url
+            ),
         ],
     )
 
@@ -655,7 +633,7 @@ def test_post_conversation_with_document_upload_feature_disabled(
 
     assert response.status_code == status.HTTP_200_OK
     assert response.get("Content-Type") == "text/event-stream"
-    assert response.get("x-vercel-ai-data-stream") == "v1"
+    assert response.get("x-vercel-ai-ui-message-stream") == "v1"
     assert response.streaming
 
     # Wait for the streaming content to be fully received
@@ -664,11 +642,15 @@ def test_post_conversation_with_document_upload_feature_disabled(
     # Replace UUIDs with placeholders for assertion
     response_content = replace_uuids_with_placeholder(response_content)
     assert response_content == (
-        '0:"From the document, I can see that "\n'
-        "0:\"it says 'Hello PDF'.\"\n"
-        'f:{"messageId":"<mocked_uuid>"}\n'
-        'd:{"finishReason":"stop","usage":{"promptTokens":150,"completionTokens":25,'
-        '"co2Impact":0.0}}\n'
+        'data: {"type":"start","messageId":"<mocked_uuid>"}\n\n'
+        'data: {"type":"text-start","id":"0"}\n\n'
+        'data: {"type":"text-delta","id":"0","delta":"From the document, I can see that "}\n'
+        "\n"
+        'data: {"type":"text-delta","id":"0","delta":"it says \'Hello PDF\'."}\n\n'
+        'data: {"type":"text-end","id":"0"}\n\n'
+        'data: {"type":"finish","messageMetadata":{"usage":{"promptTokens":150,"completionTok'
+        'ens":25,"co2Impact":0.0}}}\n\n'
+        "data: [DONE]\n\n"
     )
     # This behavior must be improved in the future to inform the user properly
     assert "Document upload feature is disabled, ignoring input documents." in caplog.text
@@ -711,13 +693,9 @@ def test_post_conversation_with_document_upload_summarize(  # pylint: disable=to
                 text="Make a summary of this document.",
                 type="text",
             ),
-        ],
-        experimental_attachments=[
-            Attachment(
-                name="sample.pdf",
-                contentType="application/pdf",
-                url=document_url,
-            )
+            FileUIPart(
+                type="file", filename="sample.pdf", mediaType="application/pdf", url=document_url
+            ),
         ],
     )
 
@@ -742,7 +720,7 @@ def test_post_conversation_with_document_upload_summarize(  # pylint: disable=to
 
     assert response.status_code == status.HTTP_200_OK
     assert response.get("Content-Type") == "text/event-stream"
-    assert response.get("x-vercel-ai-data-stream") == "v1"
+    assert response.get("x-vercel-ai-ui-message-stream") == "v1"
     assert response.streaming
 
     # Wait for the streaming content to be fully received
@@ -752,19 +730,25 @@ def test_post_conversation_with_document_upload_summarize(  # pylint: disable=to
     response_content = replace_uuids_with_placeholder(response_content)
 
     assert response_content == (
-        '9:{"toolCallId":"XXX","toolName":"document_parsing",'
-        '"args":{"documents":[{"identifier":"sample.pdf"}]}}\n'
-        'a:{"toolCallId":"XXX","result":{"state":"done"}}\n'
-        'b:{"toolCallId":"pyd_ai_YYY","toolName":"summarize"}\n'
-        '9:{"toolCallId":"pyd_ai_YYY","toolName":"summarize","args":{}}\n'
-        'h:{"sourceType":"url","id":"<mocked_uuid>","url":"sample.pdf.md",'
-        '"title":null,"providerMetadata":{}}\n'
-        'a:{"toolCallId":"pyd_ai_YYY","result":"The '
-        'document discusses various topics."}\n'
-        '0:"The document discusses various topics."\n'
-        'f:{"messageId":"<mocked_uuid>"}\n'
-        'd:{"finishReason":"stop","usage":{"promptTokens":287,"completionTokens":19,'
-        '"co2Impact":0.0}}\n'
+        'data: {"type":"start","messageId":"<mocked_uuid>"}\n\n'
+        'data: {"type":"tool-input-available","toolCallId":"XXX","toolName":"document_parsing'
+        '","input":{"documents":[{"identifier":"sample.pdf"}]}}\n\n'
+        'data: {"type":"tool-output-available","toolCallId":"XXX","output":{"state":"done"}}'
+        "\n\n"
+        'data: {"type":"tool-input-start","toolCallId":"pyd_ai_YYY","toolName":"summarize"}\n'
+        "\n"
+        'data: {"type":"tool-input-available","toolCallId":"pyd_ai_YYY","toolName":"summarize'
+        '","input":{}}\n\n'
+        'data: {"type":"source-url","sourceId":"<mocked_uuid>","url":"sample.pdf.md"}\n\n'
+        'data: {"type":"tool-output-available","toolCallId":"pyd_ai_YYY","output":"The docume'
+        'nt discusses various topics."}\n\n'
+        'data: {"type":"text-start","id":"0"}\n\n'
+        'data: {"type":"text-delta","id":"0","delta":"The document discusses various topics."'
+        "}\n\n"
+        'data: {"type":"text-end","id":"0"}\n\n'
+        'data: {"type":"finish","messageMetadata":{"usage":{"promptTokens":287,"completionTok'
+        'ens":19,"co2Impact":0.0}}}\n\n'
+        "data: [DONE]\n\n"
     )
 
     # Check that the conversation was updated
@@ -776,11 +760,7 @@ def test_post_conversation_with_document_upload_summarize(  # pylint: disable=to
         id=chat_conversation.messages[0].id,
         createdAt=timezone.now(),
         content="Make a summary of this document.",
-        reasoning=None,
-        experimental_attachments=None,
         role="user",
-        annotations=None,
-        toolInvocations=None,
         parts=[TextUIPart(type="text", text="Make a summary of this document.")],
     )
 
@@ -789,32 +769,19 @@ def test_post_conversation_with_document_upload_summarize(  # pylint: disable=to
         id=chat_conversation.messages[1].id,
         createdAt=timezone.now(),
         content="The document discusses various topics.",
-        reasoning=None,
-        experimental_attachments=None,
         role="assistant",
-        annotations=None,
-        toolInvocations=None,
         parts=[
-            ToolInvocationUIPart(
-                type="tool-invocation",
-                toolInvocation=ToolInvocationCall(
-                    toolCallId=chat_conversation.messages[1].parts[0].toolInvocation.toolCallId,
-                    toolName="summarize",
-                    args={},
-                    state="call",
-                    step=None,
-                ),
+            ToolUIPart(
+                type="tool-summarize",
+                toolCallId=chat_conversation.messages[1].parts[0].toolCallId,
+                state="input-available",
+                input={},
             ),
             TextUIPart(type="text", text="The document discusses various topics."),
-            SourceUIPart(
-                type="source",
-                source=LanguageModelV1Source(
-                    sourceType="url",
-                    id=chat_conversation.messages[1].parts[2].source.id,
-                    url="sample.pdf.md",  # might be fixed in the future
-                    title=None,
-                    providerMetadata={},
-                ),
+            SourceUrlUIPart(
+                type="source-url",
+                sourceId=chat_conversation.messages[1].parts[2].sourceId,
+                url="sample.pdf.md",
             ),
         ],
     )
@@ -974,13 +941,12 @@ def test_post_conversation_with_odt_document_upload(
                 text="What does the document say?",
                 type="text",
             ),
-        ],
-        experimental_attachments=[
-            Attachment(
-                name="sample.odt",
-                contentType="application/vnd.oasis.opendocument.text",
+            FileUIPart(
+                type="file",
+                filename="sample.odt",
+                mediaType="application/vnd.oasis.opendocument.text",
                 url=document_url,
-            )
+            ),
         ],
     )
 
@@ -1005,7 +971,7 @@ def test_post_conversation_with_odt_document_upload(
 
     assert response.status_code == status.HTTP_200_OK
     assert response.get("Content-Type") == "text/event-stream"
-    assert response.get("x-vercel-ai-data-stream") == "v1"
+    assert response.get("x-vercel-ai-ui-message-stream") == "v1"
     assert response.streaming
 
     # Wait for the streaming content to be fully received
@@ -1015,20 +981,25 @@ def test_post_conversation_with_odt_document_upload(
     response_content = replace_uuids_with_placeholder(response_content)
 
     assert response_content == (
-        '9:{"toolCallId":"XXX","toolName":"document_parsing",'
-        '"args":{"documents":[{"identifier":"sample.odt"}]}}\n'
-        'a:{"toolCallId":"XXX","result":{"state":"done"}}\n'
-        'b:{"toolCallId":"pyd_ai_YYY","toolName":"document_search_rag"}\n'
-        '9:{"toolCallId":"pyd_ai_YYY","toolName":"document_search_rag",'
-        '"args":{"query":"What does the document say?"}}\n'
-        'h:{"sourceType":"url","id":"<mocked_uuid>","url":"sample.odt","title":null,'
-        '"providerMetadata":{}}\n'
-        'a:{"toolCallId":"pyd_ai_YYY","result":[{"url":"sample.odt","content":"This '
-        'is the content of the ODT.","score":0.9}]}\n'
-        "0:\"From the document, I can see that it says 'Hello ODT'.\"\n"
-        'f:{"messageId":"<mocked_uuid>"}\n'
-        'd:{"finishReason":"stop","usage":{"promptTokens":100,"completionTokens":20,'
-        '"co2Impact":0.0}}\n'
+        'data: {"type":"start","messageId":"<mocked_uuid>"}\n\n'
+        'data: {"type":"tool-input-available","toolCallId":"XXX","toolName":"document_parsing'
+        '","input":{"documents":[{"identifier":"sample.odt"}]}}\n\n'
+        'data: {"type":"tool-output-available","toolCallId":"XXX","output":{"state":"done"}}'
+        "\n\n"
+        'data: {"type":"tool-input-start","toolCallId":"pyd_ai_YYY","toolName":"document_sear'
+        'ch_rag"}\n\n'
+        'data: {"type":"tool-input-available","toolCallId":"pyd_ai_YYY","toolName":"document_'
+        'search_rag","input":{"query":"What does the document say?"}}\n\n'
+        'data: {"type":"source-url","sourceId":"<mocked_uuid>","url":"sample.odt"}\n\n'
+        'data: {"type":"tool-output-available","toolCallId":"pyd_ai_YYY","output":[{"url":"sa'
+        'mple.odt","content":"This is the content of the ODT.","score":0.9}]}\n\n'
+        'data: {"type":"text-start","id":"0"}\n\n'
+        'data: {"type":"text-delta","id":"0","delta":"From the document, I can see that it sa'
+        "ys 'Hello ODT'.\"}\n\n"
+        'data: {"type":"text-end","id":"0"}\n\n'
+        'data: {"type":"finish","messageMetadata":{"usage":{"promptTokens":100,"completionTok'
+        'ens":20,"co2Impact":0.0}}}\n\n'
+        "data: [DONE]\n\n"
     )
 
     # Check that the conversation was updated
@@ -1040,11 +1011,7 @@ def test_post_conversation_with_odt_document_upload(
         id=chat_conversation.messages[0].id,
         createdAt=timezone.now(),
         content="What does the document say?",
-        reasoning=None,
-        experimental_attachments=None,
         role="user",
-        annotations=None,
-        toolInvocations=None,
         parts=[TextUIPart(type="text", text="What does the document say?")],
     )
 
@@ -1053,32 +1020,19 @@ def test_post_conversation_with_odt_document_upload(
         id=chat_conversation.messages[1].id,
         createdAt=timezone.now(),
         content="From the document, I can see that it says 'Hello ODT'.",
-        reasoning=None,
-        experimental_attachments=None,
         role="assistant",
-        annotations=None,
-        toolInvocations=None,
         parts=[
-            ToolInvocationUIPart(
-                type="tool-invocation",
-                toolInvocation=ToolInvocationCall(
-                    toolCallId=chat_conversation.messages[1].parts[0].toolInvocation.toolCallId,
-                    toolName="document_search_rag",
-                    args={"query": "What does the document say?"},
-                    state="call",
-                    step=None,
-                ),
+            ToolUIPart(
+                type="tool-document_search_rag",
+                toolCallId=chat_conversation.messages[1].parts[0].toolCallId,
+                state="input-available",
+                input={"query": "What does the document say?"},
             ),
             TextUIPart(type="text", text="From the document, I can see that it says 'Hello ODT'."),
-            SourceUIPart(
-                type="source",
-                source=LanguageModelV1Source(
-                    sourceType="url",
-                    id=chat_conversation.messages[1].parts[2].source.id,
-                    url="sample.odt",
-                    title=None,
-                    providerMetadata={},
-                ),
+            SourceUrlUIPart(
+                type="source-url",
+                sourceId=chat_conversation.messages[1].parts[2].sourceId,
+                url="sample.odt",
             ),
         ],
     )

--- a/src/backend/chat/tests/views/chat/conversations/test_conversation_with_document_url.py
+++ b/src/backend/chat/tests/views/chat/conversations/test_conversation_with_document_url.py
@@ -30,7 +30,7 @@ from core.file_upload.enums import AttachmentStatus
 
 from chat.agents.conversation import PREVENT_URL_HALLUCINATION_INSTRUCTION
 from chat.ai_sdk_types import (
-    Attachment,
+    FileUIPart,
     TextUIPart,
     UIMessage,
 )
@@ -190,13 +190,9 @@ def test_post_conversation_with_local_pdf_document_url(
                 text="What is in this document?",
                 type="text",
             ),
-        ],
-        experimental_attachments=[
-            Attachment(
-                name="sample.pdf",
-                contentType="application/pdf",
-                url=document_url,
-            )
+            FileUIPart(
+                type="file", filename="sample.pdf", mediaType="application/pdf", url=document_url
+            ),
         ],
     )
 
@@ -222,7 +218,7 @@ def test_post_conversation_with_local_pdf_document_url(
 
     assert response.status_code == status.HTTP_200_OK
     assert response.get("Content-Type") == "text/event-stream"
-    assert response.get("x-vercel-ai-data-stream") == "v1"
+    assert response.get("x-vercel-ai-ui-message-stream") == "v1"
     assert response.streaming
 
     # Wait for the streaming content to be fully received
@@ -232,13 +228,18 @@ def test_post_conversation_with_local_pdf_document_url(
     response_content = replace_uuids_with_placeholder(response_content)
 
     assert response_content == (
-        '9:{"toolCallId":"XXX","toolName":"document_parsing",'
-        '"args":{"documents":[{"identifier":"sample.pdf"}]}}\n'
-        'a:{"toolCallId":"XXX","result":{"state":"done"}}\n'
-        '0:"This is a document about a single pixel."\n'
-        'f:{"messageId":"<mocked_uuid>"}\n'
-        'd:{"finishReason":"stop","usage":{"promptTokens":50,"completionTokens":9,'
-        '"co2Impact":0.0}}\n'
+        'data: {"type":"start","messageId":"<mocked_uuid>"}\n\n'
+        'data: {"type":"tool-input-available","toolCallId":"XXX","toolName":"document_parsing'
+        '","input":{"documents":[{"identifier":"sample.pdf"}]}}\n\n'
+        'data: {"type":"tool-output-available","toolCallId":"XXX","output":{"state":"done"}}'
+        "\n\n"
+        'data: {"type":"text-start","id":"0"}\n\n'
+        'data: {"type":"text-delta","id":"0","delta":"This is a document about a single pixel'
+        '."}\n\n'
+        'data: {"type":"text-end","id":"0"}\n\n'
+        'data: {"type":"finish","messageMetadata":{"usage":{"promptTokens":50,"completionToke'
+        'ns":9,"co2Impact":0.0}}}\n\n'
+        "data: [DONE]\n\n"
     )
 
     # Check that the conversation was updated
@@ -250,11 +251,8 @@ def test_post_conversation_with_local_pdf_document_url(
         id=chat_conversation.messages[0].id,
         createdAt=timezone.now(),
         content="What is in this document?",
-        reasoning=None,
         experimental_attachments=None,  # We should fix this, but for now document appears in source
         role="user",
-        annotations=None,
-        toolInvocations=None,
         parts=[
             TextUIPart(type="text", text="What is in this document?"),
         ],
@@ -265,11 +263,7 @@ def test_post_conversation_with_local_pdf_document_url(
         id=chat_conversation.messages[1].id,
         createdAt=timezone.now(),
         content="This is a document about a single pixel.",
-        reasoning=None,
-        experimental_attachments=None,
         role="assistant",
-        annotations=None,
-        toolInvocations=None,
         parts=[
             TextUIPart(type="text", text="This is a document about a single pixel."),
         ],
@@ -358,13 +352,9 @@ def test_post_conversation_with_local_document_wrong_url(
                 text="What is in this document?",
                 type="text",
             ),
-        ],
-        experimental_attachments=[
-            Attachment(
-                name="sample.pdf",
-                contentType="application/pdf",
-                url=document_url,
-            )
+            FileUIPart(
+                type="file", filename="sample.pdf", mediaType="application/pdf", url=document_url
+            ),
         ],
     )
 
@@ -381,7 +371,7 @@ def test_post_conversation_with_local_document_wrong_url(
 
     assert response.status_code == status.HTTP_200_OK
     assert response.get("Content-Type") == "text/event-stream"
-    assert response.get("x-vercel-ai-data-stream") == "v1"
+    assert response.get("x-vercel-ai-ui-message-stream") == "v1"
     assert response.streaming
 
     # Wait for the streaming content to be fully received
@@ -391,13 +381,14 @@ def test_post_conversation_with_local_document_wrong_url(
     response_content = replace_uuids_with_placeholder(response_content)
 
     assert response_content == (
-        '9:{"toolCallId":"XXX","toolName":"document_parsing",'
-        '"args":{"documents":[{"identifier":"sample.pdf"}]}}\n'
-        'a:{"toolCallId":"XXX",'
-        '"result":{"state":"error","kind":"rag_error","error":"Document '
-        'URL does not belong to the conversation."}}\n'
-        'd:{"finishReason":"error","usage":{"promptTokens":0,"completionTokens":0,'
-        '"co2Impact":0.0}}\n'
+        'data: {"type":"start","messageId":"<mocked_uuid>"}\n\n'
+        'data: {"type":"tool-input-available","toolCallId":"XXX","toolName":"document_parsing'
+        '","input":{"documents":[{"identifier":"sample.pdf"}]}}\n\n'
+        'data: {"type":"tool-output-available","toolCallId":"XXX","output":{"state":"error","'
+        'kind":"rag_error","error":"Document URL does not belong to the conversation."}}\n\n'
+        'data: {"type":"finish","messageMetadata":{"usage":{"promptTokens":0,"completionToken'
+        's":0,"co2Impact":0.0}}}\n\n'
+        "data: [DONE]\n\n"
     )
 
     # Check that the conversation was not updated
@@ -427,13 +418,9 @@ def test_post_conversation_with_remote_document_url(
                 text="What is in this document?",
                 type="text",
             ),
-        ],
-        experimental_attachments=[
-            Attachment(
-                name="sample.pdf",
-                contentType="application/pdf",
-                url=document_url,
-            )
+            FileUIPart(
+                type="file", filename="sample.pdf", mediaType="application/pdf", url=document_url
+            ),
         ],
     )
 
@@ -450,7 +437,7 @@ def test_post_conversation_with_remote_document_url(
 
     assert response.status_code == status.HTTP_200_OK
     assert response.get("Content-Type") == "text/event-stream"
-    assert response.get("x-vercel-ai-data-stream") == "v1"
+    assert response.get("x-vercel-ai-ui-message-stream") == "v1"
     assert response.streaming
 
     # Wait for the streaming content to be fully received
@@ -460,13 +447,14 @@ def test_post_conversation_with_remote_document_url(
     response_content = replace_uuids_with_placeholder(response_content)
 
     assert response_content == (
-        '9:{"toolCallId":"XXX","toolName":"document_parsing",'
-        '"args":{"documents":[{"identifier":"sample.pdf"}]}}\n'
-        'a:{"toolCallId":"XXX",'
-        '"result":{"state":"error","kind":"rag_error","error":"External document '
-        'URL are not accepted yet."}}\n'
-        'd:{"finishReason":"error","usage":{"promptTokens":0,"completionTokens":0,'
-        '"co2Impact":0.0}}\n'
+        'data: {"type":"start","messageId":"<mocked_uuid>"}\n\n'
+        'data: {"type":"tool-input-available","toolCallId":"XXX","toolName":"document_parsing'
+        '","input":{"documents":[{"identifier":"sample.pdf"}]}}\n\n'
+        'data: {"type":"tool-output-available","toolCallId":"XXX","output":{"state":"error","'
+        'kind":"rag_error","error":"External document URL are not accepted yet."}}\n\n'
+        'data: {"type":"finish","messageMetadata":{"usage":{"promptTokens":0,"completionToken'
+        's":0,"co2Impact":0.0}}}\n\n'
+        "data: [DONE]\n\n"
     )
 
     # Check that the conversation was not updated
@@ -501,26 +489,22 @@ def test_post_conversation_with_local_document_url_in_history(  # pylint: disabl
                 id=str(uuid.uuid4()),
                 createdAt=timezone.now(),
                 content="What is in this document?",
-                reasoning=None,
-                experimental_attachments=[
-                    Attachment(name="sample.pdf", contentType="application/pdf", url=document_url)
-                ],
                 role="user",
-                annotations=None,
-                toolInvocations=None,
                 parts=[
                     TextUIPart(type="text", text="What is in this document?"),
+                    FileUIPart(
+                        type="file",
+                        filename="sample.pdf",
+                        mediaType="application/pdf",
+                        url=document_url,
+                    ),
                 ],
             ),
             UIMessage(
                 id=str(uuid.uuid4()),
                 createdAt=timezone.now(),
                 content="This is a document about a single pixel.",
-                reasoning=None,
-                experimental_attachments=None,
                 role="assistant",
-                annotations=None,
-                toolInvocations=None,
                 parts=[
                     TextUIPart(type="text", text="This is a document about a single pixel."),
                 ],
@@ -652,7 +636,7 @@ def test_post_conversation_with_local_document_url_in_history(  # pylint: disabl
 
     assert response.status_code == status.HTTP_200_OK
     assert response.get("Content-Type") == "text/event-stream"
-    assert response.get("x-vercel-ai-data-stream") == "v1"
+    assert response.get("x-vercel-ai-ui-message-stream") == "v1"
     assert response.streaming
 
     # Wait for the streaming content to be fully received
@@ -662,10 +646,14 @@ def test_post_conversation_with_local_document_url_in_history(  # pylint: disabl
     response_content = replace_uuids_with_placeholder(response_content)
 
     assert response_content == (
-        '0:"This is a document of square, very small and nice."\n'
-        'f:{"messageId":"<mocked_uuid>"}\n'
-        'd:{"finishReason":"stop","usage":{"promptTokens":50,"completionTokens":11,'
-        '"co2Impact":0.0}}\n'
+        'data: {"type":"start","messageId":"<mocked_uuid>"}\n\n'
+        'data: {"type":"text-start","id":"0"}\n\n'
+        'data: {"type":"text-delta","id":"0","delta":"This is a document of square, very smal'
+        'l and nice."}\n\n'
+        'data: {"type":"text-end","id":"0"}\n\n'
+        'data: {"type":"finish","messageMetadata":{"usage":{"promptTokens":50,"completionToke'
+        'ns":11,"co2Impact":0.0}}}\n\n'
+        "data: [DONE]\n\n"
     )
 
     # Check that the conversation was updated
@@ -677,15 +665,12 @@ def test_post_conversation_with_local_document_url_in_history(  # pylint: disabl
         id=chat_conversation.messages[0].id,
         createdAt=timezone.now(),
         content="What is in this document?",
-        reasoning=None,
-        experimental_attachments=[
-            Attachment(name="sample.pdf", contentType="application/pdf", url=document_url)
-        ],
         role="user",
-        annotations=None,
-        toolInvocations=None,
         parts=[
             TextUIPart(type="text", text="What is in this document?"),
+            FileUIPart(
+                type="file", filename="sample.pdf", mediaType="application/pdf", url=document_url
+            ),
         ],
     )
 
@@ -694,11 +679,7 @@ def test_post_conversation_with_local_document_url_in_history(  # pylint: disabl
         id=chat_conversation.messages[1].id,
         createdAt=timezone.now(),
         content="This is a document about a single pixel.",
-        reasoning=None,
-        experimental_attachments=None,
         role="assistant",
-        annotations=None,
-        toolInvocations=None,
         parts=[
             TextUIPart(type="text", text="This is a document about a single pixel."),
         ],
@@ -709,11 +690,7 @@ def test_post_conversation_with_local_document_url_in_history(  # pylint: disabl
         id=chat_conversation.messages[2].id,
         createdAt=timezone.now(),
         content="Give more details about this document.",
-        reasoning=None,
-        experimental_attachments=None,
         role="user",
-        annotations=None,
-        toolInvocations=None,
         parts=[
             TextUIPart(type="text", text="Give more details about this document."),
         ],
@@ -724,11 +701,7 @@ def test_post_conversation_with_local_document_url_in_history(  # pylint: disabl
         id=chat_conversation.messages[3].id,
         createdAt=timezone.now(),
         content="This is a document of square, very small and nice.",
-        reasoning=None,
-        experimental_attachments=None,
         role="assistant",
-        annotations=None,
-        toolInvocations=None,
         parts=[
             TextUIPart(type="text", text="This is a document of square, very small and nice."),
         ],
@@ -893,13 +866,7 @@ def test_post_conversation_with_local_not_pdf_document_url(
                 text="What is in this document?",
                 type="text",
             ),
-        ],
-        experimental_attachments=[
-            Attachment(
-                name=file_name,
-                contentType=content_type,
-                url=document_url,
-            )
+            FileUIPart(type="file", filename=file_name, mediaType=content_type, url=document_url),
         ],
     )
 
@@ -935,7 +902,7 @@ def test_post_conversation_with_local_not_pdf_document_url(
 
     assert response.status_code == status.HTTP_200_OK
     assert response.get("Content-Type") == "text/event-stream"
-    assert response.get("x-vercel-ai-data-stream") == "v1"
+    assert response.get("x-vercel-ai-ui-message-stream") == "v1"
     assert response.streaming
 
     # Wait for the streaming content to be fully received
@@ -945,13 +912,16 @@ def test_post_conversation_with_local_not_pdf_document_url(
     response_content = replace_uuids_with_placeholder(response_content)
 
     assert response_content == (
-        '9:{"toolCallId":"XXX","toolName":"document_parsing",'
-        f'"args":{{"documents":[{{"identifier":"{file_name}"}}]}}}}\n'
-        'a:{"toolCallId":"XXX","result":{"state":"done"}}\n'
-        '0:"This is a document about you."\n'
-        'f:{"messageId":"<mocked_uuid>"}\n'
-        'd:{"finishReason":"stop","usage":{"promptTokens":50,"completionTokens":7,'
-        '"co2Impact":0.0}}\n'
+        'data: {"type":"start","messageId":"<mocked_uuid>"}\n\n'
+        'data: {"type":"tool-input-available","toolCallId":"XXX","toolName":"document_parsing"'
+        f',"input":{{"documents":[{{"identifier":"{file_name}"}}]}}}}\n\n'
+        'data: {"type":"tool-output-available","toolCallId":"XXX","output":{"state":"done"}}\n\n'
+        'data: {"type":"text-start","id":"0"}\n\n'
+        'data: {"type":"text-delta","id":"0","delta":"This is a document about you."}\n\n'
+        'data: {"type":"text-end","id":"0"}\n\n'
+        'data: {"type":"finish","messageMetadata":{"usage":{"promptTokens":50,"completionTokens":7'
+        ',"co2Impact":0.0}}}\n\n'
+        "data: [DONE]\n\n"
     )
 
     # Check that the conversation was updated
@@ -963,11 +933,8 @@ def test_post_conversation_with_local_not_pdf_document_url(
         id=chat_conversation.messages[0].id,
         createdAt=timezone.now(),
         content="What is in this document?",
-        reasoning=None,
         experimental_attachments=None,  # We should fix this, but for now document appears in source
         role="user",
-        annotations=None,
-        toolInvocations=None,
         parts=[
             TextUIPart(type="text", text="What is in this document?"),
         ],
@@ -978,11 +945,7 @@ def test_post_conversation_with_local_not_pdf_document_url(
         id=chat_conversation.messages[1].id,
         createdAt=timezone.now(),
         content="This is a document about you.",
-        reasoning=None,
-        experimental_attachments=None,
         role="assistant",
-        annotations=None,
-        toolInvocations=None,
         parts=[
             TextUIPart(type="text", text="This is a document about you."),
         ],

--- a/src/backend/chat/tests/views/chat/conversations/test_conversation_with_history.py
+++ b/src/backend/chat/tests/views/chat/conversations/test_conversation_with_history.py
@@ -14,10 +14,9 @@ from rest_framework import status
 
 from chat.agents.conversation import PREVENT_URL_HALLUCINATION_INSTRUCTION, TitleGenerationAgent
 from chat.ai_sdk_types import (
-    Attachment,
+    FileUIPart,
     TextUIPart,
-    ToolInvocationCall,
-    ToolInvocationUIPart,
+    ToolUIPart,
     UIMessage,
 )
 from chat.factories import ChatConversationFactory
@@ -49,11 +48,7 @@ def build__history_conversation_ui_messages(history_timestamp):
             id="prev-user-msg-1",
             createdAt=history_timestamp,
             content="How does machine learning work?",
-            reasoning=None,
-            experimental_attachments=None,
             role="user",
-            annotations=None,
-            toolInvocations=None,
             parts=[TextUIPart(type="text", text="How does machine learning work?")],
         ),
         UIMessage(
@@ -63,11 +58,7 @@ def build__history_conversation_ui_messages(history_timestamp):
                 "Machine learning is a branch of artificial intelligence "
                 "that focuses on building systems that learn from data."
             ),
-            reasoning=None,
-            experimental_attachments=None,
             role="assistant",
-            annotations=None,
-            toolInvocations=None,
             parts=[
                 TextUIPart(
                     type="text",
@@ -82,11 +73,7 @@ def build__history_conversation_ui_messages(history_timestamp):
             id="prev-user-msg-2",
             createdAt=history_timestamp.replace(minute=32),
             content="What are neural networks?",
-            reasoning=None,
-            experimental_attachments=None,
             role="user",
-            annotations=None,
-            toolInvocations=None,
             parts=[TextUIPart(type="text", text="What are neural networks?")],
         ),
         UIMessage(
@@ -96,11 +83,7 @@ def build__history_conversation_ui_messages(history_timestamp):
                 "Neural networks are computing systems inspired by the "
                 "biological neural networks in animal brains."
             ),
-            reasoning=None,
-            experimental_attachments=None,
             role="assistant",
-            annotations=None,
-            toolInvocations=None,
             parts=[
                 TextUIPart(
                     type="text",
@@ -312,7 +295,7 @@ def test_post_conversation_data_protocol_with_history(
 ):
     """Test posting messages to a conversation with history using the 'data' protocol."""
 
-    url = f"/api/v1.0/chats/{history_conversation.pk}/conversation/?protocol=data"
+    url = f"/api/v1.0/chats/{history_conversation.pk}/conversation/"
     data = {
         "messages": [
             {
@@ -330,7 +313,7 @@ def test_post_conversation_data_protocol_with_history(
 
     assert response.status_code == status.HTTP_200_OK
     assert response.get("Content-Type") == "text/event-stream"
-    assert response.get("x-vercel-ai-data-stream") == "v1"
+    assert response.get("x-vercel-ai-ui-message-stream") == "v1"
     assert response.streaming
 
     # Wait for the streaming content to be fully received
@@ -340,11 +323,14 @@ def test_post_conversation_data_protocol_with_history(
     response_content = replace_uuids_with_placeholder(response_content)
 
     assert response_content == (
-        '0:"Hello"\n'
-        '0:" there"\n'
-        'f:{"messageId":"<mocked_uuid>"}\n'
-        'd:{"finishReason":"stop","usage":{"promptTokens":0,"completionTokens":0,'
-        '"co2Impact":0.0}}\n'
+        'data: {"type":"start","messageId":"<mocked_uuid>"}\n\n'
+        'data: {"type":"text-start","id":"0"}\n\n'
+        'data: {"type":"text-delta","id":"0","delta":"Hello"}\n\n'
+        'data: {"type":"text-delta","id":"0","delta":" there"}\n\n'
+        'data: {"type":"text-end","id":"0"}\n\n'
+        'data: {"type":"finish","messageMetadata":{"usage":{"promptTokens":0,"completionToken'
+        's":0,"co2Impact":0.0}}}\n\n'
+        "data: [DONE]\n\n"
     )
 
     assert mock_openai_stream.called
@@ -378,11 +364,7 @@ def test_post_conversation_data_protocol_with_history(
         id=history_conversation.messages[4].id,
         createdAt=timezone.now(),  # Mocked timestamp
         content="Hello",
-        reasoning=None,
-        experimental_attachments=None,
         role="user",
-        annotations=None,
-        toolInvocations=None,
         parts=[TextUIPart(type="text", text="Hello")],
     )
 
@@ -391,91 +373,12 @@ def test_post_conversation_data_protocol_with_history(
         id=history_conversation.messages[5].id,
         createdAt=timezone.now(),  # Mocked timestamp
         content="Hello there",
-        reasoning=None,
-        experimental_attachments=None,
         role="assistant",
-        annotations=None,
-        toolInvocations=None,
         parts=[TextUIPart(type="text", text="Hello there")],
     )
 
     # Verify that the pydantic_messages were appended correctly
     assert len(history_conversation.pydantic_messages) == 6  # Original 4 + 2 new ones
-
-
-@freeze_time("2025-07-25T10:36:35.297675Z")
-@respx.mock
-def test_post_conversation_text_protocol_with_history(
-    api_client, mock_openai_stream, history_conversation
-):
-    """Test posting messages to a conversation with history using the 'text' protocol."""
-    url = f"/api/v1.0/chats/{history_conversation.pk}/conversation/?protocol=text"
-    data = {
-        "messages": [
-            {
-                "id": "yuPoOuBkKA4FnKvk",
-                "role": "user",
-                "parts": [{"text": "Hello", "type": "text"}],
-                "content": "Hello",
-                "createdAt": "2025-07-03T15:22:17.105Z",
-            }
-        ]
-    }
-    api_client.force_login(history_conversation.owner)
-
-    response = api_client.post(url, data, format="json")
-
-    assert response.status_code == status.HTTP_200_OK
-    assert response.get("Content-Type") == "text/event-stream"
-    assert response.streaming
-
-    response_content = b"".join(response.streaming_content).decode("utf-8")
-    assert response_content == "Hello there"
-
-    assert mock_openai_stream.called
-
-    # Verify the conversation still has its history plus the new messages
-    history_conversation.refresh_from_db()
-    # The UI messages should only include the most recent one (sent from frontend)
-    assert history_conversation.ui_messages == [
-        {
-            "content": "Hello",
-            "createdAt": "2025-07-03T15:22:17.105Z",
-            "id": "yuPoOuBkKA4FnKvk",
-            "parts": [{"text": "Hello", "type": "text"}],
-            "role": "user",
-        }
-    ]
-
-    # But the messages field should have 6 messages - 4 from history + 2 new ones
-    assert len(history_conversation.messages) == 6
-
-    # Verify the most recent messages are the new ones
-    assert history_conversation.messages[4].id == IsUUID(4)
-    assert history_conversation.messages[4] == UIMessage(
-        id=history_conversation.messages[4].id,
-        createdAt=timezone.now(),  # Mocked timestamp
-        content="Hello",
-        reasoning=None,
-        experimental_attachments=None,
-        role="user",
-        annotations=None,
-        toolInvocations=None,
-        parts=[TextUIPart(type="text", text="Hello")],
-    )
-
-    assert history_conversation.messages[5].id == IsUUID(4)
-    assert history_conversation.messages[5] == UIMessage(
-        id=history_conversation.messages[5].id,
-        createdAt=timezone.now(),  # Mocked timestamp
-        content="Hello there",
-        reasoning=None,
-        experimental_attachments=None,
-        role="assistant",
-        annotations=None,
-        toolInvocations=None,
-        parts=[TextUIPart(type="text", text="Hello there")],
-    )
 
 
 @freeze_time("2025-07-25T10:36:35.297675Z")
@@ -486,7 +389,7 @@ def test_post_conversation_with_image_with_history(
     """
     Ensure an image URL is correctly forwarded to the AI service with a conversation with history.
     """
-    url = f"/api/v1.0/chats/{history_conversation.pk}/conversation/?protocol=data"
+    url = f"/api/v1.0/chats/{history_conversation.pk}/conversation/"
 
     data = {
         "messages": [
@@ -516,7 +419,7 @@ def test_post_conversation_with_image_with_history(
 
     assert response.status_code == status.HTTP_200_OK
     assert response.get("Content-Type") == "text/event-stream"
-    assert response.get("x-vercel-ai-data-stream") == "v1"
+    assert response.get("x-vercel-ai-ui-message-stream") == "v1"
     assert response.streaming
 
     # Wait for the streaming content to be fully received
@@ -526,11 +429,14 @@ def test_post_conversation_with_image_with_history(
     response_content = replace_uuids_with_placeholder(response_content)
 
     assert response_content == (
-        '0:"I see a cat"\n'
-        '0:" in the picture."\n'
-        'f:{"messageId":"<mocked_uuid>"}\n'
-        'd:{"finishReason":"stop","usage":{"promptTokens":0,"completionTokens":0'
-        ',"co2Impact":0.0}}\n'
+        'data: {"type":"start","messageId":"<mocked_uuid>"}\n\n'
+        'data: {"type":"text-start","id":"0"}\n\n'
+        'data: {"type":"text-delta","id":"0","delta":"I see a cat"}\n\n'
+        'data: {"type":"text-delta","id":"0","delta":" in the picture."}\n\n'
+        'data: {"type":"text-end","id":"0"}\n\n'
+        'data: {"type":"finish","messageMetadata":{"usage":{"promptTokens":0,"completionToken'
+        's":0,"co2Impact":0.0}}}\n\n'
+        "data: [DONE]\n\n"
     )
 
     # --- Verify the outgoing HTTP request body contains the image ---
@@ -580,22 +486,19 @@ def test_post_conversation_with_image_with_history(
         id=history_conversation.messages[4].id,
         createdAt=timezone.now(),  # Mocked timestamp
         content="Hello, what do you see on this picture?",
-        reasoning=None,
-        experimental_attachments=[
-            Attachment(
-                name=None,
-                contentType="image/png",
+        role="user",
+        parts=[
+            TextUIPart(type="text", text="Hello, what do you see on this picture?"),
+            FileUIPart(
+                type="file",
+                mediaType="image/png",
                 url=(
                     "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+w"
                     "SzIAAAABlBMVEX///+/v7+jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEA"
                     "AAAASUVORK5CYII="
                 ),
-            )
+            ),
         ],
-        role="user",
-        annotations=None,
-        toolInvocations=None,
-        parts=[TextUIPart(type="text", text="Hello, what do you see on this picture?")],
     )
 
     assert history_conversation.messages[5].id == IsUUID(4)
@@ -603,11 +506,7 @@ def test_post_conversation_with_image_with_history(
         id=history_conversation.messages[5].id,
         createdAt=timezone.now(),  # Mocked timestamp
         content="I see a cat in the picture.",
-        reasoning=None,
-        experimental_attachments=None,
         role="assistant",
-        annotations=None,
-        toolInvocations=None,
         parts=[TextUIPart(type="text", text="I see a cat in the picture.")],
     )
 
@@ -622,7 +521,7 @@ def test_post_conversation_tool_call_with_history(
     """
     settings.AI_AGENT_TOOLS = ["get_current_weather"]
 
-    url = f"/api/v1.0/chats/{history_conversation.pk}/conversation/?protocol=data"
+    url = f"/api/v1.0/chats/{history_conversation.pk}/conversation/"
 
     data = {
         "messages": [
@@ -641,7 +540,7 @@ def test_post_conversation_tool_call_with_history(
 
     assert response.status_code == status.HTTP_200_OK
     assert response.get("Content-Type") == "text/event-stream"
-    assert response.get("x-vercel-ai-data-stream") == "v1"
+    assert response.get("x-vercel-ai-ui-message-stream") == "v1"
     assert response.streaming
 
     # Wait for the streaming content to be fully received
@@ -651,16 +550,20 @@ def test_post_conversation_tool_call_with_history(
     response_content = replace_uuids_with_placeholder(response_content)
 
     assert response_content == (
-        'b:{"toolCallId":"xLDcIljdsDrz0idal7tATWSMm2jhMj47","toolName":'
-        '"get_current_weather"}\n'
-        'c:{"toolCallId":"xLDcIljdsDrz0idal7tATWSMm2jhMj47","argsTextDelta":'
-        '"{\\"location\\":\\"Paris\\", \\"unit\\":\\"celsius\\"}"}\n'
-        'a:{"toolCallId":"xLDcIljdsDrz0idal7tATWSMm2jhMj47","result":{"location":'
-        '"Paris","temperature":22,"unit":"celsius"}}\n'
-        '0:"The current weather in Paris is nice"\n'
-        'f:{"messageId":"<mocked_uuid>"}\n'
-        'd:{"finishReason":"stop","usage":{"promptTokens":0,"completionTokens":0'
-        ',"co2Impact":0.0}}\n'
+        'data: {"type":"start","messageId":"<mocked_uuid>"}\n\n'
+        'data: {"type":"tool-input-start","toolCallId":"xLDcIljdsDrz0idal7tATWSMm2jhMj47","to'
+        'olName":"get_current_weather"}\n\n'
+        'data: {"type":"tool-input-delta","toolCallId":"xLDcIljdsDrz0idal7tATWSMm2jhMj47","in'
+        'putTextDelta":"{\\"location\\":\\"Paris\\", \\"unit\\":\\"celsius\\"}"}\n\n'
+        'data: {"type":"tool-output-available","toolCallId":"xLDcIljdsDrz0idal7tATWSMm2jhMj47'
+        '","output":{"location":"Paris","temperature":22,"unit":"celsius"}}\n\n'
+        'data: {"type":"text-start","id":"0"}\n\n'
+        'data: {"type":"text-delta","id":"0","delta":"The current weather in Paris is nice"}'
+        "\n\n"
+        'data: {"type":"text-end","id":"0"}\n\n'
+        'data: {"type":"finish","messageMetadata":{"usage":{"promptTokens":0,"completionToken'
+        's":0,"co2Impact":0.0}}}\n\n'
+        "data: [DONE]\n\n"
     )
 
     # --- Verify the outgoing HTTP request body ---
@@ -696,11 +599,7 @@ def test_post_conversation_tool_call_with_history(
         id=history_conversation.messages[4].id,
         createdAt=timezone.now(),  # Mocked timestamp
         content="Weather in Paris?",
-        reasoning=None,
-        experimental_attachments=None,
         role="user",
-        annotations=None,
-        toolInvocations=None,
         parts=[TextUIPart(type="text", text="Weather in Paris?")],
     )
 
@@ -709,21 +608,13 @@ def test_post_conversation_tool_call_with_history(
         id=history_conversation.messages[5].id,
         createdAt=timezone.now(),  # Mocked timestamp
         content="The current weather in Paris is nice",
-        reasoning=None,
-        experimental_attachments=None,
         role="assistant",
-        annotations=None,
-        toolInvocations=None,
         parts=[
-            ToolInvocationUIPart(
-                type="tool-invocation",
-                toolInvocation=ToolInvocationCall(
-                    toolCallId="xLDcIljdsDrz0idal7tATWSMm2jhMj47",
-                    toolName="get_current_weather",
-                    args={"unit": "celsius", "location": "Paris"},
-                    state="call",
-                    step=None,
-                ),
+            ToolUIPart(
+                type="tool-get_current_weather",
+                toolCallId="xLDcIljdsDrz0idal7tATWSMm2jhMj47",
+                state="input-available",
+                input={"unit": "celsius", "location": "Paris"},
             ),
             TextUIPart(type="text", text="The current weather in Paris is nice"),
         ],
@@ -745,7 +636,7 @@ def test_post_conversation_tool_call_fails_with_history(
     conversation with history.
     """
 
-    url = f"/api/v1.0/chats/{history_conversation.pk}/conversation/?protocol=data"
+    url = f"/api/v1.0/chats/{history_conversation.pk}/conversation/"
 
     data = {
         "messages": [
@@ -764,7 +655,7 @@ def test_post_conversation_tool_call_fails_with_history(
 
     assert response.status_code == status.HTTP_200_OK
     assert response.get("Content-Type") == "text/event-stream"
-    assert response.get("x-vercel-ai-data-stream") == "v1"
+    assert response.get("x-vercel-ai-ui-message-stream") == "v1"
     assert response.streaming
 
     # Wait for the streaming content to be fully received
@@ -775,7 +666,7 @@ def test_post_conversation_tool_call_fails_with_history(
 
     assert "Unknown tool name: 'get_current_weather'." in response_content
     assert "self_documentation" in response_content
-    assert '0:"I cannot give you an answer to that."' in response_content
+    assert '"delta":"I cannot give you an answer to that."' in response_content
 
     # --- Verify the outgoing HTTP request body ---
     request_sent = mock_openai_stream_tool.calls[0].request
@@ -810,11 +701,7 @@ def test_post_conversation_tool_call_fails_with_history(
         id=history_conversation.messages[4].id,
         createdAt=timezone.now(),  # Mocked timestamp
         content="Weather in Paris?",
-        reasoning=None,
-        experimental_attachments=None,
         role="user",
-        annotations=None,
-        toolInvocations=None,
         parts=[TextUIPart(type="text", text="Weather in Paris?")],
     )
 
@@ -823,21 +710,13 @@ def test_post_conversation_tool_call_fails_with_history(
         id=history_conversation.messages[5].id,
         createdAt=timezone.now(),  # Mocked timestamp
         content="I cannot give you an answer to that.",
-        reasoning=None,
-        experimental_attachments=None,
         role="assistant",
-        annotations=None,
-        toolInvocations=None,
         parts=[
-            ToolInvocationUIPart(
-                type="tool-invocation",
-                toolInvocation=ToolInvocationCall(
-                    toolCallId="xLDcIljdsDrz0idal7tATWSMm2jhMj47",
-                    toolName="get_current_weather",
-                    args={"unit": "celsius", "location": "Paris"},
-                    state="call",
-                    step=None,
-                ),
+            ToolUIPart(
+                type="tool-get_current_weather",
+                toolCallId="xLDcIljdsDrz0idal7tATWSMm2jhMj47",
+                state="input-available",
+                input={"unit": "celsius", "location": "Paris"},
             ),
             TextUIPart(type="text", text="I cannot give you an answer to that."),
         ],
@@ -864,43 +743,33 @@ def history_conversation_with_image_fixture():
             id="prev-user-msg-1",
             createdAt=history_timestamp,
             content="Hello, what do you see in this image?",
-            reasoning=None,
-            experimental_attachments=[
-                Attachment(
-                    name="test-image.jpg",
-                    contentType="image/png",
+            role="user",
+            parts=[
+                TextUIPart(type="text", text="Hello, what do you see in this image?"),
+                FileUIPart(
+                    type="file",
+                    filename="test-image.jpg",
+                    mediaType="image/png",
                     url=(
                         "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+wSzIAAA"
                         "ABlBMVEX///+/v7+jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEAAAAASUVORK5C"
                         "YII="
                     ),
-                )
+                ),
             ],
-            role="user",
-            annotations=None,
-            toolInvocations=None,
-            parts=[TextUIPart(type="text", text="Hello, what do you see in this image?")],
         ),
         UIMessage(
             id="prev-assistant-msg-1",
             createdAt=history_timestamp.replace(minute=31),
             content="I see a small black square in the image.",
-            reasoning=None,
-            experimental_attachments=None,
             role="assistant",
-            annotations=None,
-            toolInvocations=None,
             parts=[TextUIPart(type="text", text="I see a small black square in the image.")],
         ),
         UIMessage(
             id="prev-user-msg-2",
             createdAt=history_timestamp.replace(minute=32),
             content="Can you tell me more about it?",
-            reasoning=None,
-            experimental_attachments=None,
             role="user",
-            annotations=None,
-            toolInvocations=None,
             parts=[TextUIPart(type="text", text="Can you tell me more about it?")],
         ),
         UIMessage(
@@ -910,11 +779,7 @@ def history_conversation_with_image_fixture():
                 "It appears to be a very simple image with a small black square "
                 "in the center on a white background."
             ),
-            reasoning=None,
-            experimental_attachments=None,
             role="assistant",
-            annotations=None,
-            toolInvocations=None,
             parts=[
                 TextUIPart(
                     type="text",
@@ -1028,32 +893,20 @@ def history_conversation_with_tool_fixture():
             id="prev-user-msg-1",
             createdAt=history_timestamp,
             content="What's the weather like in London?",
-            reasoning=None,
-            experimental_attachments=None,
             role="user",
-            annotations=None,
-            toolInvocations=None,
             parts=[TextUIPart(type="text", text="What's the weather like in London?")],
         ),
         UIMessage(
             id="prev-assistant-msg-1",
             createdAt=history_timestamp.replace(minute=31),
             content="The current weather in London is cloudy with a temperature of 18°C.",
-            reasoning=None,
-            experimental_attachments=None,
             role="assistant",
-            annotations=None,
-            toolInvocations=None,
             parts=[
-                ToolInvocationUIPart(
-                    type="tool-invocation",
-                    toolInvocation=ToolInvocationCall(
-                        toolCallId="previous-tool-call-123",
-                        toolName="get_current_weather",
-                        args={"location": "London", "unit": "celsius"},
-                        state="call",
-                        step=None,
-                    ),
+                ToolUIPart(
+                    type="tool-get_current_weather",
+                    toolCallId="previous-tool-call-123",
+                    state="input-available",
+                    input={"location": "London", "unit": "celsius"},
                 ),
                 TextUIPart(
                     type="text",
@@ -1065,11 +918,7 @@ def history_conversation_with_tool_fixture():
             id="prev-user-msg-2",
             createdAt=history_timestamp.replace(minute=32),
             content="And how about tomorrow?",
-            reasoning=None,
-            experimental_attachments=None,
             role="user",
-            annotations=None,
-            toolInvocations=None,
             parts=[TextUIPart(type="text", text="And how about tomorrow?")],
         ),
         UIMessage(
@@ -1078,21 +927,13 @@ def history_conversation_with_tool_fixture():
             content=(
                 "Tomorrow's forecast for London shows partly sunny conditions with a high of 20°C."
             ),
-            reasoning=None,
-            experimental_attachments=None,
             role="assistant",
-            annotations=None,
-            toolInvocations=None,
             parts=[
-                ToolInvocationUIPart(
-                    type="tool-invocation",
-                    toolInvocation=ToolInvocationCall(
-                        toolCallId="previous-tool-call-456",
-                        toolName="get_current_weather",
-                        args={"location": "London", "days": 1, "unit": "celsius"},
-                        state="call",
-                        step=None,
-                    ),
+                ToolUIPart(
+                    type="tool-get_current_weather",
+                    toolCallId="previous-tool-call-456",
+                    state="input-available",
+                    input={"location": "London", "days": 1, "unit": "celsius"},
                 ),
                 TextUIPart(
                     type="text",
@@ -1283,7 +1124,7 @@ def test_post_conversation_with_existing_image_history(
     api_client, mock_openai_stream, history_conversation_with_image
 ):
     """Test posting a message to a conversation that already has images in its history."""
-    url = f"/api/v1.0/chats/{history_conversation_with_image.pk}/conversation/?protocol=data"
+    url = f"/api/v1.0/chats/{history_conversation_with_image.pk}/conversation/"
     data = {
         "messages": [
             {
@@ -1301,7 +1142,7 @@ def test_post_conversation_with_existing_image_history(
 
     assert response.status_code == status.HTTP_200_OK
     assert response.get("Content-Type") == "text/event-stream"
-    assert response.get("x-vercel-ai-data-stream") == "v1"
+    assert response.get("x-vercel-ai-ui-message-stream") == "v1"
     assert response.streaming
 
     # Wait for the streaming content to be fully received
@@ -1311,11 +1152,14 @@ def test_post_conversation_with_existing_image_history(
     response_content = replace_uuids_with_placeholder(response_content)
 
     assert response_content == (
-        '0:"Hello"\n'
-        '0:" there"\n'
-        'f:{"messageId":"<mocked_uuid>"}\n'
-        'd:{"finishReason":"stop","usage":{"promptTokens":0,"completionTokens":0'
-        ',"co2Impact":0.0}}\n'
+        'data: {"type":"start","messageId":"<mocked_uuid>"}\n\n'
+        'data: {"type":"text-start","id":"0"}\n\n'
+        'data: {"type":"text-delta","id":"0","delta":"Hello"}\n\n'
+        'data: {"type":"text-delta","id":"0","delta":" there"}\n\n'
+        'data: {"type":"text-end","id":"0"}\n\n'
+        'data: {"type":"finish","messageMetadata":{"usage":{"promptTokens":0,"completionToken'
+        's":0,"co2Impact":0.0}}}\n\n'
+        "data: [DONE]\n\n"
     )
 
     assert mock_openai_stream.called
@@ -1350,11 +1194,7 @@ def test_post_conversation_with_existing_image_history(
         id=history_conversation_with_image.messages[4].id,
         createdAt=timezone.now(),  # Mocked timestamp
         content="What was in that image again?",
-        reasoning=None,
-        experimental_attachments=None,
         role="user",
-        annotations=None,
-        toolInvocations=None,
         parts=[TextUIPart(type="text", text="What was in that image again?")],
     )
 
@@ -1363,11 +1203,7 @@ def test_post_conversation_with_existing_image_history(
         id=history_conversation_with_image.messages[5].id,
         createdAt=timezone.now(),  # Mocked timestamp
         content="Hello there",
-        reasoning=None,
-        experimental_attachments=None,
         role="assistant",
-        annotations=None,
-        toolInvocations=None,
         parts=[TextUIPart(type="text", text="Hello there")],
     )
 
@@ -1383,7 +1219,7 @@ def test_post_conversation_with_existing_tool_history(
     """Test posting a message to a conversation that already has tool calls in its history."""
     settings.AI_AGENT_TOOLS = ["get_current_weather"]
 
-    url = f"/api/v1.0/chats/{history_conversation_with_tool.pk}/conversation/?protocol=data"
+    url = f"/api/v1.0/chats/{history_conversation_with_tool.pk}/conversation/"
     data = {
         "messages": [
             {
@@ -1401,7 +1237,7 @@ def test_post_conversation_with_existing_tool_history(
 
     assert response.status_code == status.HTTP_200_OK
     assert response.get("Content-Type") == "text/event-stream"
-    assert response.get("x-vercel-ai-data-stream") == "v1"
+    assert response.get("x-vercel-ai-ui-message-stream") == "v1"
     assert response.streaming
 
     # Wait for the streaming content to be fully received
@@ -1411,16 +1247,20 @@ def test_post_conversation_with_existing_tool_history(
     response_content = replace_uuids_with_placeholder(response_content)
 
     assert response_content == (
-        'b:{"toolCallId":"xLDcIljdsDrz0idal7tATWSMm2jhMj47","toolName":'
-        '"get_current_weather"}\n'
-        'c:{"toolCallId":"xLDcIljdsDrz0idal7tATWSMm2jhMj47","argsTextDelta":'
-        '"{\\"location\\":\\"Paris\\", \\"unit\\":\\"celsius\\"}"}\n'
-        'a:{"toolCallId":"xLDcIljdsDrz0idal7tATWSMm2jhMj47","result":{"location":'
-        '"Paris","temperature":22,"unit":"celsius"}}\n'
-        '0:"The current weather in Paris is nice"\n'
-        'f:{"messageId":"<mocked_uuid>"}\n'
-        'd:{"finishReason":"stop","usage":{"promptTokens":0,"completionTokens":0'
-        ',"co2Impact":0.0}}\n'
+        'data: {"type":"start","messageId":"<mocked_uuid>"}\n\n'
+        'data: {"type":"tool-input-start","toolCallId":"xLDcIljdsDrz0idal7tATWSMm2jhMj47","to'
+        'olName":"get_current_weather"}\n\n'
+        'data: {"type":"tool-input-delta","toolCallId":"xLDcIljdsDrz0idal7tATWSMm2jhMj47","in'
+        'putTextDelta":"{\\"location\\":\\"Paris\\", \\"unit\\":\\"celsius\\"}"}\n\n'
+        'data: {"type":"tool-output-available","toolCallId":"xLDcIljdsDrz0idal7tATWSMm2jhMj47'
+        '","output":{"location":"Paris","temperature":22,"unit":"celsius"}}\n\n'
+        'data: {"type":"text-start","id":"0"}\n\n'
+        'data: {"type":"text-delta","id":"0","delta":"The current weather in Paris is nice"}'
+        "\n\n"
+        'data: {"type":"text-end","id":"0"}\n\n'
+        'data: {"type":"finish","messageMetadata":{"usage":{"promptTokens":0,"completionToken'
+        's":0,"co2Impact":0.0}}}\n\n'
+        "data: [DONE]\n\n"
     )
 
     assert mock_openai_stream_tool.called
@@ -1444,11 +1284,7 @@ def test_post_conversation_with_existing_tool_history(
         id=history_conversation_with_tool.messages[4].id,
         createdAt=timezone.now(),  # Mocked timestamp
         content="How about Paris weather?",
-        reasoning=None,
-        experimental_attachments=None,
         role="user",
-        annotations=None,
-        toolInvocations=None,
         parts=[TextUIPart(type="text", text="How about Paris weather?")],
     )
 
@@ -1457,21 +1293,13 @@ def test_post_conversation_with_existing_tool_history(
         id=history_conversation_with_tool.messages[5].id,
         createdAt=timezone.now(),  # Mocked timestamp
         content="The current weather in Paris is nice",
-        reasoning=None,
-        experimental_attachments=None,
         role="assistant",
-        annotations=None,
-        toolInvocations=None,
         parts=[
-            ToolInvocationUIPart(
-                type="tool-invocation",
-                toolInvocation=ToolInvocationCall(
-                    toolCallId="xLDcIljdsDrz0idal7tATWSMm2jhMj47",
-                    toolName="get_current_weather",
-                    args={"unit": "celsius", "location": "Paris"},
-                    state="call",
-                    step=None,
-                ),
+            ToolUIPart(
+                type="tool-get_current_weather",
+                toolCallId="xLDcIljdsDrz0idal7tATWSMm2jhMj47",
+                state="input-available",
+                input={"unit": "celsius", "location": "Paris"},
             ),
             TextUIPart(type="text", text="The current weather in Paris is nice"),
         ],
@@ -1616,7 +1444,7 @@ def test_post_conversation_add_image_to_conversation_with_tool_history(
     api_client, mock_openai_stream_image, history_conversation_with_tool
 ):
     """Test adding an image to a conversation that already has tool calls in its history."""
-    url = f"/api/v1.0/chats/{history_conversation_with_tool.pk}/conversation/?protocol=data"
+    url = f"/api/v1.0/chats/{history_conversation_with_tool.pk}/conversation/"
 
     data = {
         "messages": [
@@ -1646,7 +1474,7 @@ def test_post_conversation_add_image_to_conversation_with_tool_history(
 
     assert response.status_code == status.HTTP_200_OK
     assert response.get("Content-Type") == "text/event-stream"
-    assert response.get("x-vercel-ai-data-stream") == "v1"
+    assert response.get("x-vercel-ai-ui-message-stream") == "v1"
     assert response.streaming
 
     # Wait for the streaming content to be fully received
@@ -1656,11 +1484,14 @@ def test_post_conversation_add_image_to_conversation_with_tool_history(
     response_content = replace_uuids_with_placeholder(response_content)
 
     assert response_content == (
-        '0:"I see a cat"\n'
-        '0:" in the picture."\n'
-        'f:{"messageId":"<mocked_uuid>"}\n'
-        'd:{"finishReason":"stop","usage":{"promptTokens":0,"completionTokens":0,'
-        '"co2Impact":0.0}}\n'
+        'data: {"type":"start","messageId":"<mocked_uuid>"}\n\n'
+        'data: {"type":"text-start","id":"0"}\n\n'
+        'data: {"type":"text-delta","id":"0","delta":"I see a cat"}\n\n'
+        'data: {"type":"text-delta","id":"0","delta":" in the picture."}\n\n'
+        'data: {"type":"text-end","id":"0"}\n\n'
+        'data: {"type":"finish","messageMetadata":{"usage":{"promptTokens":0,"completionToken'
+        's":0,"co2Impact":0.0}}}\n\n'
+        "data: [DONE]\n\n"
     )
 
     # Verify that the request to OpenAI included both
@@ -1690,22 +1521,19 @@ def test_post_conversation_add_image_to_conversation_with_tool_history(
         id=history_conversation_with_tool.messages[4].id,
         createdAt=timezone.now(),  # Mocked timestamp
         content="How's the weather in this image?",
-        reasoning=None,
-        experimental_attachments=[
-            Attachment(
-                name=None,
-                contentType="image/png",
+        role="user",
+        parts=[
+            TextUIPart(type="text", text="How's the weather in this image?"),
+            FileUIPart(
+                type="file",
+                mediaType="image/png",
                 url=(
                     "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+w"
                     "SzIAAAABlBMVEX///+/v7+jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEA"
                     "AAAASUVORK5CYII="
                 ),
-            )
+            ),
         ],
-        role="user",
-        annotations=None,
-        toolInvocations=None,
-        parts=[TextUIPart(type="text", text="How's the weather in this image?")],
     )
 
     assert history_conversation_with_tool.messages[5].id == IsUUID(4)
@@ -1713,11 +1541,7 @@ def test_post_conversation_add_image_to_conversation_with_tool_history(
         id=history_conversation_with_tool.messages[5].id,
         createdAt=timezone.now(),  # Mocked timestamp
         content="I see a cat in the picture.",
-        reasoning=None,
-        experimental_attachments=None,
         role="assistant",
-        annotations=None,
-        toolInvocations=None,
         parts=[TextUIPart(type="text", text="I see a cat in the picture.")],
     )
 
@@ -1739,7 +1563,7 @@ def test_post_conversation_triggers_automatic_title_generation_after_first_messa
     # Configure the title generation threshold
     settings.AUTO_TITLE_AFTER_USER_MESSAGES = 1
     conversation = ChatConversationFactory()
-    url = f"/api/v1.0/chats/{conversation.pk}/conversation/?protocol=data"
+    url = f"/api/v1.0/chats/{conversation.pk}/conversation/"
     data = {
         "messages": [
             {
@@ -1769,7 +1593,7 @@ def test_post_conversation_triggers_automatic_title_generation_after_first_messa
 
     # Verify the conversation_metadata event is in the stream
 
-    assert '"type": "conversation_metadata"' in response_content
+    assert '"type":"data-conversation-metadata"' in response_content
 
     # Refresh and verify title was updated
     conversation.refresh_from_db()
@@ -1802,7 +1626,7 @@ def test_post_conversation_triggers_automatic_title_generation_at_threshold(
     # Configure the title generation threshold
     settings.AUTO_TITLE_AFTER_USER_MESSAGES = 3
 
-    url = f"/api/v1.0/chats/{history_conversation.pk}/conversation/?protocol=data"
+    url = f"/api/v1.0/chats/{history_conversation.pk}/conversation/"
     data = {
         "messages": [
             {
@@ -1832,7 +1656,7 @@ def test_post_conversation_triggers_automatic_title_generation_at_threshold(
 
     # Verify the conversation_metadata event is in the stream
 
-    assert '"type": "conversation_metadata"' in response_content
+    assert '"type":"data-conversation-metadata"' in response_content
 
     # Refresh and verify title was updated
     history_conversation.refresh_from_db()
@@ -1860,7 +1684,7 @@ def test_post_conversation_does_not_regenerate_title_when_user_set(
     history_conversation.title_set_by_user_at = timezone.now()
     history_conversation.save()
 
-    url = f"/api/v1.0/chats/{history_conversation.pk}/conversation/?protocol=data"
+    url = f"/api/v1.0/chats/{history_conversation.pk}/conversation/"
     data = {
         "messages": [
             {
@@ -1913,28 +1737,20 @@ def test_post_conversation_does_not_generate_title_before_threshold(
             id="prev-user-msg-1",
             createdAt=history_timestamp,
             content="Hello!",
-            reasoning=None,
-            experimental_attachments=None,
             role="user",
-            annotations=None,
-            toolInvocations=None,
             parts=[TextUIPart(type="text", text="Hello!")],
         ),
         UIMessage(
             id="prev-assistant-msg-1",
             createdAt=history_timestamp.replace(minute=31),
             content="Hi there! How can I help you?",
-            reasoning=None,
-            experimental_attachments=None,
             role="assistant",
-            annotations=None,
-            toolInvocations=None,
             parts=[TextUIPart(type="text", text="Hi there! How can I help you?")],
         ),
     ]
     conversation.save()
 
-    url = f"/api/v1.0/chats/{conversation.pk}/conversation/?protocol=data"
+    url = f"/api/v1.0/chats/{conversation.pk}/conversation/"
     data = {
         "messages": [
             {
@@ -1983,7 +1799,7 @@ def test_post_conversation_does_not_generate_title_after_threshold(
     # Configure the title generation threshold
     settings.AUTO_TITLE_AFTER_USER_MESSAGES = 2
 
-    url = f"/api/v1.0/chats/{history_conversation.pk}/conversation/?protocol=data"
+    url = f"/api/v1.0/chats/{history_conversation.pk}/conversation/"
     data = {
         "messages": [
             {

--- a/src/backend/chat/tests/views/chat/conversations/test_conversation_with_image_url.py
+++ b/src/backend/chat/tests/views/chat/conversations/test_conversation_with_image_url.py
@@ -21,7 +21,7 @@ from rest_framework import status
 
 from chat.agents.conversation import PREVENT_URL_HALLUCINATION_INSTRUCTION
 from chat.ai_sdk_types import (
-    Attachment,
+    FileUIPart,
     TextUIPart,
     UIMessage,
 )
@@ -75,13 +75,7 @@ def test_post_conversation_with_local_image_url(
                 text="What is in this image?",
                 type="text",
             ),
-        ],
-        experimental_attachments=[
-            Attachment(
-                name="sample.png",
-                contentType="image/png",
-                url=image_url,
-            )
+            FileUIPart(type="file", filename="sample.png", mediaType="image/png", url=image_url),
         ],
     )
 
@@ -129,7 +123,7 @@ def test_post_conversation_with_local_image_url(
 
     assert response.status_code == status.HTTP_200_OK
     assert response.get("Content-Type") == "text/event-stream"
-    assert response.get("x-vercel-ai-data-stream") == "v1"
+    assert response.get("x-vercel-ai-ui-message-stream") == "v1"
     assert response.streaming
 
     # Wait for the streaming content to be fully received
@@ -139,10 +133,14 @@ def test_post_conversation_with_local_image_url(
     response_content = replace_uuids_with_placeholder(response_content)
 
     assert response_content == (
-        '0:"This is an image of a single pixel."\n'
-        'f:{"messageId":"<mocked_uuid>"}\n'
-        'd:{"finishReason":"stop","usage":{"promptTokens":50,"completionTokens":9,'
-        '"co2Impact":0.0}}\n'
+        'data: {"type":"start","messageId":"<mocked_uuid>"}\n\n'
+        'data: {"type":"text-start","id":"0"}\n\n'
+        'data: {"type":"text-delta","id":"0","delta":"This is an image of a single pixel."}\n'
+        "\n"
+        'data: {"type":"text-end","id":"0"}\n\n'
+        'data: {"type":"finish","messageMetadata":{"usage":{"promptTokens":50,"completionToke'
+        'ns":9,"co2Impact":0.0}}}\n\n'
+        "data: [DONE]\n\n"
     )
 
     # Check that the conversation was updated
@@ -154,15 +152,10 @@ def test_post_conversation_with_local_image_url(
         id=chat_conversation.messages[0].id,  # don't test the value directly
         createdAt=timezone.now(),
         content="What is in this image?",
-        reasoning=None,
-        experimental_attachments=[
-            Attachment(name="sample.png", contentType="image/png", url=image_url)
-        ],
         role="user",
-        annotations=None,
-        toolInvocations=None,
         parts=[
             TextUIPart(type="text", text="What is in this image?"),
+            FileUIPart(type="file", filename="sample.png", mediaType="image/png", url=image_url),
         ],
     )
 
@@ -171,11 +164,7 @@ def test_post_conversation_with_local_image_url(
         id=chat_conversation.messages[1].id,  # don't test the value directly
         createdAt=timezone.now(),
         content="This is an image of a single pixel.",
-        reasoning=None,
-        experimental_attachments=None,
         role="assistant",
-        annotations=None,
-        toolInvocations=None,
         parts=[
             TextUIPart(type="text", text="This is an image of a single pixel."),
         ],
@@ -273,13 +262,7 @@ def test_post_conversation_with_local_image_wrong_url(
                 text="What is in this image?",
                 type="text",
             ),
-        ],
-        experimental_attachments=[
-            Attachment(
-                name="sample.png",
-                contentType="image/png",
-                url=image_url,
-            )
+            FileUIPart(type="file", filename="sample.png", mediaType="image/png", url=image_url),
         ],
     )
 
@@ -322,7 +305,7 @@ def test_post_conversation_with_local_image_wrong_url(
 
     assert response.status_code == status.HTTP_200_OK
     assert response.get("Content-Type") == "text/event-stream"
-    assert response.get("x-vercel-ai-data-stream") == "v1"
+    assert response.get("x-vercel-ai-ui-message-stream") == "v1"
     assert response.streaming
 
     # Wait for the streaming content to be fully received
@@ -332,10 +315,13 @@ def test_post_conversation_with_local_image_wrong_url(
     response_content = replace_uuids_with_placeholder(response_content)
 
     assert response_content == (
-        '0:"cannot read image."\n'
-        'f:{"messageId":"<mocked_uuid>"}\n'
-        'd:{"finishReason":"stop","usage":{"promptTokens":50,"completionTokens":4,'
-        '"co2Impact":0.0}}\n'
+        'data: {"type":"start","messageId":"<mocked_uuid>"}\n\n'
+        'data: {"type":"text-start","id":"0"}\n\n'
+        'data: {"type":"text-delta","id":"0","delta":"cannot read image."}\n\n'
+        'data: {"type":"text-end","id":"0"}\n\n'
+        'data: {"type":"finish","messageMetadata":{"usage":{"promptTokens":50,"completionToke'
+        'ns":4,"co2Impact":0.0}}}\n\n'
+        "data: [DONE]\n\n"
     )
 
     # We don't check conversation messages here because the LLM would
@@ -365,13 +351,7 @@ def test_post_conversation_with_remote_image_url(
                 text="What is in this image?",
                 type="text",
             ),
-        ],
-        experimental_attachments=[
-            Attachment(
-                name="sample.png",
-                contentType="image/png",
-                url=image_url,
-            )
+            FileUIPart(type="file", filename="sample.png", mediaType="image/png", url=image_url),
         ],
     )
 
@@ -414,7 +394,7 @@ def test_post_conversation_with_remote_image_url(
 
     assert response.status_code == status.HTTP_200_OK
     assert response.get("Content-Type") == "text/event-stream"
-    assert response.get("x-vercel-ai-data-stream") == "v1"
+    assert response.get("x-vercel-ai-ui-message-stream") == "v1"
     assert response.streaming
 
     # Wait for the streaming content to be fully received
@@ -424,10 +404,14 @@ def test_post_conversation_with_remote_image_url(
     response_content = replace_uuids_with_placeholder(response_content)
 
     assert response_content == (
-        '0:"This is an image of a single pixel."\n'
-        'f:{"messageId":"<mocked_uuid>"}\n'
-        'd:{"finishReason":"stop","usage":{"promptTokens":50,"completionTokens":9,'
-        '"co2Impact":0.0}}\n'
+        'data: {"type":"start","messageId":"<mocked_uuid>"}\n\n'
+        'data: {"type":"text-start","id":"0"}\n\n'
+        'data: {"type":"text-delta","id":"0","delta":"This is an image of a single pixel."}\n'
+        "\n"
+        'data: {"type":"text-end","id":"0"}\n\n'
+        'data: {"type":"finish","messageMetadata":{"usage":{"promptTokens":50,"completionToke'
+        'ns":9,"co2Impact":0.0}}}\n\n'
+        "data: [DONE]\n\n"
     )
 
     # Check that the conversation was updated
@@ -439,15 +423,10 @@ def test_post_conversation_with_remote_image_url(
         id=chat_conversation.messages[0].id,  # don't test the value directly
         createdAt=timezone.now(),
         content="What is in this image?",
-        reasoning=None,
-        experimental_attachments=[
-            Attachment(name="sample.png", contentType="image/png", url=image_url)
-        ],
         role="user",
-        annotations=None,
-        toolInvocations=None,
         parts=[
             TextUIPart(type="text", text="What is in this image?"),
+            FileUIPart(type="file", filename="sample.png", mediaType="image/png", url=image_url),
         ],
     )
 
@@ -456,11 +435,7 @@ def test_post_conversation_with_remote_image_url(
         id=chat_conversation.messages[1].id,  # don't test the value directly
         createdAt=timezone.now(),
         content="This is an image of a single pixel.",
-        reasoning=None,
-        experimental_attachments=None,
         role="assistant",
-        annotations=None,
-        toolInvocations=None,
         parts=[
             TextUIPart(type="text", text="This is an image of a single pixel."),
         ],
@@ -486,26 +461,19 @@ def test_post_conversation_with_local_image_url_in_history(
                 id=str(uuid.uuid4()),
                 createdAt=timezone.now(),
                 content="What is in this image?",
-                reasoning=None,
-                experimental_attachments=[
-                    Attachment(name="sample.png", contentType="image/png", url=image_url)
-                ],
                 role="user",
-                annotations=None,
-                toolInvocations=None,
                 parts=[
                     TextUIPart(type="text", text="What is in this image?"),
+                    FileUIPart(
+                        type="file", filename="sample.png", mediaType="image/png", url=image_url
+                    ),
                 ],
             ),
             UIMessage(
                 id=str(uuid.uuid4()),
                 createdAt=timezone.now(),
                 content="This is an image of a single pixel.",
-                reasoning=None,
-                experimental_attachments=None,
                 role="assistant",
-                annotations=None,
-                toolInvocations=None,
                 parts=[
                     TextUIPart(type="text", text="This is an image of a single pixel."),
                 ],
@@ -649,7 +617,7 @@ def test_post_conversation_with_local_image_url_in_history(
 
     assert response.status_code == status.HTTP_200_OK
     assert response.get("Content-Type") == "text/event-stream"
-    assert response.get("x-vercel-ai-data-stream") == "v1"
+    assert response.get("x-vercel-ai-ui-message-stream") == "v1"
     assert response.streaming
 
     # Wait for the streaming content to be fully received
@@ -659,10 +627,14 @@ def test_post_conversation_with_local_image_url_in_history(
     response_content = replace_uuids_with_placeholder(response_content)
 
     assert response_content == (
-        '0:"This is an image of square, very small and nice."\n'
-        'f:{"messageId":"<mocked_uuid>"}\n'
-        'd:{"finishReason":"stop","usage":{"promptTokens":50,"completionTokens":11,'
-        '"co2Impact":0.0}}\n'
+        'data: {"type":"start","messageId":"<mocked_uuid>"}\n\n'
+        'data: {"type":"text-start","id":"0"}\n\n'
+        'data: {"type":"text-delta","id":"0","delta":"This is an image of square, very small '
+        'and nice."}\n\n'
+        'data: {"type":"text-end","id":"0"}\n\n'
+        'data: {"type":"finish","messageMetadata":{"usage":{"promptTokens":50,"completionToke'
+        'ns":11,"co2Impact":0.0}}}\n\n'
+        "data: [DONE]\n\n"
     )
 
     # Check that the conversation was updated
@@ -674,15 +646,10 @@ def test_post_conversation_with_local_image_url_in_history(
         id=chat_conversation.messages[0].id,  # don't test the value directly
         createdAt=timezone.now(),
         content="What is in this image?",
-        reasoning=None,
-        experimental_attachments=[
-            Attachment(name="sample.png", contentType="image/png", url=image_url)
-        ],
         role="user",
-        annotations=None,
-        toolInvocations=None,
         parts=[
             TextUIPart(type="text", text="What is in this image?"),
+            FileUIPart(type="file", filename="sample.png", mediaType="image/png", url=image_url),
         ],
     )
 
@@ -691,11 +658,7 @@ def test_post_conversation_with_local_image_url_in_history(
         id=chat_conversation.messages[1].id,  # don't test the value directly
         createdAt=timezone.now(),
         content="This is an image of a single pixel.",
-        reasoning=None,
-        experimental_attachments=None,
         role="assistant",
-        annotations=None,
-        toolInvocations=None,
         parts=[
             TextUIPart(type="text", text="This is an image of a single pixel."),
         ],
@@ -706,11 +669,7 @@ def test_post_conversation_with_local_image_url_in_history(
         id=chat_conversation.messages[2].id,  # don't test the value directly
         createdAt=timezone.now(),
         content="Give more details about this image.",
-        reasoning=None,
-        experimental_attachments=None,
         role="user",
-        annotations=None,
-        toolInvocations=None,
         parts=[
             TextUIPart(type="text", text="Give more details about this image."),
         ],
@@ -721,11 +680,7 @@ def test_post_conversation_with_local_image_url_in_history(
         id=chat_conversation.messages[3].id,  # don't test the value directly
         createdAt=timezone.now(),
         content="This is an image of square, very small and nice.",
-        reasoning=None,
-        experimental_attachments=None,
         role="assistant",
-        annotations=None,
-        toolInvocations=None,
         parts=[
             TextUIPart(type="text", text="This is an image of square, very small and nice."),
         ],

--- a/src/backend/chat/tests/views/chat/conversations/test_conversation_with_project.py
+++ b/src/backend/chat/tests/views/chat/conversations/test_conversation_with_project.py
@@ -15,11 +15,14 @@ from chat.tools.descriptions import SELF_DOCUMENTATION_SYSTEM_PROMPT
 pytestmark = pytest.mark.django_db(transaction=True)
 
 _HELLO_THERE_STREAM = (
-    '0:"Hello"\n'
-    '0:" there"\n'
-    'f:{"messageId":"<mocked_uuid>"}\n'
-    'd:{"finishReason":"stop","usage":{"promptTokens":0,"completionTokens":0,'
-    '"co2Impact":0.0}}\n'
+    'data: {"type":"start","messageId":"<mocked_uuid>"}\n\n'
+    'data: {"type":"text-start","id":"0"}\n\n'
+    'data: {"type":"text-delta","id":"0","delta":"Hello"}\n\n'
+    'data: {"type":"text-delta","id":"0","delta":" there"}\n\n'
+    'data: {"type":"text-end","id":"0"}\n\n'
+    'data: {"type":"finish","messageMetadata":{"usage":{"promptTokens":0,"completionTokens":0'
+    ',"co2Impact":0.0}}}\n\n'
+    "data: [DONE]\n\n"
 )
 
 
@@ -92,7 +95,7 @@ def test_post_conversation_includes_project_llm_instructions(
     else:
         conversation = ChatConversationFactory(owner__language="en-us")
 
-    url = f"/api/v1.0/chats/{conversation.pk}/conversation/?protocol=data"
+    url = f"/api/v1.0/chats/{conversation.pk}/conversation/"
     api_client.force_login(conversation.owner)
     response = api_client.post(url, project_hello_data, format="json")
 

--- a/src/backend/chat/tests/views/chat/conversations/test_conversations_with_co2_impact.py
+++ b/src/backend/chat/tests/views/chat/conversations/test_conversations_with_co2_impact.py
@@ -17,9 +17,13 @@ pytestmark = pytest.mark.django_db(transaction=True)
 EXPECTED_CO2_IMPACT = 1e-05
 
 
-def _extract_annotation_events(response_content: str) -> list:
-    """Parse `8:` (message annotation) events from a data-stream response body."""
-    return [json.loads(line[2:]) for line in response_content.splitlines() if line.startswith("8:")]
+def _extract_message_metadata(response_content: str) -> list:
+    """Parse the metadata carried by the `finish` frames of a UI message stream."""
+    return [
+        json.loads(line.removeprefix("data: "))["messageMetadata"]
+        for line in response_content.splitlines()
+        if line.startswith('data: {"type":"finish"')
+    ]
 
 
 @pytest.fixture(name="albert_settings", autouse=True)
@@ -51,7 +55,7 @@ def albert_conversation_fixture(api_client):
     """Create an Albert-backed conversation and return (conversation, url)
     with the client logged in."""
     chat_conversation = ChatConversationFactory(owner__language="en-us")
-    url = f"/api/v1.0/chats/{chat_conversation.pk}/conversation/?protocol=data"
+    url = f"/api/v1.0/chats/{chat_conversation.pk}/conversation/"
     api_client.force_login(chat_conversation.owner)
     return chat_conversation, url
 
@@ -96,13 +100,13 @@ def _make_stream(with_co2: bool) -> str:
 
 @freeze_time("2025-07-25T10:36:35.297675Z")
 @respx.mock
-def test_albert_co2_impact_appears_in_annotations_and_stream(
+def test_albert_co2_impact_appears_in_metadata_and_stream(
     api_client,
     mock_openai_stream_multi_calls,
     albert_conversation,
 ):
     """
-    CO2 impact from Albert API is stored in messages[1].annotations in the database
+    CO2 impact from Albert API is stored in messages[1].metadata in the database
     and accumulated in agent_usage across turns.
     """
     chat_conversation, url = albert_conversation
@@ -122,16 +126,16 @@ def test_albert_co2_impact_appears_in_annotations_and_stream(
     response_content = b"".join(response.streaming_content).decode("utf-8")
     assert response_content
     assert mock_openai_stream_multi_calls.called
-    # The CO2 annotation is streamed so the live message shows it without a reload
-    assert _extract_annotation_events(response_content) == [
-        [{"co2_impact": pytest.approx(EXPECTED_CO2_IMPACT)}]
+    # The CO2 impact is streamed so the live message shows it without a reload
+    assert [metadata["co2_impact"] for metadata in _extract_message_metadata(response_content)] == [
+        pytest.approx(EXPECTED_CO2_IMPACT)
     ]
     chat_conversation.refresh_from_db()
 
-    # Verify the assistant message carries the CO2 annotation in the DB
-    assert chat_conversation.messages[1].annotations == [
-        {"co2_impact": pytest.approx(EXPECTED_CO2_IMPACT)}
-    ]
+    # Verify the assistant message carries the CO2 impact in the DB
+    assert chat_conversation.messages[1].metadata == {
+        "co2_impact": pytest.approx(EXPECTED_CO2_IMPACT)
+    }
     assert chat_conversation.agent_usage["co2_impact"] == pytest.approx(EXPECTED_CO2_IMPACT)
 
     # Add new User message to trigger another assistant response and verify
@@ -162,15 +166,15 @@ def test_albert_co2_impact_appears_in_annotations_and_stream(
 
     second_response_content = b"".join(second_response.streaming_content).decode("utf-8")
     assert second_response_content
-    # The streamed annotation carries this turn's impact, not the cumulative total
-    assert _extract_annotation_events(second_response_content) == [
-        [{"co2_impact": pytest.approx(EXPECTED_CO2_IMPACT)}]
-    ]
-    # Verify CO2 annotation appears on the new assistant message
+    # The streamed metadata carries this turn's impact, not the cumulative total
+    assert [
+        metadata["co2_impact"] for metadata in _extract_message_metadata(second_response_content)
+    ] == [pytest.approx(EXPECTED_CO2_IMPACT)]
+    # Verify the CO2 impact appears on the new assistant message
     chat_conversation.refresh_from_db()
-    assert chat_conversation.messages[3].annotations == [
-        {"co2_impact": pytest.approx(EXPECTED_CO2_IMPACT)}
-    ]
+    assert chat_conversation.messages[3].metadata == {
+        "co2_impact": pytest.approx(EXPECTED_CO2_IMPACT)
+    }
     # agent_usage is the sum of each request usage
     assert chat_conversation.agent_usage["co2_impact"] == pytest.approx(2 * EXPECTED_CO2_IMPACT)
 
@@ -220,9 +224,9 @@ def test_albert_co2_impact_preserved_when_second_request_has_no_co2(
     assert b"".join(response.streaming_content).decode("utf-8")
     chat_conversation.refresh_from_db()
 
-    assert chat_conversation.messages[1].annotations == [
-        {"co2_impact": pytest.approx(EXPECTED_CO2_IMPACT)}
-    ]
+    assert chat_conversation.messages[1].metadata == {
+        "co2_impact": pytest.approx(EXPECTED_CO2_IMPACT)
+    }
     assert chat_conversation.agent_usage["co2_impact"] == pytest.approx(EXPECTED_CO2_IMPACT)
 
     # Second request — Albert returns NO CO2 data
@@ -249,11 +253,14 @@ def test_albert_co2_impact_preserved_when_second_request_has_no_co2(
     second_response = api_client.post(url, second_data, format="json")
     second_response_content = b"".join(second_response.streaming_content).decode("utf-8")
     assert second_response_content
-    # No CO2 from the API means no annotation event in the stream either
-    assert _extract_annotation_events(second_response_content) == []
+    # No CO2 from the API means no co2_impact in the streamed metadata either
+    assert all(
+        "co2_impact" not in metadata
+        for metadata in _extract_message_metadata(second_response_content)
+    )
     chat_conversation.refresh_from_db()
 
-    # New assistant message should have no CO2 annotation (none returned by API)
-    assert chat_conversation.messages[3].annotations in (None, [])
+    # New assistant message should have no CO2 metadata (none returned by API)
+    assert not chat_conversation.messages[3].metadata
     # agent_usage must still carry the CO2 from the first request — not reset to zero
     assert chat_conversation.agent_usage["co2_impact"] == pytest.approx(EXPECTED_CO2_IMPACT)

--- a/src/backend/chat/vercel_ai_sdk/core/events_v5.py
+++ b/src/backend/chat/vercel_ai_sdk/core/events_v5.py
@@ -3,11 +3,15 @@ This module contains the event types for the Vercel AI SDK Python SDK.
 """
 
 from enum import Enum
-from typing import Annotated, Any, Dict, Literal, Union
+from typing import Annotated, Any, Dict, Literal, Optional, Union
 
-from pydantic import Field
+from pydantic import Field, field_validator
 
 from .types import ConfiguredBaseModel
+
+# Named data parts are typed ``data-<name>`` on the wire; a bare ``data`` type is
+# not routed to the client's ``onData`` callback.
+DATA_TYPE_PREFIX = "data-"
 
 
 class EventType(str, Enum):
@@ -25,7 +29,6 @@ class EventType(str, Enum):
     SOURCE_URL = "source-url"
     SOURCE_DOCUMENT = "source-document"
     FILE = "file"
-    DATA = "data"
     ERROR = "error"
     TOOL_INPUT_START = "tool-input-start"
     TOOL_INPUT_DELTA = "tool-input-delta"
@@ -50,7 +53,7 @@ class MessageStartEvent(BaseEvent):
     """
 
     type: Literal[EventType.MESSAGE_START] = EventType.MESSAGE_START
-    messageId: str
+    messageId: Optional[str] = None
 
 
 class TextStartEvent(BaseEvent):
@@ -117,6 +120,7 @@ class SourceUrlPart(BaseEvent):
     type: Literal[EventType.SOURCE_URL] = EventType.SOURCE_URL
     sourceId: str
     url: str
+    title: Optional[str] = None
 
 
 class SourceDocumentPart(BaseEvent):
@@ -143,10 +147,24 @@ class FilePart(BaseEvent):
 class DataPart(BaseEvent):
     """
     Event for custom data parts to allow streaming of arbitrary structured data.
+
+    The wire type carries the part name (``data-cooldown``, ``data-keepalive``...);
+    only such named parts reach the client's ``onData`` callback. ``transient``
+    parts are delivered to ``onData`` only and never appended to the message,
+    which is what every part we emit wants: they are all consumed at stream time.
     """
 
-    type: Literal[EventType.DATA] = EventType.DATA
+    type: str
     data: Dict[str, Any]
+    transient: bool = True
+
+    @field_validator("type")
+    @classmethod
+    def _check_named(cls, value: str) -> str:
+        """Reject a bare ``data`` type, which the client would silently drop."""
+        if not value.startswith(DATA_TYPE_PREFIX) or value == DATA_TYPE_PREFIX:
+            raise ValueError(f"Data part type must be '{DATA_TYPE_PREFIX}<name>', got {value!r}")
+        return value
 
 
 class ErrorPart(BaseEvent):
@@ -196,7 +214,9 @@ class ToolOutputAvailablePart(BaseEvent):
 
     type: Literal[EventType.TOOL_OUTPUT_AVAILABLE] = EventType.TOOL_OUTPUT_AVAILABLE
     toolCallId: str
-    output: Dict[str, Any]
+    # Tool results are not always objects: the agent yields plain strings and
+    # lists too, so the payload stays untyped.
+    output: Any
 
 
 class StartStepPart(BaseEvent):
@@ -218,32 +238,40 @@ class FinishStepPart(BaseEvent):
 class FinishMessagePart(BaseEvent):
     """
     Event indicating the completion of a message.
+
+    ``messageMetadata`` is surfaced by the client as ``message.metadata``; it is
+    how per-message usage and CO2 impact reach the UI.
     """
 
     type: Literal[EventType.FINISH_MESSAGE] = EventType.FINISH_MESSAGE
+    messageMetadata: Optional[Dict[str, Any]] = None
 
 
-Event = Annotated[
-    Union[
-        MessageStartEvent,
-        TextStartEvent,
-        TextDeltaEvent,
-        TextEndEvent,
-        ReasoningStartEvent,
-        ReasoningDeltaEvent,
-        ReasoningEndEvent,
-        SourceUrlPart,
-        SourceDocumentPart,
-        FilePart,
-        DataPart,
-        ErrorPart,
-        ToolInputStartPart,
-        ToolInputDeltaPart,
-        ToolInputAvailablePart,
-        ToolOutputAvailablePart,
-        StartStepPart,
-        FinishStepPart,
-        FinishMessagePart,
+# ``DataPart`` stays out of the discriminated union: its type is dynamic
+# (``data-<name>``), so it cannot act as a discriminator literal.
+Event = Union[
+    Annotated[
+        Union[
+            MessageStartEvent,
+            TextStartEvent,
+            TextDeltaEvent,
+            TextEndEvent,
+            ReasoningStartEvent,
+            ReasoningDeltaEvent,
+            ReasoningEndEvent,
+            SourceUrlPart,
+            SourceDocumentPart,
+            FilePart,
+            ErrorPart,
+            ToolInputStartPart,
+            ToolInputDeltaPart,
+            ToolInputAvailablePart,
+            ToolOutputAvailablePart,
+            StartStepPart,
+            FinishStepPart,
+            FinishMessagePart,
+        ],
+        Field(discriminator="type"),
     ],
-    Field(discriminator="type"),
+    DataPart,
 ]

--- a/src/backend/chat/vercel_ai_sdk/encoder/encoder.py
+++ b/src/backend/chat/vercel_ai_sdk/encoder/encoder.py
@@ -6,9 +6,7 @@ from typing import Union
 from chat.constants import SSE_MIME_TYPE
 
 from ..core.events_v4 import BaseEvent as V4BaseEvent
-from ..core.events_v4 import TextPart
 from ..core.events_v5 import BaseEvent as V5BaseEvent
-from ..core.events_v5 import TextDeltaEvent
 
 
 class EventEncoderVersion(str, Enum):
@@ -18,7 +16,10 @@ class EventEncoderVersion(str, Enum):
     V5 = "v5"
 
 
-CURRENT_EVENT_ENCODER_VERSION = EventEncoderVersion.V4  # used encoder version
+CURRENT_EVENT_ENCODER_VERSION = EventEncoderVersion.V5  # used encoder version
+
+# Terminator the v5 UI message stream must end with.
+DONE_FRAME = "data: [DONE]\n\n"
 
 
 class EventEncoder:
@@ -56,28 +57,6 @@ class EventEncoder:
 
         if self.version == EventEncoderVersion.V5 and isinstance(event, V5BaseEvent):
             return self._encode_sse(event)
-
-        return None
-
-    def encode_text(self, event: Union[V4BaseEvent, V5BaseEvent]) -> str | None:
-        """
-        Encodes an event based on the version.
-
-        Args:
-            event (Union[V5BaseEvent, V4BaseEvent]): The event to encode.
-        Returns:
-            str | None: The encoded event as a string,
-            or None if the event type is not adapted to the SDK version.
-
-        Note: Only TextPart/TextDeltaEvent are handled. ErrorPart events are silently
-        dropped on the text protocol path — the `data` protocol (encode()) is the only
-        supported path for surfacing provider errors to the frontend.
-        """
-        if self.version == EventEncoderVersion.V4 and isinstance(event, TextPart):
-            return event.text
-
-        if self.version == EventEncoderVersion.V5 and isinstance(event, TextDeltaEvent):
-            return event.delta
 
         return None
 

--- a/src/backend/chat/vercel_ai_sdk/encoder/v4_to_v5.py
+++ b/src/backend/chat/vercel_ai_sdk/encoder/v4_to_v5.py
@@ -1,0 +1,184 @@
+"""Translate the agent's v4 stream events into v5 UI-message-stream chunks.
+
+The agent (``chat/clients/pydantic_ai.py``) emits v4 events exclusively. Rather
+than rewriting every emit site, the wire upgrade happens here, at the encoding
+boundary: feed one v4 event in, get the v5 chunks it becomes out.
+
+The translation is stateful for two reasons:
+
+* v5 text and reasoning are *blocks* (``text-start`` / ``text-delta`` /
+  ``text-end``) while v4 streams bare deltas, so the translator opens a block on
+  the first delta and closes it when anything else arrives;
+* v4 message annotations are a separate frame while v5 carries them as
+  ``messageMetadata`` on ``finish``, so annotations are buffered until then.
+
+One instance per stream.
+"""
+
+import logging
+from typing import Any, Dict, List, Optional, Tuple
+
+from ..core import events_v4, events_v5
+
+logger = logging.getLogger(__name__)
+
+TEXT_BLOCK = "text"
+REASONING_BLOCK = "reasoning"
+
+# start/delta/end event classes per block kind.
+_BLOCK_EVENTS = {
+    TEXT_BLOCK: (
+        events_v5.TextStartEvent,
+        events_v5.TextDeltaEvent,
+        events_v5.TextEndEvent,
+    ),
+    REASONING_BLOCK: (
+        events_v5.ReasoningStartEvent,
+        events_v5.ReasoningDeltaEvent,
+        events_v5.ReasoningEndEvent,
+    ),
+}
+
+
+def data_part_type(name: str) -> str:
+    """Build the wire type of a named data part, e.g. ``keep_alive`` -> ``data-keep-alive``."""
+    return f"{events_v5.DATA_TYPE_PREFIX}{name.replace('_', '-')}"
+
+
+class V4ToV5Translator:
+    """Turn a stream of v4 events into the equivalent v5 chunks."""
+
+    def __init__(self) -> None:
+        self._open_block: Optional[Tuple[str, str]] = None
+        self._block_count = 0
+        self._annotations: Dict[str, Any] = {}
+
+    def translate(self, event: events_v4.Event) -> List[events_v5.Event]:
+        """Translate a single v4 event into the v5 chunks it becomes."""
+        if isinstance(event, events_v4.TextPart):
+            return self._delta(TEXT_BLOCK, event.text)
+
+        if isinstance(event, events_v4.ReasoningPart):
+            return self._delta(REASONING_BLOCK, event.reasoning)
+
+        if isinstance(event, events_v4.MessageAnnotationPart):
+            # Buffered, not emitted: v5 delivers annotations as `finish` metadata.
+            for annotation in event.annotations:
+                if isinstance(annotation, dict):
+                    self._annotations.update(annotation)
+                else:
+                    logger.warning("Dropping non-object message annotation: %r", annotation)
+            return []
+
+        return self._close_block() + self._translate_standalone(event)
+
+    def flush(self) -> List[events_v5.Event]:
+        """Close whatever is still open at the end of the stream."""
+        return self._close_block()
+
+    def _translate_standalone(  # noqa: PLR0911  # pylint: disable=too-many-return-statements
+        self, event: events_v4.Event
+    ) -> List[events_v5.Event]:
+        """Translate an event that is not part of a text or reasoning block."""
+        if isinstance(event, events_v4.ToolCallStreamingStartPart):
+            return [
+                events_v5.ToolInputStartPart(
+                    toolCallId=event.tool_call_id, toolName=event.tool_name
+                )
+            ]
+
+        if isinstance(event, events_v4.ToolCallDeltaPart):
+            return [
+                events_v5.ToolInputDeltaPart(
+                    toolCallId=event.tool_call_id, inputTextDelta=event.args_text_delta
+                )
+            ]
+
+        if isinstance(event, events_v4.ToolCallPart):
+            return [
+                events_v5.ToolInputAvailablePart(
+                    toolCallId=event.tool_call_id,
+                    toolName=event.tool_name,
+                    input=event.args,
+                )
+            ]
+
+        if isinstance(event, events_v4.ToolResultPart):
+            return [
+                events_v5.ToolOutputAvailablePart(
+                    toolCallId=event.tool_call_id, output=event.result
+                )
+            ]
+
+        if isinstance(event, events_v4.SourcePart):
+            return [events_v5.SourceUrlPart(sourceId=event.id, url=event.url, title=event.title)]
+
+        if isinstance(event, events_v4.StartStepPart):
+            return [events_v5.StartStepPart()]
+
+        if isinstance(event, events_v4.FinishStepPart):
+            return [events_v5.FinishStepPart()]
+
+        if isinstance(event, events_v4.DataPart):
+            return self._data_parts(event)
+
+        if isinstance(event, events_v4.ErrorPart):
+            # The frontend keys its error handling on these codes.
+            return [events_v5.ErrorPart(errorText=event.error)]
+
+        if isinstance(event, events_v4.FinishMessagePart):
+            return [events_v5.FinishMessagePart(messageMetadata=self._message_metadata(event))]
+
+        logger.warning("No v5 translation for v4 event type %s", type(event).__name__)
+        return []
+
+    @staticmethod
+    def _data_parts(event: events_v4.DataPart) -> List[events_v5.Event]:
+        """Split a v4 data frame into one named, transient v5 data part per item.
+
+        Every data part we emit is consumed while the stream runs (title,
+        cooldown, skipped images, keep-alive), so none of them belong in the
+        persisted message: `transient` delivers them to `onData` only.
+        """
+        parts = []
+        for item in event.data:
+            # An empty type must be dropped here too: `data_part_type("")` yields
+            # a bare `data-`, which the v5 DataPart validator rejects outright.
+            if (
+                not isinstance(item, dict)
+                or not isinstance(item.get("type"), str)
+                or not item["type"]
+            ):
+                logger.warning("Dropping data item without a string type: %r", item)
+                continue
+            parts.append(
+                events_v5.DataPart(type=data_part_type(item["type"]), data=item, transient=True)
+            )
+        return parts
+
+    def _message_metadata(self, event: events_v4.FinishMessagePart) -> Dict[str, Any]:
+        """Build the `finish` metadata from the buffered annotations and the usage."""
+        return {
+            "usage": event.usage.model_dump(by_alias=True, exclude_none=True),
+            **self._annotations,
+        }
+
+    def _delta(self, kind: str, delta: str) -> List[events_v5.Event]:
+        """Emit a delta, opening the matching block first when needed."""
+        events: List[events_v5.Event] = []
+        if self._open_block is None or self._open_block[0] != kind:
+            events += self._close_block()
+            block_id = str(self._block_count)
+            self._block_count += 1
+            self._open_block = (kind, block_id)
+            events.append(_BLOCK_EVENTS[kind][0](id=block_id))
+        events.append(_BLOCK_EVENTS[kind][1](id=self._open_block[1], delta=delta))
+        return events
+
+    def _close_block(self) -> List[events_v5.Event]:
+        """Close the open text or reasoning block, if any."""
+        if self._open_block is None:
+            return []
+        kind, block_id = self._open_block
+        self._open_block = None
+        return [_BLOCK_EVENTS[kind][2](id=block_id)]

--- a/src/backend/chat/views/conversations.py
+++ b/src/backend/chat/views/conversations.py
@@ -94,8 +94,8 @@ class ChatViewSet(  # pylint: disable=too-many-ancestors, abstract-method
 
     The chat conversations are filtered by the authenticated user.
     The `post_conversation` action allows sending messages to the chat and receiving a
-    streaming response with "data" formatted for Vercel AI SDK
-    see https://ai-sdk.dev/docs/ai-sdk-ui/stream-protocol#data-stream-protocol.
+    streaming response formatted as a Vercel AI SDK UI message stream,
+    see https://ai-sdk.dev/docs/ai-sdk-ui/stream-protocol.
     """
 
     pagination_class = Pagination
@@ -217,7 +217,6 @@ class ChatViewSet(  # pylint: disable=too-many-ancestors, abstract-method
         Args:
             request: The HTTP request object containing:
                 - messages: List of message objects with role and content
-                - protocol: Optional protocol parameter ('text' or 'data', defaults to 'data')
             pk: The primary key of the chat conversation.
 
         Returns:
@@ -225,7 +224,6 @@ class ChatViewSet(  # pylint: disable=too-many-ancestors, abstract-method
         """
         query_params_serializer = ChatConversationRequestSerializer(data=request.query_params)
         query_params_serializer.is_valid(raise_exception=True)
-        protocol = query_params_serializer.validated_data["protocol"]
         force_web_search = query_params_serializer.validated_data["force_web_search"]
         requested_model_hrid = query_params_serializer.validated_data["model_hrid"]
 
@@ -281,7 +279,7 @@ class ChatViewSet(  # pylint: disable=too-many-ancestors, abstract-method
 
         messages = serializer.validated_data["messages"]
 
-        logger.info("Validated %d messages, protocol=%s", len(messages), protocol)
+        logger.info("Validated %d messages", len(messages))
 
         if not messages:
             return Response({"error": "No messages provided"}, status=status.HTTP_400_BAD_REQUEST)
@@ -327,28 +325,18 @@ class ChatViewSet(  # pylint: disable=too-many-ancestors, abstract-method
 
         if is_async_mode:
             logger.debug("Using ASYNC streaming for chat conversation.")
-            if protocol == "data":
-                base_stream = ai_service.stream_data_async(
-                    messages, force_web_search=force_web_search
-                )
-            else:  # Default to 'text' protocol
-                base_stream = ai_service.stream_text_async(
-                    messages, force_web_search=force_web_search
-                )
+            base_stream = ai_service.stream_data_async(messages, force_web_search=force_web_search)
             streaming_content = stream_with_keepalive_async(base_stream)
         else:
             logger.debug("Using SYNC streaming for chat conversation.")
-            if protocol == "data":
-                base_stream = ai_service.stream_data(messages, force_web_search=force_web_search)
-            else:  # Default to 'text' protocol
-                base_stream = ai_service.stream_text(messages, force_web_search=force_web_search)
-
+            base_stream = ai_service.stream_data(messages, force_web_search=force_web_search)
             streaming_content = stream_with_keepalive_sync(base_stream)
         response = StreamingHttpResponse(
             streaming_content,
             content_type=SSE_MIME_TYPE,
             headers={
-                "x-vercel-ai-data-stream": "v1",  # This header is used for Vercel AI streaming,
+                # Tells the Vercel AI SDK this is a v5 UI message stream.
+                "x-vercel-ai-ui-message-stream": "v1",
                 "X-Accel-Buffering": "no",  # Prevent nginx buffering
             },
         )

--- a/src/backend/chat/views/conversations.py
+++ b/src/backend/chat/views/conversations.py
@@ -93,8 +93,8 @@ class ChatViewSet(  # pylint: disable=too-many-ancestors, abstract-method
 
     The chat conversations are filtered by the authenticated user.
     The `post_conversation` action allows sending messages to the chat and receiving a
-    streaming response with "data" formatted for Vercel AI SDK
-    see https://ai-sdk.dev/docs/ai-sdk-ui/stream-protocol#data-stream-protocol.
+    streaming response formatted as a Vercel AI SDK UI message stream,
+    see https://ai-sdk.dev/docs/ai-sdk-ui/stream-protocol.
     """
 
     pagination_class = Pagination
@@ -213,7 +213,6 @@ class ChatViewSet(  # pylint: disable=too-many-ancestors, abstract-method
         Args:
             request: The HTTP request object containing:
                 - messages: List of message objects with role and content
-                - protocol: Optional protocol parameter ('text' or 'data', defaults to 'data')
             pk: The primary key of the chat conversation.
 
         Returns:
@@ -221,7 +220,6 @@ class ChatViewSet(  # pylint: disable=too-many-ancestors, abstract-method
         """
         query_params_serializer = ChatConversationRequestSerializer(data=request.query_params)
         query_params_serializer.is_valid(raise_exception=True)
-        protocol = query_params_serializer.validated_data["protocol"]
         force_web_search = query_params_serializer.validated_data["force_web_search"]
         requested_model_hrid = query_params_serializer.validated_data["model_hrid"]
 
@@ -277,7 +275,7 @@ class ChatViewSet(  # pylint: disable=too-many-ancestors, abstract-method
 
         messages = serializer.validated_data["messages"]
 
-        logger.info("Validated %d messages, protocol=%s", len(messages), protocol)
+        logger.info("Validated %d messages", len(messages))
 
         if not messages:
             return Response({"error": "No messages provided"}, status=status.HTTP_400_BAD_REQUEST)
@@ -323,28 +321,18 @@ class ChatViewSet(  # pylint: disable=too-many-ancestors, abstract-method
 
         if is_async_mode:
             logger.debug("Using ASYNC streaming for chat conversation.")
-            if protocol == "data":
-                base_stream = ai_service.stream_data_async(
-                    messages, force_web_search=force_web_search
-                )
-            else:  # Default to 'text' protocol
-                base_stream = ai_service.stream_text_async(
-                    messages, force_web_search=force_web_search
-                )
+            base_stream = ai_service.stream_data_async(messages, force_web_search=force_web_search)
             streaming_content = stream_with_keepalive_async(base_stream)
         else:
             logger.debug("Using SYNC streaming for chat conversation.")
-            if protocol == "data":
-                base_stream = ai_service.stream_data(messages, force_web_search=force_web_search)
-            else:  # Default to 'text' protocol
-                base_stream = ai_service.stream_text(messages, force_web_search=force_web_search)
-
+            base_stream = ai_service.stream_data(messages, force_web_search=force_web_search)
             streaming_content = stream_with_keepalive_sync(base_stream)
         response = StreamingHttpResponse(
             streaming_content,
             content_type=SSE_MIME_TYPE,
             headers={
-                "x-vercel-ai-data-stream": "v1",  # This header is used for Vercel AI streaming,
+                # Tells the Vercel AI SDK this is a v5 UI message stream.
+                "x-vercel-ai-ui-message-stream": "v1",
                 "X-Accel-Buffering": "no",  # Prevent nginx buffering
             },
         )

--- a/src/frontend/apps/conversations/package.json
+++ b/src/frontend/apps/conversations/package.json
@@ -16,8 +16,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@ai-sdk/react": "1.2.12",
-    "@ai-sdk/ui-utils": "1.2.11",
+    "@ai-sdk/react": "2.0.241",
     "@fontsource-variable/material-symbols-outlined": "5.2.45",
     "@fontsource/material-icons": "5.2.7",
     "@fontsource/material-icons-outlined": "5.2.6",
@@ -28,6 +27,7 @@
     "@sentry/react": "10.58.0",
     "@shikijs/rehype": "^4.2.0",
     "@tanstack/react-query": "5.101.0",
+    "ai": "5.0.238",
     "clsx": "2.1.1",
     "cmdk": "1.1.1",
     "i18next": "26.3.1",

--- a/src/frontend/apps/conversations/src/features/chat/api/__tests__/useChat.test.tsx
+++ b/src/frontend/apps/conversations/src/features/chat/api/__tests__/useChat.test.tsx
@@ -2,9 +2,9 @@ import { ReadableStream } from 'node:stream/web';
 import { TextDecoder, TextEncoder } from 'node:util';
 import { deserialize, serialize } from 'node:v8';
 
-import { Message } from '@ai-sdk/ui-utils';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { act, renderHook, waitFor } from '@testing-library/react';
+import { FileUIPart, UIMessage } from 'ai';
 import type { Mock } from 'vitest';
 
 import { fetchAPI } from '@/api';
@@ -70,28 +70,34 @@ describe('isImagesSkippedEvent', () => {
   });
 });
 
-const makeUserMessage = (
-  id: string,
-  attachments: Message['experimental_attachments'],
-): Message => ({
+const filePart = (
+  filename: string,
+  mediaType: string,
+  url: string,
+  extra: Record<string, unknown> = {},
+): FileUIPart => ({ type: 'file', filename, mediaType, url, ...extra });
+
+const makeUserMessage = (id: string, files: FileUIPart[]): UIMessage => ({
   id,
   role: 'user',
-  content: 'hi',
-  experimental_attachments: attachments,
+  parts: [{ type: 'text', text: 'hi' }, ...files],
 });
 
-const makeAssistantMessage = (id: string): Message => ({
+const makeAssistantMessage = (id: string): UIMessage => ({
   id,
   role: 'assistant',
-  content: 'hello',
+  parts: [{ type: 'text', text: 'hello' }],
 });
 
+const filePartsOf = (message: UIMessage): FileUIPart[] =>
+  message.parts.filter((part): part is FileUIPart => part.type === 'file');
+
 describe('stampImagesSkippedOnLatestUserMessage', () => {
-  it('stamps skipped on every image attachment of the latest user message', () => {
-    const messages: Message[] = [
+  it('stamps skipped on every image file part of the latest user message', () => {
+    const messages: UIMessage[] = [
       makeUserMessage('1', [
-        { name: 'a.png', contentType: 'image/png', url: 'http://a' },
-        { name: 'b.pdf', contentType: 'application/pdf', url: 'http://b' },
+        filePart('a.png', 'image/png', 'http://a'),
+        filePart('b.pdf', 'application/pdf', 'http://b'),
       ]),
       makeAssistantMessage('2'),
     ];
@@ -99,21 +105,19 @@ describe('stampImagesSkippedOnLatestUserMessage', () => {
     const result = stampImagesSkippedOnLatestUserMessage(messages);
 
     expect(result).not.toBe(messages);
-    const updatedAttachments = result[0].experimental_attachments!;
-    expect(updatedAttachments[0]).toMatchObject({
-      name: 'a.png',
+    const updatedFiles = filePartsOf(result[0]);
+    expect(updatedFiles[0]).toMatchObject({
+      filename: 'a.png',
       skipped: { reason: 'model_text_only' },
     });
-    expect(updatedAttachments[1]).toMatchObject({ name: 'b.pdf' });
-    expect((updatedAttachments[1] as { skipped?: unknown }).skipped).toBe(
-      undefined,
-    );
+    expect(updatedFiles[1]).toMatchObject({ filename: 'b.pdf' });
+    expect((updatedFiles[1] as { skipped?: unknown }).skipped).toBe(undefined);
   });
 
   it('returns the same reference when no images are present', () => {
-    const messages: Message[] = [
+    const messages: UIMessage[] = [
       makeUserMessage('1', [
-        { name: 'doc.pdf', contentType: 'application/pdf', url: 'http://x' },
+        filePart('doc.pdf', 'application/pdf', 'http://x'),
       ]),
     ];
 
@@ -121,18 +125,12 @@ describe('stampImagesSkippedOnLatestUserMessage', () => {
   });
 
   it('returns the same reference when images are already stamped', () => {
-    const messages: Message[] = [
+    const messages: UIMessage[] = [
       makeUserMessage('1', [
-        {
-          name: 'a.png',
-          contentType: 'image/png',
-          url: 'http://a',
-          // already stamped by an earlier event
-          ...({ skipped: { reason: 'model_text_only' } } as Record<
-            string,
-            unknown
-          >),
-        },
+        // already stamped by an earlier event
+        filePart('a.png', 'image/png', 'http://a', {
+          skipped: { reason: 'model_text_only' },
+        }),
       ]),
     ];
 
@@ -140,20 +138,16 @@ describe('stampImagesSkippedOnLatestUserMessage', () => {
   });
 
   it('returns the same reference when there is no user message', () => {
-    const messages: Message[] = [makeAssistantMessage('1')];
+    const messages: UIMessage[] = [makeAssistantMessage('1')];
 
     expect(stampImagesSkippedOnLatestUserMessage(messages)).toBe(messages);
   });
 
   it('only touches the latest user message', () => {
-    const messages: Message[] = [
-      makeUserMessage('1', [
-        { name: 'old.png', contentType: 'image/png', url: 'http://old' },
-      ]),
+    const messages: UIMessage[] = [
+      makeUserMessage('1', [filePart('old.png', 'image/png', 'http://old')]),
       makeAssistantMessage('2'),
-      makeUserMessage('3', [
-        { name: 'new.png', contentType: 'image/png', url: 'http://new' },
-      ]),
+      makeUserMessage('3', [filePart('new.png', 'image/png', 'http://new')]),
     ];
 
     const result = stampImagesSkippedOnLatestUserMessage(messages);
@@ -161,7 +155,7 @@ describe('stampImagesSkippedOnLatestUserMessage', () => {
     expect(result[0]).toBe(messages[0]); // untouched
     expect(result[2]).not.toBe(messages[2]);
     expect(
-      (result[2].experimental_attachments![0] as { skipped?: unknown }).skipped,
+      (filePartsOf(result[2])[0] as { skipped?: unknown }).skipped,
     ).toEqual({ reason: 'model_text_only' });
   });
 });
@@ -179,11 +173,14 @@ Object.assign(globalThis, {
 const CHAT_API = 'chats/conv-1/conversation/';
 
 // A turn cut short right after the `summarize` tool returned: the summary
-// landed, the answer never started, and no `f:` (start_step) closes the
-// message. That shape is what makes the SDK's multi-step continuation kick in.
+// landed, the answer never started, and no `finish` closes the message. That
+// shape is what an SDK configured to continue multi-step turns would re-POST.
 const INTERRUPTED_AFTER_SUMMARY = [
-  '9:{"toolCallId":"c1","toolName":"summarize","args":{"state":"running","summary_scope":"conversation"}}\n',
-  'a:{"toolCallId":"c1","result":{"state":"done"}}\n',
+  'data: {"type":"start"}\n\n',
+  'data: {"type":"tool-input-available","toolCallId":"c1","toolName":"summarize"',
+  ',"input":{"state":"running","summary_scope":"conversation"}}\n\n',
+  'data: {"type":"tool-output-available","toolCallId":"c1","output":{"state":"done"}}\n\n',
+  'data: [DONE]\n\n',
 ].join('');
 
 const streamOf = (payload: string) =>
@@ -232,7 +229,7 @@ describe('useChat multi-step continuation', () => {
     );
 
     await act(async () => {
-      await result.current.append({ role: 'user', content: 'hello' });
+      await result.current.sendMessage({ text: 'hello' });
     });
     await waitFor(() => expect(result.current.status).toBe('ready'));
     expect(onError).not.toHaveBeenCalled();
@@ -240,5 +237,96 @@ describe('useChat multi-step continuation', () => {
     // A second POST would carry an assistant-terminated message list, which the
     // backend answers with an empty stream — leaving the bubble blank.
     expect(chatCalls).toEqual([CHAT_API]);
+  });
+});
+
+// The exact frames the backend emits for a turn with a tool call, a source, a
+// cooldown notice and a CO2 impact — copied from the encoder's golden test.
+const FULL_TURN = [
+  'data: {"type":"start","messageId":"trace-abc"}\n\n',
+  'data: {"type":"tool-input-available","toolCallId":"c1","toolName":"document_search_rag"',
+  ',"input":{"query":"what?"}}\n\n',
+  'data: {"type":"source-url","sourceId":"s1","url":"https://example.test"}\n\n',
+  'data: {"type":"tool-output-available","toolCallId":"c1","output":{"state":"done"}}\n\n',
+  'data: {"type":"text-start","id":"0"}\n\n',
+  'data: {"type":"text-delta","id":"0","delta":"Hello"}\n\n',
+  'data: {"type":"text-delta","id":"0","delta":" there"}\n\n',
+  'data: {"type":"text-end","id":"0"}\n\n',
+  'data: {"type":"data-cooldown","data":{"type":"cooldown","seconds":30}',
+  ',"transient":true}\n\n',
+  'data: {"type":"data-images-skipped","data":{"type":"images_skipped"',
+  ',"kind":"chat_notice","reason":"model_text_only"},"transient":true}\n\n',
+  'data: {"type":"finish","messageMetadata":{"usage":{"promptTokens":10',
+  ',"completionTokens":3,"co2Impact":0.5},"co2_impact":0.5}}\n\n',
+  'data: [DONE]\n\n',
+].join('');
+
+describe('useChat against a backend stream', () => {
+  const fetchAPIMock = vi.mocked(fetchAPI) as unknown as Mock;
+
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider
+      client={
+        new QueryClient({ defaultOptions: { queries: { retry: false } } })
+      }
+    >
+      {children}
+    </QueryClientProvider>
+  );
+
+  it('builds the message, its metadata and the transient notices', async () => {
+    fetchAPIMock.mockImplementation((url: string) => {
+      if (url.startsWith('chat-cooldown')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ cooldown_seconds: 0 }),
+        });
+      }
+      return Promise.resolve({ ok: true, body: streamOf(FULL_TURN) });
+    });
+
+    const onImagesSkipped = vi.fn();
+    const { result } = renderHook(
+      () => useChat({ id: 'conv-1', api: CHAT_API, onImagesSkipped }),
+      { wrapper },
+    );
+
+    // Let the chat-cooldown query settle first: it resets cooldownUntil, and
+    // landing after the stream would clobber the value the frame carries.
+    await waitFor(() =>
+      expect(fetchAPIMock).toHaveBeenCalledWith('chat-cooldown/'),
+    );
+
+    await act(async () => {
+      await result.current.sendMessage({ text: 'hello' });
+    });
+    await waitFor(() => expect(result.current.status).toBe('ready'));
+
+    const assistant = result.current.messages.at(-1)!;
+    // The message id the backend announced, which the feedback buttons key on.
+    expect(assistant.id).toBe('trace-abc');
+    expect(assistant.parts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'text', text: 'Hello there' }),
+        expect.objectContaining({
+          type: 'source-url',
+          sourceId: 's1',
+          url: 'https://example.test',
+        }),
+        expect.objectContaining({
+          type: 'tool-document_search_rag',
+          state: 'output-available',
+          output: { state: 'done' },
+        }),
+      ]),
+    );
+    expect(assistant.metadata).toMatchObject({ co2_impact: 0.5 });
+
+    // Transient data parts reach the callbacks without polluting the message.
+    expect(onImagesSkipped).toHaveBeenCalledWith('chat_notice');
+    expect(result.current.cooldownUntil).toBeGreaterThan(Date.now());
+    expect(assistant.parts.some((part) => part.type.startsWith('data-'))).toBe(
+      false,
+    );
   });
 });

--- a/src/frontend/apps/conversations/src/features/chat/api/useChat.tsx
+++ b/src/frontend/apps/conversations/src/features/chat/api/useChat.tsx
@@ -1,7 +1,12 @@
-import { UseChatOptions, useChat as useAiSdkChat } from '@ai-sdk/react';
-import { Message } from '@ai-sdk/ui-utils';
+import { useChat as useAiSdkChat } from '@ai-sdk/react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { useEffect, useRef, useState } from 'react';
+import {
+  ChatOnDataCallback,
+  DefaultChatTransport,
+  FileUIPart,
+  UIMessage,
+} from 'ai';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { fetchAPI } from '@/api';
 import { KEY_CONVERSATION } from '@/features/chat/api/useConversation';
@@ -23,6 +28,8 @@ const fetchAPIAdapter = (input: RequestInfo | URL, init?: RequestInit) => {
 
   const searchParams = new URLSearchParams();
 
+  // Read at request time, not at render time: the transport is built once but
+  // these preferences change between messages.
   const { forceWebSearch, selectedModelHrid } =
     useChatPreferencesStore.getState();
 
@@ -117,83 +124,99 @@ export function isImagesSkippedEvent(
   );
 }
 
+/** A file part the backend kept on the message but hid from the model. */
+export type SkippableFileUIPart = FileUIPart & {
+  skipped?: { reason: string };
+};
+
+const isImageFilePart = (
+  part: UIMessage['parts'][number],
+): part is SkippableFileUIPart =>
+  part.type === 'file' && part.mediaType.startsWith('image/');
+
 /**
- * Stamp `skipped: { reason: <IMAGE_SKIP_REASON_TEXT_ONLY> }` on every image-like
- * attachment of the latest user message, returning the same array reference
- * when nothing changed. Used to mark optimistic attachments live when the
- * backend signals it skipped them (mirroring the persisted-state behaviour).
+ * Stamp `skipped: { reason: <IMAGE_SKIP_REASON_TEXT_ONLY> }` on every image file
+ * part of the latest user message, returning the same array reference when
+ * nothing changed. Used to mark optimistic attachments live when the backend
+ * signals it skipped them (mirroring the persisted-state behaviour).
  */
 export function stampImagesSkippedOnLatestUserMessage(
-  prevMessages: Message[],
-): Message[] {
+  prevMessages: UIMessage[],
+): UIMessage[] {
   const lastUserIdx = prevMessages.findLastIndex((m) => m.role === 'user');
   if (lastUserIdx === -1) return prevMessages;
   const lastUser = prevMessages[lastUserIdx];
-  const attachments = lastUser.experimental_attachments;
-  if (!attachments || attachments.length === 0) return prevMessages;
   let mutated = false;
-  const updated = attachments.map((att) => {
-    if (
-      att.contentType?.startsWith('image/') &&
-      !(att as { skipped?: unknown }).skipped
-    ) {
+  const parts = lastUser.parts.map((part) => {
+    if (isImageFilePart(part) && !part.skipped) {
       mutated = true;
-      return { ...att, skipped: { reason: IMAGE_SKIP_REASON_TEXT_ONLY } };
+      return { ...part, skipped: { reason: IMAGE_SKIP_REASON_TEXT_ONLY } };
     }
-    return att;
+    return part;
   });
   if (!mutated) return prevMessages;
   const next = [...prevMessages];
-  next[lastUserIdx] = {
-    ...lastUser,
-    experimental_attachments: updated,
-  };
+  next[lastUserIdx] = { ...lastUser, parts };
   return next;
 }
 
-export function useChat(options: Omit<UseChatOptions, 'fetch'>) {
+export interface UseChatOptions {
+  /** Conversation id; changing it starts a fresh chat. */
+  id?: string;
+  /** Messages the chat starts with. */
+  messages?: UIMessage[];
+  /** Endpoint the transport posts to. */
+  api: string;
+  onError?: (error: Error) => void;
+  /** Called for each `images_skipped` notice streamed by the backend. */
+  onImagesSkipped?: (kind: ImagesSkippedEventKind) => void;
+}
+
+export function useChat({ api, onImagesSkipped, ...options }: UseChatOptions) {
   const queryClient = useQueryClient();
-  const { onFinish: onFinishOption, ...restOptions } = options;
-
-  const result = useAiSdkChat({
-    ...restOptions,
-    // Single step: every tool loop runs server-side inside the agent, and we
-    // register no client-side tool (no `onToolCall`/`addToolResult`), so there
-    // is nothing for the client to continue. With maxSteps > 1 the SDK
-    // auto-resubmits whenever a stream ends with a resolved tool invocation and
-    // no trailing `start_step` — which is what an interrupted turn looks like
-    // once the `summarize` tool has returned. That resubmit flips the status
-    // away from `error`, hiding the failure, and the backend answers an
-    // assistant-terminated message list with an empty stream: the bubble stays
-    // blank instead of showing an error and a retry.
-    maxSteps: 1,
-    fetch: fetchAPIAdapter,
-    onFinish: (message, finishOptions) => {
-      if (message.annotations?.length) {
-        result.setMessages((prev) => {
-          const lastAssistantIndex = prev.findLastIndex(
-            (msg) => msg.role === 'assistant',
-          );
-          if (lastAssistantIndex === -1) {
-            return prev;
-          }
-          const updated = [...prev];
-          updated[lastAssistantIndex] = {
-            ...updated[lastAssistantIndex],
-            annotations: message.annotations,
-          };
-          return updated;
-        });
-      }
-      onFinishOption?.(message, finishOptions);
-    },
-  });
-
   // Epoch ms until which the user must wait before sending a new message.
   const [cooldownUntil, setCooldownUntil] = useState<number | null>(null);
-  // Track how many data items we have already handled so each event is
-  // processed exactly once (the data stream grows append-only).
-  const processedCountRef = useRef(0);
+
+  // The transport is captured when the chat is created, so the callbacks it
+  // ends up holding must always reach the latest render's handlers.
+  const onImagesSkippedRef = useRef(onImagesSkipped);
+  onImagesSkippedRef.current = onImagesSkipped;
+
+  const transport = useMemo(
+    () => new DefaultChatTransport({ api, fetch: fetchAPIAdapter }),
+    [api],
+  );
+
+  const onData = useCallback<ChatOnDataCallback<UIMessage>>(
+    (part) => {
+      const item = part.data;
+      if (isConversationMetadataEvent(item)) {
+        void queryClient.invalidateQueries({
+          queryKey: [KEY_LIST_CONVERSATION],
+        });
+        void queryClient.invalidateQueries({
+          queryKey: [KEY_LIST_PROJECT],
+        });
+        void queryClient.invalidateQueries({
+          queryKey: [KEY_CONVERSATION, item.conversationId],
+        });
+      } else if (isCooldownEvent(item)) {
+        setCooldownUntil(Date.now() + item.seconds * 1000);
+      } else if (isImagesSkippedEvent(item)) {
+        onImagesSkippedRef.current?.(item.kind);
+      }
+    },
+    [queryClient],
+  );
+
+  // No `sendAutomaticallyWhen`: every tool loop runs server-side inside the
+  // agent and we register no client-side tool, so there is nothing for the
+  // client to continue. Auto-resubmitting would hide a failure — an interrupted
+  // turn looks like a resolved tool invocation with no trailing step, and the
+  // resubmit flips the status away from `error` while the backend answers an
+  // assistant-terminated message list with an empty stream: the bubble stays
+  // blank instead of showing an error and a retry.
+  const result = useAiSdkChat({ ...options, transport, onData });
 
   // Restore the cooldown from the backend (the authoritative source) so it
   // survives a refresh, a new tab, or switching conversations. react-query
@@ -213,35 +236,6 @@ export function useChat(options: Omit<UseChatOptions, 'fetch'>) {
         : null,
     );
   }, [cooldownData]);
-
-  useEffect(() => {
-    const data = result.data;
-    if (!Array.isArray(data)) {
-      processedCountRef.current = 0;
-      return;
-    }
-    // Stream reset (e.g. switching conversations): reprocess from the start.
-    if (data.length < processedCountRef.current) {
-      processedCountRef.current = 0;
-    }
-    for (let i = processedCountRef.current; i < data.length; i++) {
-      const item = data[i];
-      if (isConversationMetadataEvent(item)) {
-        void queryClient.invalidateQueries({
-          queryKey: [KEY_LIST_CONVERSATION],
-        });
-        void queryClient.invalidateQueries({
-          queryKey: [KEY_LIST_PROJECT],
-        });
-        void queryClient.invalidateQueries({
-          queryKey: [KEY_CONVERSATION, item.conversationId],
-        });
-      } else if (isCooldownEvent(item)) {
-        setCooldownUntil(Date.now() + item.seconds * 1000);
-      }
-    }
-    processedCountRef.current = data.length;
-  }, [result.data, queryClient]);
 
   return { ...result, cooldownUntil };
 }

--- a/src/frontend/apps/conversations/src/features/chat/components/Chat.tsx
+++ b/src/frontend/apps/conversations/src/features/chat/components/Chat.tsx
@@ -1,6 +1,12 @@
-import { Message, SourceUIPart } from '@ai-sdk/ui-utils';
 import { Button, Modal, ModalSize } from '@gouvfr-lasuite/cunningham-react';
 import { InfiniteData, useQueryClient } from '@tanstack/react-query';
+import {
+  FileUIPart,
+  SourceUrlUIPart,
+  UIMessage,
+  getToolName,
+  isToolUIPart,
+} from 'ai';
 import 'katex/dist/katex.min.css'; // `rehype-katex` does not import the CSS for you
 import React, {
   useCallback,
@@ -21,7 +27,7 @@ import { useProjectAttachments } from '@/features/attachments/api/useProjectAtta
 import { useReindexProjectAttachment } from '@/features/attachments/api/useReindexProjectAttachment';
 import { useUploadFile } from '@/features/attachments/hooks/useUploadFile';
 import {
-  isImagesSkippedEvent,
+  ImagesSkippedEventKind,
   stampImagesSkippedOnLatestUserMessage,
   useChat,
 } from '@/features/chat/api/useChat';
@@ -39,13 +45,13 @@ import { ChatError, ChatErrorType } from '@/features/chat/components/ChatError';
 import { ImageProcessingUnavailableBanner } from '@/features/chat/components/ImageProcessingUnavailableBanner';
 import { InputChat } from '@/features/chat/components/InputChat';
 import { MessageItem } from '@/features/chat/components/MessageItem';
+import { SourceItemList } from '@/features/chat/components/SourceItemList';
 import {
   STATUS_LINK_KINDS,
   getReindexErrorMessage,
 } from '@/features/chat/components/reindexErrorMessages';
-import { SourceItemList } from '@/features/chat/components/SourceItemList';
-import { useClipboard } from '@/hook';
 import { useSourcePanelAnchor } from '@/features/sources-panel';
+import { useClipboard } from '@/hook';
 import { useResponsiveStore } from '@/stores';
 
 import { useSourceMetadataCache } from '../hooks';
@@ -88,8 +94,6 @@ export const Chat = ({
   const { isMobile, isDesktop } = useResponsiveStore();
   const sourcesPanelAnchorEl = useSourcePanelAnchor();
 
-  const streamProtocol = 'data'; // or 'text'
-
   const {
     forceWebSearch,
     toggleForceWebSearch,
@@ -103,8 +107,8 @@ export const Chat = ({
 
   const [conversationId, setConversationId] = useState(initialConversationId);
   const apiUrl = conversationId
-    ? `chats/${conversationId}/conversation/?protocol=${streamProtocol}`
-    : `chats/conversation/?protocol=${streamProtocol}`;
+    ? `chats/${conversationId}/conversation/`
+    : 'chats/conversation/';
 
   // Initialize upload hook
   const { uploadFile, isErrorAttachment, errorAttachment } = useUploadFile(
@@ -186,7 +190,7 @@ export const Chat = ({
   const { prefetchMetadata, getMetadata } = useSourceMetadataCache();
 
   const [initialConversationMessages, setInitialConversationMessages] =
-    useState<Message[] | undefined>(undefined);
+    useState<UIMessage[] | undefined>(undefined);
   // True when the pinned model is text-only and any image exists in the
   // conversation (project or history). Drives the "image processing
   // unavailable" banner above the input box.
@@ -194,7 +198,7 @@ export const Chat = ({
   const [imagesBannerDismissed, setImagesBannerDismissed] =
     useState<boolean>(false);
   const [pendingFirstMessage, setPendingFirstMessage] = useState<{
-    event: FormEvent<HTMLFormElement>;
+    input: string;
     attachments?: Attachment[];
     forceWebSearch?: boolean;
   } | null>(null);
@@ -208,11 +212,13 @@ export const Chat = ({
   >(null);
   const lastUserMessageIdRef = useRef<string | null>(null);
   const hasScrolledToBottomOnLoadRef = useRef(false);
+  // Conversation the chat instance currently holds messages for, so a real
+  // switch (A -> B) can be told apart from the other reasons the effect below
+  // re-runs.
+  const loadedConversationIdRef = useRef(initialConversationId);
   const lastSubmissionRef = useRef<{
     input: string;
     files: FileList | null;
-    event: FormEvent<HTMLFormElement>;
-    options?: Record<string, unknown>;
   } | null>(null);
 
   const { mutate: createChatConversation } = useCreateChatConversation();
@@ -307,27 +313,45 @@ export const Chat = ({
     console.error('Chat error:', error);
   };
 
+  // The input lives here now: v5's useChat no longer owns it.
+  const [input, setInput] = useState('');
+  const handleInputChange = useCallback(
+    (event: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) =>
+      setInput(event.target.value),
+    [],
+  );
+
+  // Deliberately not memoized: the hook keeps the latest handler in a ref, so a
+  // fresh closure each render is what keeps `setMessages` pointing at the
+  // current conversation's chat.
+  const onImagesSkipped = (kind: ImagesSkippedEventKind) => {
+    if (kind === 'chat_notice') {
+      setImagesSkipped(true);
+    } else {
+      setMessages(stampImagesSkippedOnLatestUserMessage);
+    }
+  };
+
   const {
     messages,
-    input,
-    handleSubmit: baseHandleSubmit,
-    handleInputChange,
+    sendMessage,
     status,
     stop: stopChat,
     setMessages,
     cooldownUntil,
-    data,
   } = useChat({
-    id: conversationId,
-    initialMessages: initialConversationMessages,
+    // `useChat` rebuilds the chat whenever its id differs from the instance's,
+    // and an instance with no id gets a generated one - so `undefined` never
+    // matches and the new-chat screen would rebuild on every render.
+    id: conversationId ?? 'new',
+    messages: initialConversationMessages,
     api: apiUrl,
-    streamProtocol: streamProtocol,
-    sendExtraMessageFields: true,
     onError: onErrorChat,
+    onImagesSkipped,
   });
 
   const stopGeneration = async () => {
-    stopChat();
+    await stopChat();
 
     const response = await fetchAPI(`chats/${conversationId}/stop-streaming/`, {
       method: 'POST',
@@ -350,7 +374,8 @@ export const Chat = ({
   };
 
   const handleSubmitWrapper = (event: FormEvent<HTMLFormElement>) => {
-    void handleSubmit(event);
+    event.preventDefault();
+    void submitMessage();
   };
 
   const handleRetry = () => {
@@ -369,9 +394,7 @@ export const Chat = ({
 
     retryOriginalInputRef.current = input;
     retryOriginalFilesRef.current = files;
-    handleInputChange({
-      target: { value: lastInput },
-    } as ChangeEvent<HTMLTextAreaElement>);
+    setInput(lastInput);
     setFiles(lastFiles);
     setShouldRetry(true);
   };
@@ -381,10 +404,10 @@ export const Chat = ({
     messages.forEach((message) => {
       if (message.parts) {
         const sourceParts = message.parts.filter(
-          (part): part is SourceUIPart => part.type === 'source',
+          (part): part is SourceUrlUIPart => part.type === 'source-url',
         );
         sourceParts.forEach((part) => {
-          void prefetchMetadata(part.source.url);
+          void prefetchMetadata(part.url);
         });
       }
     });
@@ -418,7 +441,7 @@ export const Chat = ({
       return [];
     }
     return sourceMessage.parts.filter(
-      (part): part is SourceUIPart => part.type === 'source',
+      (part): part is SourceUrlUIPart => part.type === 'source-url',
     );
   }, [isSourceOpen, messages]);
 
@@ -524,15 +547,15 @@ export const Chat = ({
     const lastAssistant = messages.filter((m) => m.role === 'assistant').pop();
     if (!lastAssistant?.parts) return;
     if (lastAssistant.id === lastResumeErrorMessageIdRef.current) return;
-    const resumePart = lastAssistant.parts.find(
-      (p) =>
-        p.type === 'tool-invocation' &&
-        p.toolInvocation.toolName === 'conversation_resume' &&
-        p.toolInvocation.state === 'result',
-    );
-    if (!resumePart || resumePart.type !== 'tool-invocation') return;
-    if (resumePart.toolInvocation.state !== 'result') return;
-    const result = resumePart.toolInvocation.result as {
+    const resumePart = lastAssistant.parts
+      .filter(isToolUIPart)
+      .find(
+        (p) =>
+          getToolName(p) === 'conversation_resume' &&
+          p.state === 'output-available',
+      );
+    if (!resumePart) return;
+    const result = resumePart.output as {
       state: string;
       kind?: string;
       failed_documents?: string[];
@@ -655,12 +678,13 @@ export const Chat = ({
   // Scroll to bottom when conversation_resume tool appears so the illustration is fully visible
   useEffect(() => {
     const lastAssistant = messages.filter((m) => m.role === 'assistant').pop();
-    const hasResumeTool = lastAssistant?.parts?.some(
-      (p) =>
-        p.type === 'tool-invocation' &&
-        p.toolInvocation.toolName === 'conversation_resume' &&
-        p.toolInvocation.state !== 'result',
-    );
+    const hasResumeTool = lastAssistant?.parts
+      .filter(isToolUIPart)
+      .some(
+        (p) =>
+          getToolName(p) === 'conversation_resume' &&
+          p.state !== 'output-available',
+      );
     if (hasResumeTool && chatContainerRef.current) {
       requestAnimationFrame(() => {
         if (chatContainerRef.current) {
@@ -678,12 +702,9 @@ export const Chat = ({
     setConversationId(initialConversationId);
     // Reset input when conversation changes
     if (initialConversationId !== conversationId) {
-      handleInputChange({
-        target: { value: '' },
-      } as ChangeEvent<HTMLTextAreaElement>);
+      setInput('');
       setHasInitialized(false); // Réinitialiser pour permettre le scroll au prochain chargement
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [initialConversationId, conversationId]);
 
   // On mount, if there is pending input/files, initialize state and set flag
@@ -697,10 +718,7 @@ export const Chat = ({
         setIsReadingInstructions(true);
       }
       if (pendingInput) {
-        const syntheticEvent = {
-          target: { value: pendingInput },
-        } as ChangeEvent<HTMLInputElement>;
-        handleInputChange(syntheticEvent);
+        setInput(pendingInput);
       }
       if (pendingFiles) {
         setFiles(pendingFiles);
@@ -715,13 +733,7 @@ export const Chat = ({
   // When shouldAutoSubmit is set, and input/files are ready, submit
   useEffect(() => {
     if (shouldAutoSubmit && (input.trim() || (files && files.length > 0))) {
-      // Create a synthetic event for form submission
-      const form = document.createElement('form');
-      const syntheticFormEvent = {
-        preventDefault: () => {},
-        target: form,
-      } as unknown as FormEvent<HTMLFormElement>;
-      void handleSubmit(syntheticFormEvent);
+      void submitMessage();
       setShouldAutoSubmit(false);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -733,12 +745,9 @@ export const Chat = ({
       lastSubmissionRef.current &&
       input === lastSubmissionRef.current.input
     ) {
-      const { event } = lastSubmissionRef.current;
-
-      void handleSubmit(event);
-      handleInputChange({
-        target: { value: retryOriginalInputRef.current },
-      } as ChangeEvent<HTMLTextAreaElement>);
+      void submitMessage();
+      // Restore what the user had typed before the retry took over the input.
+      setInput(retryOriginalInputRef.current);
       setFiles(retryOriginalFilesRef.current);
 
       setShouldRetry(false);
@@ -746,28 +755,19 @@ export const Chat = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [shouldRetry, input, files]);
 
-  useEffect(() => {
-    if (!data || !Array.isArray(data)) return;
-    if (
-      data.some(
-        (item) => isImagesSkippedEvent(item) && item.kind === 'chat_notice',
-      )
-    ) {
-      setImagesSkipped(true);
-    }
-    if (
-      data.some(
-        (item) =>
-          isImagesSkippedEvent(item) && item.kind === 'last_message_marked',
-      )
-    ) {
-      setMessages(stampImagesSkippedOnLatestUserMessage);
-    }
-  }, [data, setMessages]);
-
   // Fetch initial conversation messages if initialConversationId is provided and no pending input
   useEffect(() => {
     hasScrolledToBottomOnLoadRef.current = false; // Réinitialiser au début du chargement
+    // Navigating between two conversations reuses this component (the route
+    // carries no key) and rebuilds the chat instance as soon as the id
+    // changes - before the fetch below resolves. Drop the previous messages
+    // first, otherwise they are shown under the new conversation and, if the
+    // user submits in that window, posted to its endpoint.
+    if (loadedConversationIdRef.current !== initialConversationId) {
+      loadedConversationIdRef.current = initialConversationId;
+      setInitialConversationMessages(undefined);
+      setMessages([]);
+    }
     setImagesSkipped(false);
     // Drop the previous conversation's project so its indexing gate can't leak
     // into this one; the getConversation() success below repopulates it. Skip
@@ -797,7 +797,10 @@ export const Chat = ({
             id: initialConversationId,
           });
           if (!ignore) {
+            // v5 keeps the messages inside the chat instance, which was built
+            // when the id changed — before this fetch resolved.
             setInitialConversationMessages(conversation.messages);
+            setMessages(conversation.messages);
             setImagesSkipped(conversation.images_skipped ?? false);
             setConversationProjectId(conversation.project?.id ?? null);
             setHasInitialized(true);
@@ -806,6 +809,7 @@ export const Chat = ({
           // Optionally handle error (e.g., setInitialConversationMessages([]) or show error)
           if (!ignore) {
             setInitialConversationMessages([]);
+            setMessages([]);
             setHasInitialized(true);
           }
         }
@@ -816,6 +820,7 @@ export const Chat = ({
       ignore = true;
     };
     // Only run when initialConversationId or pendingInput changes
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [initialConversationId, pendingInput]);
 
   const dismissImagesBanner = useCallback(() => {
@@ -868,10 +873,21 @@ export const Chat = ({
     return !!project?.llm_instructions?.trim();
   }, [pendingProjectId, queryClient]);
 
-  // Custom handleSubmit to include attachments and handle chat creation
-  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
+  const toFileParts = (attachments: Attachment[]): FileUIPart[] =>
+    attachments.map((attachment) => ({
+      type: 'file',
+      url: attachment.url,
+      mediaType: attachment.contentType ?? 'application/octet-stream',
+      filename: attachment.name,
+    }));
 
+  const send = (text: string, attachments: Attachment[]) => {
+    void sendMessage({ text, files: toFileParts(attachments) });
+    setInput('');
+  };
+
+  // Custom submit to include attachments and handle chat creation
+  const submitMessage = async () => {
     // Inference-load cooldown: block new messages until the wait elapses.
     if (cooldownUntil && Date.now() < cooldownUntil) {
       return;
@@ -913,8 +929,8 @@ export const Chat = ({
     }
 
     if (!conversationId) {
-      // Save the event and files, then create the chat
-      setPendingFirstMessage({ event, attachments, forceWebSearch });
+      // Save the message and files, then create the chat
+      setPendingFirstMessage({ input, attachments, forceWebSearch });
       // Save input and files to Zustand store before navigation
       setPendingChat(input, files);
       if (checkProjectHasInstructions()) {
@@ -939,21 +955,10 @@ export const Chat = ({
             // After setting the conversationId, submit the pending message
             setTimeout(() => {
               if (pendingFirstMessage) {
-                // Prepare options with attachments
-                const options: Record<string, unknown> = {};
-                if (
-                  pendingFirstMessage.attachments &&
-                  pendingFirstMessage.attachments.length > 0
-                ) {
-                  options.experimental_attachments =
-                    pendingFirstMessage.attachments;
-                }
-
-                if (Object.keys(options).length > 0) {
-                  baseHandleSubmit(pendingFirstMessage.event, options);
-                } else {
-                  baseHandleSubmit(pendingFirstMessage.event);
-                }
+                send(
+                  pendingFirstMessage.input,
+                  pendingFirstMessage.attachments ?? [],
+                );
                 setFiles(null);
                 if (fileInputRef.current) {
                   fileInputRef.current.value = '';
@@ -967,25 +972,10 @@ export const Chat = ({
       return;
     }
 
-    // Prepare options with attachments
-    const options: Record<string, unknown> = {};
-    if (attachments.length > 0) {
-      options.experimental_attachments = attachments;
-    }
-
     setChatErrorType('generic');
-    lastSubmissionRef.current = {
-      input,
-      files,
-      event,
-      options: Object.keys(options).length > 0 ? options : undefined,
-    };
+    lastSubmissionRef.current = { input, files };
 
-    if (Object.keys(options).length > 0) {
-      baseHandleSubmit(event, options);
-    } else {
-      baseHandleSubmit(event);
-    }
+    send(input, attachments);
     // Attendre un peu avant de vider les fichiers pour s'assurer qu'ils sont traités
     setTimeout(() => {
       setFiles(null);

--- a/src/frontend/apps/conversations/src/features/chat/components/MessageItem.tsx
+++ b/src/frontend/apps/conversations/src/features/chat/components/MessageItem.tsx
@@ -1,5 +1,11 @@
-import { Message, SourceUIPart, ToolInvocationUIPart } from '@ai-sdk/ui-utils';
 import { Button } from '@gouvfr-lasuite/cunningham-react';
+import {
+  SourceUrlUIPart,
+  ToolUIPart,
+  UIMessage,
+  getToolName,
+  isToolUIPart,
+} from 'ai';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -8,6 +14,7 @@ import ClipboardIcon from '@/assets/icons/uikit-custom/clipboard.svg?react';
 import SourcesIcon from '@/assets/icons/uikit-custom/sources.svg?react';
 import { Box, Loader, Text } from '@/components';
 import { useConfig } from '@/core/config';
+import { SkippableFileUIPart } from '@/features/chat/api/useChat';
 import { AttachmentList } from '@/features/chat/components/AttachmentList';
 import { FeedbackButtons } from '@/features/chat/components/FeedbackButtons';
 import {
@@ -20,6 +27,7 @@ import { SummarizationError } from '@/features/chat/components/SummarizationErro
 import { SummarizationProgress } from '@/features/chat/components/SummarizationProgress';
 import { ToolInvocationItem } from '@/features/chat/components/ToolInvocationItem';
 import { getMessageCo2Impact } from '@/features/chat/utils/getMessageCo2Impact';
+import { getMessageText } from '@/features/chat/utils/getMessageText';
 
 import { ChatErrorType } from './ChatError';
 
@@ -172,7 +180,7 @@ export const splitStreamingContent = (content: string): StreamingContent => {
 };
 
 export interface MessageItemProps {
-  message: Message;
+  message: UIMessage;
   isLastMessage: boolean;
   isLastAssistantMessage: boolean;
   isFirstConversationMessage: boolean;
@@ -239,66 +247,71 @@ const MessageItemComponent: React.FC<MessageItemProps> = ({
 
   const co2ImpactKg = getMessageCo2Impact(message);
 
-  const sourceParts = React.useMemo(() => {
-    if (!message.parts) {
-      return [];
-    }
-    return message.parts.filter(
-      (part): part is SourceUIPart => part.type === 'source',
-    );
-  }, [message.parts]);
-
-  const toolInvocationParts = React.useMemo(() => {
-    if (!message.parts) {
-      return [];
-    }
-    return message.parts.filter(
-      (part): part is ToolInvocationUIPart => part.type === 'tool-invocation',
-    );
-  }, [message.parts]);
-
-  const hasTextContent = React.useMemo(
+  const sourceParts = React.useMemo(
     () =>
-      (message.parts ?? []).some(
-        (part) => part.type === 'text' && part.text.trim().length > 0,
-      ) ||
-      // Older/hydrated messages render from `message.content` without populated
-      // text parts — fall back to it so they keep the "Edit in Docs" action.
-      (message.content?.trim().length ?? 0) > 0,
-    [message.parts, message.content],
+      message.parts.filter(
+        (part): part is SourceUrlUIPart => part.type === 'source-url',
+      ),
+    [message.parts],
   );
 
-  const hasNonDocumentParsingTool = React.useMemo(() => {
-    return toolInvocationParts.some(
-      (part) =>
-        part.toolInvocation.toolName !== 'document_parsing' &&
-        part.toolInvocation.toolName !== 'conversation_resume',
-    );
-  }, [toolInvocationParts]);
+  const toolInvocationParts = React.useMemo(
+    () => message.parts.filter(isToolUIPart),
+    [message.parts],
+  );
 
-  const activeToolInvocation = React.useMemo(() => {
-    const tool = [...toolInvocationParts]
-      .reverse()
-      .find(
+  const attachments = React.useMemo(
+    () =>
+      message.parts
+        .filter((part) => part.type === 'file')
+        .map((part) => ({
+          name: part.filename,
+          contentType: part.mediaType,
+          url: part.url,
+          skipped: (part as SkippableFileUIPart).skipped,
+        })),
+    [message.parts],
+  );
+
+  const textContent = React.useMemo(() => getMessageText(message), [message]);
+
+  const hasTextContent = textContent.trim().length > 0;
+
+  const hasNonDocumentParsingTool = React.useMemo(
+    () =>
+      toolInvocationParts.some(
         (part) =>
-          part.toolInvocation.toolName !== 'document_parsing' &&
-          part.toolInvocation.state !== 'result' &&
-          part.toolInvocation.toolName !== 'conversation_resume',
-      );
-    return tool?.toolInvocation;
-  }, [toolInvocationParts]);
+          getToolName(part) !== 'document_parsing' &&
+          getToolName(part) !== 'conversation_resume',
+      ),
+    [toolInvocationParts],
+  );
 
-  const conversationSummarizeInvocation = React.useMemo(() => {
-    const part = [...toolInvocationParts]
-      .reverse()
-      .find(
-        (p) =>
-          p.toolInvocation.toolName === 'summarize' &&
-          (p.toolInvocation.args as { summary_scope?: string })
-            ?.summary_scope === 'conversation',
-      );
-    return part?.toolInvocation;
-  }, [toolInvocationParts]);
+  const activeToolInvocation = React.useMemo(
+    () =>
+      [...toolInvocationParts]
+        .reverse()
+        .find(
+          (part) =>
+            getToolName(part) !== 'document_parsing' &&
+            part.state !== 'output-available' &&
+            getToolName(part) !== 'conversation_resume',
+        ),
+    [toolInvocationParts],
+  );
+
+  const conversationSummarizeInvocation = React.useMemo(
+    () =>
+      [...toolInvocationParts]
+        .reverse()
+        .find(
+          (part) =>
+            getToolName(part) === 'summarize' &&
+            (part.input as { summary_scope?: string })?.summary_scope ===
+              'conversation',
+        ),
+    [toolInvocationParts],
+  );
 
   // The summary phase failed the turn: the backend emits the `summarize`
   // tool-call before it can fail, so the invocation is still present here and
@@ -323,7 +336,7 @@ const MessageItemComponent: React.FC<MessageItemProps> = ({
     isCurrentlyStreaming &&
     status === 'streaming' &&
     isSummarizationBarHidden &&
-    !message.content &&
+    !textContent &&
     !activeToolInvocation;
 
   // Memoize the streaming content split to avoid recreating components in JSX
@@ -331,12 +344,12 @@ const MessageItemComponent: React.FC<MessageItemProps> = ({
     // When not streaming, everything is completed as a single block array
     if (!isCurrentlyStreaming) {
       return {
-        completedBlocks: splitIntoBlocks(message.content),
+        completedBlocks: splitIntoBlocks(textContent),
         pending: '',
       };
     }
-    return splitStreamingContent(message.content);
-  }, [isCurrentlyStreaming, message.content]);
+    return splitStreamingContent(textContent);
+  }, [isCurrentlyStreaming, textContent]);
 
   const handleCopy = React.useCallback(() => {
     const html = contentRef.current?.innerHTML;
@@ -349,20 +362,20 @@ const MessageItemComponent: React.FC<MessageItemProps> = ({
       // while code editors and plain-text apps use text/plain (raw markdown).
       const item = new ClipboardItem({
         'text/html': new Blob([html], { type: 'text/html' }),
-        'text/plain': new Blob([message.content], { type: 'text/plain' }),
+        'text/plain': new Blob([textContent], { type: 'text/plain' }),
       });
       navigator.clipboard.write([item]).then(
         () => showCopiedState(),
         () => {
-          onCopyToClipboard(message.content);
+          onCopyToClipboard(textContent);
           showCopiedState();
         },
       );
     } else {
-      onCopyToClipboard(message.content);
+      onCopyToClipboard(textContent);
       showCopiedState();
     }
-  }, [contentRef, message.content, onCopyToClipboard, showCopiedState]);
+  }, [contentRef, textContent, onCopyToClipboard, showCopiedState]);
 
   const handleOpenSources = React.useCallback(() => {
     onOpenSources(message.id);
@@ -391,15 +404,11 @@ const MessageItemComponent: React.FC<MessageItemProps> = ({
         $display="block"
         $width={`${message.role === 'user' ? 'auto' : '100%'}`}
       >
-        {message.experimental_attachments &&
-          message.experimental_attachments.length > 0 && (
-            <Box>
-              <AttachmentList
-                attachments={message.experimental_attachments}
-                isReadOnly={true}
-              />
-            </Box>
-          )}
+        {attachments.length > 0 && (
+          <Box>
+            <AttachmentList attachments={attachments} isReadOnly={true} />
+          </Box>
+        )}
         <Box
           className={`chatMessage ${message.role === 'user' ? 'chatMessage--user' : 'chatMessage--assistant'}`}
           style={
@@ -409,7 +418,7 @@ const MessageItemComponent: React.FC<MessageItemProps> = ({
           }
         >
           {/* Message content */}
-          {message.content && (
+          {textContent && (
             <Box
               ref={contentRef}
               className="mainContent-chat"
@@ -431,7 +440,7 @@ const MessageItemComponent: React.FC<MessageItemProps> = ({
                   $theme="greyscale"
                   $variation="850"
                 >
-                  {message.content}
+                  {textContent}
                 </Text>
               ) : (
                 // Render completed blocks as markdown, pending block as plain text
@@ -455,7 +464,10 @@ const MessageItemComponent: React.FC<MessageItemProps> = ({
                   }}
                 >
                   <SummarizationProgress
-                    done={conversationSummarizeInvocation.state === 'result'}
+                    done={
+                      conversationSummarizeInvocation.state ===
+                      'output-available'
+                    }
                     onHidden={handleSummarizationBarHidden}
                   />
                 </Box>
@@ -512,7 +524,7 @@ const MessageItemComponent: React.FC<MessageItemProps> = ({
                 >
                   <Loader />
                   <Text $variation="600" $size="md">
-                    {activeToolInvocation.toolName === 'summarize'
+                    {getToolName(activeToolInvocation) === 'summarize'
                       ? t('Summarizing...')
                       : t('Search...')}
                   </Text>
@@ -522,7 +534,7 @@ const MessageItemComponent: React.FC<MessageItemProps> = ({
               isLastAssistantMessage ? (
                 <ToolInvocationItem
                   key={`tool-invocation-${partIndex}`}
-                  toolInvocation={part.toolInvocation}
+                  toolInvocation={part}
                   status={status}
                   hideSearchLoader={true}
                 />
@@ -609,19 +621,27 @@ const MessageItemComponent: React.FC<MessageItemProps> = ({
 
 MessageItemComponent.displayName = 'MessageItem';
 
-// Tool invocations go from `call` to `result` in place, without changing the
+// Tool invocations advance through their states in place, without changing the
 // parts count, so their states need their own signature: the summarization
 // progress bar and the loader that replaces it hang on that transition.
-const getToolInvocationStates = (message: Message): string =>
-  (message.parts ?? [])
-    .filter(
-      (part): part is ToolInvocationUIPart => part.type === 'tool-invocation',
-    )
-    .map((part) => part.toolInvocation.state)
+const getToolInvocationStates = (message: UIMessage): string =>
+  message.parts
+    .filter(isToolUIPart)
+    .map((part: ToolUIPart) => part.state)
     .join(',');
 
-const getSourcePartsCount = (message: Message): number =>
-  (message.parts ?? []).filter((part) => part.type === 'source').length;
+const getSourcePartsCount = (message: UIMessage): number =>
+  message.parts.filter((part) => part.type === 'source-url').length;
+
+const getFilePartsCount = (message: UIMessage): number =>
+  message.parts.filter((part) => part.type === 'file').length;
+
+// The backend can mark an image as skipped after the message was rendered, which
+// only mutates the part in place - the part count stays the same.
+const getSkippedFilePartsCount = (message: UIMessage): number =>
+  message.parts.filter(
+    (part) => part.type === 'file' && (part as SkippableFileUIPart).skipped,
+  ).length;
 
 // Custom comparison function for React.memo
 // Only re-render when props that affect rendering change
@@ -633,7 +653,7 @@ const arePropsEqual = (
   if (prevProps.message.id !== nextProps.message.id) {
     return false;
   }
-  if (prevProps.message.content !== nextProps.message.content) {
+  if (getMessageText(prevProps.message) !== getMessageText(nextProps.message)) {
     return false;
   }
   if (prevProps.message.role !== nextProps.message.role) {
@@ -648,8 +668,8 @@ const arePropsEqual = (
   }
 
   // Check parts changes (for streaming tool invocations and sources)
-  const prevPartsLength = prevProps.message.parts?.length ?? 0;
-  const nextPartsLength = nextProps.message.parts?.length ?? 0;
+  const prevPartsLength = prevProps.message.parts.length;
+  const nextPartsLength = nextProps.message.parts.length;
   if (prevPartsLength !== nextPartsLength) {
     return false;
   }
@@ -667,11 +687,17 @@ const arePropsEqual = (
   }
 
   // Check attachments
-  const prevAttachmentsLength =
-    prevProps.message.experimental_attachments?.length ?? 0;
-  const nextAttachmentsLength =
-    nextProps.message.experimental_attachments?.length ?? 0;
-  if (prevAttachmentsLength !== nextAttachmentsLength) {
+  if (
+    getFilePartsCount(prevProps.message) !==
+    getFilePartsCount(nextProps.message)
+  ) {
+    return false;
+  }
+
+  if (
+    getSkippedFilePartsCount(prevProps.message) !==
+    getSkippedFilePartsCount(nextProps.message)
+  ) {
     return false;
   }
 

--- a/src/frontend/apps/conversations/src/features/chat/components/SourceItemList.tsx
+++ b/src/frontend/apps/conversations/src/features/chat/components/SourceItemList.tsx
@@ -1,4 +1,4 @@
-import { SourceUIPart } from '@ai-sdk/ui-utils';
+import { SourceUrlUIPart } from 'ai';
 import React from 'react';
 
 import { Box } from '@/components';
@@ -12,7 +12,7 @@ export interface SourceMetadata {
 }
 
 interface SourceItemListProps {
-  parts: readonly SourceUIPart[];
+  parts: readonly SourceUrlUIPart[];
   getMetadata: (url: string) => SourceMetadata | undefined;
 }
 
@@ -33,9 +33,9 @@ const SourceItemListComponent: React.FC<SourceItemListProps> = ({
       {parts.map((part, index) => (
         <SourceItem
           index={index + 1}
-          key={part.source.url}
-          url={part.source.url}
-          metadata={getMetadata(part.source.url)}
+          key={part.sourceId}
+          url={part.url}
+          metadata={getMetadata(part.url)}
         />
       ))}
     </Box>

--- a/src/frontend/apps/conversations/src/features/chat/components/ToolInvocationItem.tsx
+++ b/src/frontend/apps/conversations/src/features/chat/components/ToolInvocationItem.tsx
@@ -1,4 +1,4 @@
-import { ToolInvocation } from '@ai-sdk/ui-utils';
+import { ToolUIPart, getToolName } from 'ai';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -44,7 +44,7 @@ const ConversationResumeLoader = ({ t }: { t: (key: string) => string }) => {
 };
 
 interface ToolInvocationItemProps {
-  toolInvocation: ToolInvocation;
+  toolInvocation: ToolUIPart;
   status?: string;
   hideSearchLoader?: boolean;
 }
@@ -55,9 +55,10 @@ export const ToolInvocationItem: React.FC<ToolInvocationItemProps> = ({
   hideSearchLoader = false,
 }) => {
   const { t } = useTranslation();
+  const toolName = getToolName(toolInvocation);
 
-  if (toolInvocation.toolName === 'conversation_resume') {
-    if (toolInvocation.state !== 'result') {
+  if (toolName === 'conversation_resume') {
+    if (toolInvocation.state !== 'output-available') {
       return <ConversationResumeLoader t={t} />;
     }
 
@@ -65,13 +66,13 @@ export const ToolInvocationItem: React.FC<ToolInvocationItemProps> = ({
     return null;
   }
 
-  if (toolInvocation.toolName === 'document_parsing') {
-    if (toolInvocation.state === 'partial-call') {
+  if (toolName === 'document_parsing') {
+    if (toolInvocation.state === 'input-streaming') {
       return null;
     }
 
-    if (toolInvocation.state === 'result') {
-      const result = toolInvocation.result as {
+    if (toolInvocation.state === 'output-available') {
+      const result = toolInvocation.output as {
         state?: string;
         kind?: string;
         error?: string;
@@ -82,7 +83,7 @@ export const ToolInvocationItem: React.FC<ToolInvocationItemProps> = ({
       return null;
     }
 
-    const documents: unknown = (toolInvocation.args as { documents: unknown })
+    const documents: unknown = (toolInvocation.input as { documents: unknown })
       ?.documents;
     const documentIdentifiers: string[] =
       Array.isArray(documents) &&

--- a/src/frontend/apps/conversations/src/features/chat/components/__tests__/MessageItem.test.tsx
+++ b/src/frontend/apps/conversations/src/features/chat/components/__tests__/MessageItem.test.tsx
@@ -5,6 +5,7 @@ import userEvent from '@testing-library/user-event';
 import { Suspense } from 'react';
 
 import { ToastProvider } from '@/components/ToastProvider';
+import { stampImagesSkippedOnLatestUserMessage } from '@/features/chat/api/useChat';
 
 import {
   MessageItem,
@@ -46,7 +47,16 @@ vi.mock('../MoreActionsButton', () => ({
 
 // Mock child components
 vi.mock('../AttachmentList', () => ({
-  AttachmentList: () => <div data-testid="attachment-list" />,
+  AttachmentList: ({
+    attachments,
+  }: {
+    attachments: { skipped?: unknown }[];
+  }) => (
+    <div
+      data-testid="attachment-list"
+      data-skipped={attachments.filter((one) => one.skipped).length}
+    />
+  ),
 }));
 
 vi.mock('../FeedbackButtons', () => ({
@@ -366,7 +376,7 @@ describe('MessageItem', () => {
     message: {
       id: 'msg-1',
       role: 'assistant' as const,
-      content: 'Hello world',
+      parts: [{ type: 'text' as const, text: 'Hello world' }],
     },
     isLastMessage: false,
     isLastAssistantMessage: false,
@@ -514,7 +524,9 @@ describe('MessageItem', () => {
             {...defaultProps}
             message={{
               ...defaultProps.message,
-              content: 'Block 1\n\nPending content',
+              parts: [
+                { type: 'text' as const, text: 'Block 1\n\nPending content' },
+              ],
             }}
             status="streaming"
             isLastAssistantMessage={true}
@@ -534,8 +546,14 @@ describe('MessageItem', () => {
     it('renders AttachmentList when message has attachments', async () => {
       const messageWithAttachments = {
         ...defaultProps.message,
-        experimental_attachments: [
-          { url: 'https://example.com/file.pdf', name: 'file.pdf' },
+        parts: [
+          ...defaultProps.message.parts,
+          {
+            type: 'file' as const,
+            url: 'https://example.com/file.pdf',
+            filename: 'file.pdf',
+            mediaType: 'application/pdf',
+          },
         ],
       };
 
@@ -548,6 +566,44 @@ describe('MessageItem', () => {
       expect(screen.getByTestId('attachment-list')).toBeInTheDocument();
     });
 
+    it('re-renders when the backend marks an image as skipped', async () => {
+      // The stamp mutates the part in place, leaving the file count unchanged:
+      // the memo comparator has to look at the skip state itself.
+      const message = {
+        ...defaultProps.message,
+        role: 'user' as const,
+        parts: [
+          { type: 'text' as const, text: 'Look at this' },
+          {
+            type: 'file' as const,
+            url: 'https://example.com/photo.png',
+            filename: 'photo.png',
+            mediaType: 'image/png',
+          },
+        ],
+      };
+
+      const { rerender } = render(
+        withProviders(<MessageItem {...defaultProps} message={message} />),
+      );
+      expect(screen.getByTestId('attachment-list')).toHaveAttribute(
+        'data-skipped',
+        '0',
+      );
+
+      const [stamped] = stampImagesSkippedOnLatestUserMessage([message]);
+      await act(async () => {
+        rerender(
+          withProviders(<MessageItem {...defaultProps} message={stamped} />),
+        );
+      });
+
+      expect(screen.getByTestId('attachment-list')).toHaveAttribute(
+        'data-skipped',
+        '1',
+      );
+    });
+
     it('does not render AttachmentList when no attachments', async () => {
       await act(async () => {
         renderWithProviders(<MessageItem {...defaultProps} />);
@@ -558,14 +614,14 @@ describe('MessageItem', () => {
   });
 
   describe('energy indicator', () => {
-    it('renders MessageEnergyIndicator when co2 annotation is present', async () => {
+    it('renders MessageEnergyIndicator when co2 metadata is present', async () => {
       await act(async () => {
         renderWithProviders(
           <MessageItem
             {...defaultProps}
             message={{
               ...defaultProps.message,
-              annotations: [{ co2_impact: TEST_CO2_IMPACT_KG }],
+              metadata: { co2_impact: TEST_CO2_IMPACT_KG },
             }}
           />,
         );
@@ -576,7 +632,7 @@ describe('MessageItem', () => {
       ).toBeInTheDocument();
     });
 
-    it('does not render MessageEnergyIndicator without co2 annotation', async () => {
+    it('does not render MessageEnergyIndicator without co2 metadata', async () => {
       await act(async () => {
         renderWithProviders(<MessageItem {...defaultProps} />);
       });
@@ -618,16 +674,12 @@ describe('MessageItem', () => {
     const conversationSummarizeMessage = {
       id: 'msg-sum',
       role: 'assistant' as const,
-      content: '',
       parts: [
         {
-          type: 'tool-invocation' as const,
-          toolInvocation: {
-            toolCallId: 'call-1',
-            toolName: 'summarize',
-            state: 'call' as const,
-            args: { state: 'running', summary_scope: 'conversation' },
-          },
+          type: 'tool-summarize' as const,
+          toolCallId: 'call-1',
+          state: 'input-available' as const,
+          input: { state: 'running', summary_scope: 'conversation' },
         },
       ],
     };
@@ -657,13 +709,10 @@ describe('MessageItem', () => {
         ...conversationSummarizeMessage,
         parts: [
           {
-            type: 'tool-invocation' as const,
-            toolInvocation: {
-              toolCallId: 'call-2',
-              toolName: 'summarize',
-              state: 'call' as const,
-              args: { state: 'running', summary_scope: 'document' },
-            },
+            type: 'tool-summarize' as const,
+            toolCallId: 'call-2',
+            state: 'input-available' as const,
+            input: { state: 'running', summary_scope: 'document' },
           },
         ],
       };
@@ -715,14 +764,11 @@ describe('MessageItem', () => {
         ...conversationSummarizeMessage,
         parts: [
           {
-            type: 'tool-invocation' as const,
-            toolInvocation: {
-              toolCallId: 'call-1',
-              toolName: 'summarize',
-              state: 'result' as const,
-              args: { state: 'running', summary_scope: 'conversation' },
-              result: { state: 'done' },
-            },
+            type: 'tool-summarize' as const,
+            toolCallId: 'call-1',
+            state: 'output-available' as const,
+            input: { state: 'running', summary_scope: 'conversation' },
+            output: { state: 'done' },
           },
         ],
       };
@@ -766,14 +812,11 @@ describe('MessageItem', () => {
         ...conversationSummarizeMessage,
         parts: [
           {
-            type: 'tool-invocation' as const,
-            toolInvocation: {
-              toolCallId: 'call-1',
-              toolName: 'summarize',
-              state: 'result' as const,
-              args: { state: 'running', summary_scope: 'conversation' },
-              result: { state: 'done' },
-            },
+            type: 'tool-summarize' as const,
+            toolCallId: 'call-1',
+            state: 'output-available' as const,
+            input: { state: 'running', summary_scope: 'conversation' },
+            output: { state: 'done' },
           },
         ],
       };
@@ -795,7 +838,13 @@ describe('MessageItem', () => {
         withProviders(
           <MessageItem
             {...defaultProps}
-            message={{ ...summarizedMessage, content: 'Here is the answer' }}
+            message={{
+              ...summarizedMessage,
+              parts: [
+                ...summarizedMessage.parts,
+                { type: 'text' as const, text: 'Here is the answer' },
+              ],
+            }}
             status="streaming"
             isLastAssistantMessage={true}
           />,

--- a/src/frontend/apps/conversations/src/features/chat/components/__tests__/ToolInvocationItem.test.tsx
+++ b/src/frontend/apps/conversations/src/features/chat/components/__tests__/ToolInvocationItem.test.tsx
@@ -18,11 +18,11 @@ const renderResultError = (kind?: string) =>
   render(
     <ToolInvocationItem
       toolInvocation={{
+        type: 'tool-document_parsing',
         toolCallId: 'test-id',
-        toolName: 'document_parsing',
-        state: 'result',
-        args: {},
-        result: {
+        state: 'output-available',
+        input: {},
+        output: {
           state: 'error',
           ...(kind ? { kind } : {}),
           error: 'whatever',
@@ -37,14 +37,14 @@ describe('ToolInvocationItem', () => {
   });
 
   describe('conversation_resume', () => {
-    it('shows the resuming loader when state is call', () => {
+    it('shows the resuming loader when the input is available', () => {
       render(
         <ToolInvocationItem
           toolInvocation={{
+            type: 'tool-conversation_resume',
             toolCallId: 'test-id',
-            toolName: 'conversation_resume',
-            state: 'call',
-            args: {},
+            state: 'input-available',
+            input: {},
           }}
         />,
       );
@@ -59,15 +59,15 @@ describe('ToolInvocationItem', () => {
       ).toBeInTheDocument();
     });
 
-    it('renders nothing when state is result', () => {
+    it('renders nothing when the output is available', () => {
       const { container } = render(
         <ToolInvocationItem
           toolInvocation={{
+            type: 'tool-conversation_resume',
             toolCallId: 'test-id',
-            toolName: 'conversation_resume',
-            state: 'result',
-            args: {},
-            result: { state: 'done' },
+            state: 'output-available',
+            input: {},
+            output: { state: 'done' },
           }}
         />,
       );

--- a/src/frontend/apps/conversations/src/features/chat/types.tsx
+++ b/src/frontend/apps/conversations/src/features/chat/types.tsx
@@ -1,6 +1,6 @@
-import { Message } from '@ai-sdk/react';
+import { UIMessage } from 'ai';
 
-export type ChatMessage = Message;
+export type ChatMessage = UIMessage;
 
 export interface ChatConversationProject {
   id: string;

--- a/src/frontend/apps/conversations/src/features/chat/utils/__tests__/getMessageCo2Impact.test.ts
+++ b/src/frontend/apps/conversations/src/features/chat/utils/__tests__/getMessageCo2Impact.test.ts
@@ -1,39 +1,30 @@
-import { Message } from '@ai-sdk/ui-utils';
+import { UIMessage } from 'ai';
 
 import { getMessageCo2Impact } from '../getMessageCo2Impact';
 
 const TEST_CO2_IMPACT_KG = 0.00002191613089507352;
 
-describe('getMessageCo2Impact', () => {
-  it('returns co2_impact from annotations', () => {
-    const message = {
-      id: 'trace-1',
-      role: 'assistant',
-      content: 'Hello',
-      annotations: [{ co2_impact: TEST_CO2_IMPACT_KG }],
-    } as Message & { annotations: { co2_impact: number }[] };
+const assistantMessage = (metadata?: unknown): UIMessage => ({
+  id: 'trace-1',
+  role: 'assistant',
+  parts: [{ type: 'text', text: 'Hello' }],
+  metadata,
+});
 
-    expect(getMessageCo2Impact(message)).toBe(TEST_CO2_IMPACT_KG);
+describe('getMessageCo2Impact', () => {
+  it('returns co2_impact from the message metadata', () => {
+    expect(
+      getMessageCo2Impact(assistantMessage({ co2_impact: TEST_CO2_IMPACT_KG })),
+    ).toBe(TEST_CO2_IMPACT_KG);
   });
 
-  it('returns undefined when annotations are missing', () => {
-    expect(
-      getMessageCo2Impact({
-        id: '1',
-        role: 'assistant',
-        content: 'Hello',
-      }),
-    ).toBeUndefined();
+  it('returns undefined when metadata is missing', () => {
+    expect(getMessageCo2Impact(assistantMessage())).toBeUndefined();
   });
 
   it('returns undefined when co2_impact is zero', () => {
     expect(
-      getMessageCo2Impact({
-        id: 'trace-1',
-        role: 'assistant',
-        content: 'Hello',
-        annotations: [{ co2_impact: 0 }],
-      }),
+      getMessageCo2Impact(assistantMessage({ co2_impact: 0 })),
     ).toBeUndefined();
   });
 });

--- a/src/frontend/apps/conversations/src/features/chat/utils/getMessageCo2Impact.ts
+++ b/src/frontend/apps/conversations/src/features/chat/utils/getMessageCo2Impact.ts
@@ -1,18 +1,11 @@
-import { Message } from '@ai-sdk/ui-utils';
+import { UIMessage } from 'ai';
 
-type Co2Annotation = { co2_impact?: number };
+type Co2Metadata = { co2_impact?: number };
 
-export const getMessageCo2Impact = (message: Message): number | undefined => {
-  const annotations = (message as Message & { annotations?: Co2Annotation[] })
-    .annotations;
+export const getMessageCo2Impact = (message: UIMessage): number | undefined => {
+  const impact = (message.metadata as Co2Metadata | undefined)?.co2_impact;
 
-  const impact = annotations
-    ?.map((annotation) => annotation as Co2Annotation)
-    .find(
-      (annotation) => typeof annotation.co2_impact === 'number',
-    )?.co2_impact;
-
-  if (impact !== undefined && impact > 0) {
+  if (typeof impact === 'number' && impact > 0) {
     return impact;
   }
 

--- a/src/frontend/apps/conversations/src/features/chat/utils/getMessageText.ts
+++ b/src/frontend/apps/conversations/src/features/chat/utils/getMessageText.ts
@@ -1,0 +1,14 @@
+import { UIMessage } from 'ai';
+
+/**
+ * The message text, assembled from its text parts.
+ *
+ * v5 messages carry their text in parts; older stored messages that only had
+ * the deprecated `content` field are upconverted to a text part by the backend,
+ * so this is the single source of truth on the client.
+ */
+export const getMessageText = (message: UIMessage): string =>
+  message.parts
+    .filter((part) => part.type === 'text')
+    .map((part) => part.text)
+    .join('');

--- a/src/frontend/apps/conversations/src/features/sources-panel/SourcePanel.tsx
+++ b/src/frontend/apps/conversations/src/features/sources-panel/SourcePanel.tsx
@@ -1,4 +1,4 @@
-import { createContext, type PropsWithChildren, useContext } from 'react';
+import { type PropsWithChildren, createContext, useContext } from 'react';
 
 /** Réexport legacy pour compatibilité ; préférer `SourcePanel` + `useSourcePanelAnchor`. */
 export const SourcesPanelAnchorContext = createContext<HTMLDivElement | null>(

--- a/src/frontend/yarn.lock
+++ b/src/frontend/yarn.lock
@@ -35,40 +35,41 @@
     react-transition-group "^4.4.5"
     use-sync-external-store "^1.6.0"
 
-"@ai-sdk/provider-utils@2.2.8":
-  version "2.2.8"
-  resolved "https://registry.yarnpkg.com/@ai-sdk/provider-utils/-/provider-utils-2.2.8.tgz#ad11b92d5a1763ab34ba7b5fc42494bfe08b76d1"
-  integrity sha512-fqhG+4sCVv8x7nFzYnFo19ryhAa3w096Kmc3hWxMQfW/TubPOmt3A6tYZhl4mUfQWWQMsuSkLrtjlWuXBVSGQA==
+"@ai-sdk/gateway@2.0.135":
+  version "2.0.135"
+  resolved "https://registry.yarnpkg.com/@ai-sdk/gateway/-/gateway-2.0.135.tgz#24aac09c260db3dd4c05952763cb44aa0eee7844"
+  integrity sha512-c/5QgAgamlZP6bIKdPqIEAyZzyA6BgYdeZhNDAyQ148/wiKEVxdbajr+2qofXr8MM1b1QPz0SBbr31+t1F4Yog==
   dependencies:
-    "@ai-sdk/provider" "1.1.3"
-    nanoid "^3.3.8"
-    secure-json-parse "^2.7.0"
+    "@ai-sdk/provider" "2.0.3"
+    "@ai-sdk/provider-utils" "3.0.32"
+    "@vercel/oidc" "3.1.0"
 
-"@ai-sdk/provider@1.1.3":
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/@ai-sdk/provider/-/provider-1.1.3.tgz#ebdda8077b8d2b3f290dcba32c45ad19b2704681"
-  integrity sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg==
+"@ai-sdk/provider-utils@3.0.32":
+  version "3.0.32"
+  resolved "https://registry.yarnpkg.com/@ai-sdk/provider-utils/-/provider-utils-3.0.32.tgz#52022fdec2f9b88dc7c8c4dff22108f617933f84"
+  integrity sha512-izgUo50kamJMwoYCXoFwVccuJeyYp0y1+twf0FfpEz7kdQBloZLZbgLYUOUpannLWrV7xYSJR48BQJIQFbFiAQ==
+  dependencies:
+    "@ai-sdk/provider" "2.0.3"
+    "@standard-schema/spec" "^1.0.0"
+    eventsource-parser "^3.0.6"
+    undici "^5.29.0"
+
+"@ai-sdk/provider@2.0.3":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@ai-sdk/provider/-/provider-2.0.3.tgz#8a3727d31947c6238e59dcbb72b7e1a871fd570c"
+  integrity sha512-h88OPkavHTiN9tMn2l5awAznGB0lXzjcLhgR1/rvjB2zlLprsNxbM2tt6OJsHUxduLC3klq0/eqaSf6fX5XVww==
   dependencies:
     json-schema "^0.4.0"
 
-"@ai-sdk/react@1.2.12":
-  version "1.2.12"
-  resolved "https://registry.yarnpkg.com/@ai-sdk/react/-/react-1.2.12.tgz#f4250b6df566b170af98a71d5708b52108dd0ce1"
-  integrity sha512-jK1IZZ22evPZoQW3vlkZ7wvjYGYF+tRBKXtrcolduIkQ/m/sOAVcVeVDUDvh1T91xCnWCdUGCPZg2avZ90mv3g==
+"@ai-sdk/react@2.0.241":
+  version "2.0.241"
+  resolved "https://registry.yarnpkg.com/@ai-sdk/react/-/react-2.0.241.tgz#ac4bb63b6e80b0f4d7091af5b627f451268ee8a1"
+  integrity sha512-kWKnDKWrwVxeiGZJZWyvZ800r8amhXcARWl5wXYOrUdy/IvBb7ksoJ1Ple5fjYnYnu0oDwAPzc1kl7Ee5eh5zw==
   dependencies:
-    "@ai-sdk/provider-utils" "2.2.8"
-    "@ai-sdk/ui-utils" "1.2.11"
+    "@ai-sdk/provider-utils" "3.0.32"
+    ai "5.0.238"
     swr "^2.2.5"
     throttleit "2.1.0"
-
-"@ai-sdk/ui-utils@1.2.11":
-  version "1.2.11"
-  resolved "https://registry.yarnpkg.com/@ai-sdk/ui-utils/-/ui-utils-1.2.11.tgz#4f815589d08d8fef7292ade54ee5db5d09652603"
-  integrity sha512-3zcwCc8ezzFlwp3ZD15wAPjf2Au4s3vAbKsXQVyhxODHcmu0iyPO2Eua6D/vicq/AUm/BAo60r97O6HU+EI0+w==
-  dependencies:
-    "@ai-sdk/provider" "1.1.3"
-    "@ai-sdk/provider-utils" "2.2.8"
-    zod-to-json-schema "^3.24.1"
 
 "@asamuzakjp/css-color@^5.1.11":
   version "5.1.11"
@@ -1539,6 +1540,11 @@
     "@napi-rs/canvas-win32-arm64-msvc" "0.1.100"
     "@napi-rs/canvas-win32-x64-msvc" "0.1.100"
 
+"@napi-rs/lzma-linux-x64-gnu@1.5.1":
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz#e57d4306966078662038094fb38eb9146dc3aea9"
+  integrity sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==
+
 "@napi-rs/wasm-runtime@^0.2.11":
   version "0.2.12"
   resolved "https://registry.yarnpkg.com/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz#3e78a8b96e6c33a6c517e1894efbd5385a7cb6f2"
@@ -1568,6 +1574,11 @@
   dependencies:
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
+
+"@opentelemetry/api@1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/api/-/api-1.9.0.tgz#d03eba68273dc0f7509e2a3d5cba21eae10379fe"
+  integrity sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==
 
 "@oxc-project/types@=0.143.0":
   version "0.143.0"
@@ -3141,130 +3152,130 @@
     estree-walker "^2.0.2"
     picomatch "^4.0.2"
 
-"@rollup/rollup-android-arm-eabi@4.62.2":
-  version "4.62.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz#5e9849b661c2229cf967a08dbe2dbbe9e8c991e5"
-  integrity sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==
+"@rollup/rollup-android-arm-eabi@4.62.4":
+  version "4.62.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.4.tgz#2b86c8fff13a065845ddb65f64d814499ace020f"
+  integrity sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==
 
-"@rollup/rollup-android-arm64@4.62.2":
-  version "4.62.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz#5b0699ee5dd484b222c9ed74aff43c91ea8b17f8"
-  integrity sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==
+"@rollup/rollup-android-arm64@4.62.4":
+  version "4.62.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.4.tgz#af217357ecc06ae5e4f54ef34ee72b1e37f8dbc3"
+  integrity sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A==
 
-"@rollup/rollup-darwin-arm64@4.62.2":
-  version "4.62.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz#8bc52c9d7a3ce8d0533c351a9c935de781daa06f"
-  integrity sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==
+"@rollup/rollup-darwin-arm64@4.62.4":
+  version "4.62.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.4.tgz#e9d0adba06e39b632fc8e880100ff06547eda80b"
+  integrity sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw==
 
-"@rollup/rollup-darwin-x64@4.62.2":
-  version "4.62.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz#ba2ef3e8fb310f0af35588f270cfa5aa96e48764"
-  integrity sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==
+"@rollup/rollup-darwin-x64@4.62.4":
+  version "4.62.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.4.tgz#eff983a29db7d8ea7f733f1ce430fc64e159a5e6"
+  integrity sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A==
 
-"@rollup/rollup-freebsd-arm64@4.62.2":
-  version "4.62.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz#93b10bdbfe8ada226b8bc0c02ef6b7f544474d96"
-  integrity sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==
+"@rollup/rollup-freebsd-arm64@4.62.4":
+  version "4.62.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.4.tgz#abe1399a70e819034f492d05dbcc97964310bb57"
+  integrity sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ==
 
-"@rollup/rollup-freebsd-x64@4.62.2":
-  version "4.62.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz#3e8aa38ef3c9c300946871e3fdbb0c30e0a20f86"
-  integrity sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==
+"@rollup/rollup-freebsd-x64@4.62.4":
+  version "4.62.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.4.tgz#b2e0f8c24a362ac7112be3d5549c6940597e0168"
+  integrity sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg==
 
-"@rollup/rollup-linux-arm-gnueabihf@4.62.2":
-  version "4.62.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz#1d7994384bb0ad1bc41921b506e1642d4f9d7fc3"
-  integrity sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==
+"@rollup/rollup-linux-arm-gnueabihf@4.62.4":
+  version "4.62.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.4.tgz#a5f2a7e7eb719254a6800db18e9f369d3c623439"
+  integrity sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==
 
-"@rollup/rollup-linux-arm-musleabihf@4.62.2":
-  version "4.62.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz#a6540f47cf844a56b80ca9ff95d2acdfb2cef97b"
-  integrity sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==
+"@rollup/rollup-linux-arm-musleabihf@4.62.4":
+  version "4.62.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.4.tgz#390c86c797695af87c38d6f005222d920b5bfa22"
+  integrity sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==
 
-"@rollup/rollup-linux-arm64-gnu@4.62.2":
-  version "4.62.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz#404f2045651840cbf48da91ba6d0f490f0bc2cbf"
-  integrity sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==
+"@rollup/rollup-linux-arm64-gnu@4.62.4":
+  version "4.62.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.4.tgz#1fea78609a15813cda98d93fe8d987c87017f572"
+  integrity sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==
 
-"@rollup/rollup-linux-arm64-musl@4.62.2":
-  version "4.62.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz#a3404ffddf7b474b48c99b9c893b6247bb765ba5"
-  integrity sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==
+"@rollup/rollup-linux-arm64-musl@4.62.4":
+  version "4.62.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.4.tgz#3b50031c9916517576098f6e11b38a13147dc463"
+  integrity sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==
 
-"@rollup/rollup-linux-loong64-gnu@4.62.2":
-  version "4.62.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz#e8aac6d549b377945e349882f199b7c8eb75ca38"
-  integrity sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==
+"@rollup/rollup-linux-loong64-gnu@4.62.4":
+  version "4.62.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.4.tgz#b403255546099a4300b17d976ee1776224c090e5"
+  integrity sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==
 
-"@rollup/rollup-linux-loong64-musl@4.62.2":
-  version "4.62.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz#6e2e44ea50310b3a582078a915e5feb879c820d4"
-  integrity sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==
+"@rollup/rollup-linux-loong64-musl@4.62.4":
+  version "4.62.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.4.tgz#5900610e59c66ee594539c6590566dbfda7082b1"
+  integrity sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==
 
-"@rollup/rollup-linux-ppc64-gnu@4.62.2":
-  version "4.62.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz#6898302da6d77a0537cde64b2b4c6b60659bd110"
-  integrity sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==
+"@rollup/rollup-linux-ppc64-gnu@4.62.4":
+  version "4.62.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.4.tgz#a892cc8b8414bc8ae0b267816b5e384e5d321ff2"
+  integrity sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==
 
-"@rollup/rollup-linux-ppc64-musl@4.62.2":
-  version "4.62.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz#333717c95dd5a66bef8f63e7ef8a9fd845fd18d0"
-  integrity sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==
+"@rollup/rollup-linux-ppc64-musl@4.62.4":
+  version "4.62.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.4.tgz#d9e60d568b7db4df2196fb2411b0c6918b2360cc"
+  integrity sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==
 
-"@rollup/rollup-linux-riscv64-gnu@4.62.2":
-  version "4.62.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz#81bc06ba380352004d01f4826eb7cdccefa05bad"
-  integrity sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==
+"@rollup/rollup-linux-riscv64-gnu@4.62.4":
+  version "4.62.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.4.tgz#5b3141ab43afbd9e50f639e562e94ed256d201cf"
+  integrity sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==
 
-"@rollup/rollup-linux-riscv64-musl@4.62.2":
-  version "4.62.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz#95a7cd39de21389ad6788a5284eaaa738e29ca4c"
-  integrity sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==
+"@rollup/rollup-linux-riscv64-musl@4.62.4":
+  version "4.62.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.4.tgz#b0fe751015bc3822f9004884eaba5e5cdfde7aa6"
+  integrity sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==
 
-"@rollup/rollup-linux-s390x-gnu@4.62.2":
-  version "4.62.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz#06e6db2ec1bc48b5374c7923ef83c2eb024b2452"
-  integrity sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==
+"@rollup/rollup-linux-s390x-gnu@4.62.4":
+  version "4.62.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.4.tgz#0cb323e850509e1b9bf6d241328a98b0e12e2916"
+  integrity sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==
 
-"@rollup/rollup-linux-x64-gnu@4.62.2":
-  version "4.62.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz#5dc818988285e09e88790c6462def72413df2da3"
-  integrity sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==
+"@rollup/rollup-linux-x64-gnu@4.62.4":
+  version "4.62.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.4.tgz#1e7470123e7a8ba8c160a7a043447472d5549542"
+  integrity sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==
 
-"@rollup/rollup-linux-x64-musl@4.62.2":
-  version "4.62.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz#2080f4a93349e9afd34be6fc1a37e01fc8bfc80f"
-  integrity sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==
+"@rollup/rollup-linux-x64-musl@4.62.4":
+  version "4.62.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.4.tgz#19df9a17d20ff3c17bd8e9cc2553563ae0aa0580"
+  integrity sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==
 
-"@rollup/rollup-openbsd-x64@4.62.2":
-  version "4.62.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz#21d64a8acb66221724b923e51af5333df1af044b"
-  integrity sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==
+"@rollup/rollup-openbsd-x64@4.62.4":
+  version "4.62.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.4.tgz#31c3ca1bd00e80f309a1d0cb8da4bdf59cb2dfa3"
+  integrity sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==
 
-"@rollup/rollup-openharmony-arm64@4.62.2":
-  version "4.62.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz#8e0fcd9d02141e337b4c5b5cff576cb9a76b1ba0"
-  integrity sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==
+"@rollup/rollup-openharmony-arm64@4.62.4":
+  version "4.62.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.4.tgz#84561a14381caecb7652e158d10551a5edc0a6fc"
+  integrity sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ==
 
-"@rollup/rollup-win32-arm64-msvc@4.62.2":
-  version "4.62.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz#bdb4cc4efd58efe808203347f0f5463f0ea16e52"
-  integrity sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==
+"@rollup/rollup-win32-arm64-msvc@4.62.4":
+  version "4.62.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.4.tgz#bc532edb20cd39c0b53eee2dfae43b52c2e3be1e"
+  integrity sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw==
 
-"@rollup/rollup-win32-ia32-msvc@4.62.2":
-  version "4.62.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz#dbaebde5afd24eae0eefe915d901632e7cb59860"
-  integrity sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==
+"@rollup/rollup-win32-ia32-msvc@4.62.4":
+  version "4.62.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.4.tgz#a6f51492976c9fc19801be298df2f76a3cbebf7a"
+  integrity sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ==
 
-"@rollup/rollup-win32-x64-gnu@4.62.2":
-  version "4.62.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz#84109e85fea5f8f1353499f96578fdc2a0e8b138"
-  integrity sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==
+"@rollup/rollup-win32-x64-gnu@4.62.4":
+  version "4.62.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.4.tgz#ae60710b0868b2fe731d9f7c341fa49cbf8e8629"
+  integrity sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw==
 
-"@rollup/rollup-win32-x64-msvc@4.62.2":
-  version "4.62.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz#3671ce3f9b928d5c01f879792d5c0b60ae14d4ad"
-  integrity sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==
+"@rollup/rollup-win32-x64-msvc@4.62.4":
+  version "4.62.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.4.tgz#c3a265fe0f9af4fb63bad86d3829386bc5da0026"
+  integrity sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q==
 
 "@sentry/browser-utils@10.58.0":
   version "10.58.0"
@@ -3437,7 +3448,7 @@
     "@adobe/react-spectrum-workflow" "2.3.5"
     "@swc/helpers" "^0.5.0"
 
-"@standard-schema/spec@^1.1.0":
+"@standard-schema/spec@^1.0.0", "@standard-schema/spec@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@standard-schema/spec/-/spec-1.1.0.tgz#a79b55dbaf8604812f52d140b2c9ab41bc150bb8"
   integrity sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==
@@ -4119,6 +4130,11 @@
   resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz#538b1e103bf8d9864e7b85cc96fa8d6fb6c40777"
   integrity sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==
 
+"@vercel/oidc@3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@vercel/oidc/-/oidc-3.1.0.tgz#066caee449b84079f33c7445fc862464fe10ec32"
+  integrity sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==
+
 "@vitejs/plugin-react@6.0.5":
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/@vitejs/plugin-react/-/plugin-react-6.0.5.tgz#48ee7951093ff9054952cff9d64e874355cde372"
@@ -4202,6 +4218,16 @@ acorn@^8.11.0, acorn@^8.15.0, acorn@^8.4.1:
   version "8.15.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.15.0.tgz#a360898bc415edaac46c8241f6383975b930b816"
   integrity sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==
+
+ai@5.0.238:
+  version "5.0.238"
+  resolved "https://registry.yarnpkg.com/ai/-/ai-5.0.238.tgz#dd3e4a14bc46185809650b3c66d5a22da7988935"
+  integrity sha512-gOXowDNXwAShfAUmtBxlvFNRxNWyrq1iPdsAd/IYy9TdQPtt08hHfXXk7JJzZVU6WZ9gM/KAxQdUfqqTpAE9VA==
+  dependencies:
+    "@ai-sdk/gateway" "2.0.135"
+    "@ai-sdk/provider" "2.0.3"
+    "@ai-sdk/provider-utils" "3.0.32"
+    "@opentelemetry/api" "1.9.0"
 
 ajv@^6.14.0:
   version "6.14.0"
@@ -5753,6 +5779,11 @@ events-universal@^1.0.0:
   integrity sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==
   dependencies:
     bare-events "^2.7.0"
+
+eventsource-parser@^3.0.6:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/eventsource-parser/-/eventsource-parser-3.1.1.tgz#b96cbb7dace4f3774f58a9e3b1ae9a4a524872e2"
+  integrity sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==
 
 execa@^5.0.0:
   version "5.1.1"
@@ -8383,7 +8414,7 @@ ms@^2.1.3:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
-nanoid@^3.3.17, nanoid@^3.3.8:
+nanoid@^3.3.17:
   version "3.3.18"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.18.tgz#f66a2de1199ffde0fcf21c8a5f13106b1c081913"
   integrity sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==
@@ -9603,37 +9634,38 @@ rolldown@~1.2.0, rolldown@~1.2.1:
     "@rolldown/binding-win32-x64-msvc" "1.2.3"
 
 rollup@^4.60.3:
-  version "4.62.2"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-4.62.2.tgz#d90fc4cb811f071303c890b779595634f35f9541"
-  integrity sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==
+  version "4.62.4"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-4.62.4.tgz#96d2e62070f0b0ac63424edd0c93a7fb864ef069"
+  integrity sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==
   dependencies:
     "@types/estree" "1.0.9"
   optionalDependencies:
-    "@rollup/rollup-android-arm-eabi" "4.62.2"
-    "@rollup/rollup-android-arm64" "4.62.2"
-    "@rollup/rollup-darwin-arm64" "4.62.2"
-    "@rollup/rollup-darwin-x64" "4.62.2"
-    "@rollup/rollup-freebsd-arm64" "4.62.2"
-    "@rollup/rollup-freebsd-x64" "4.62.2"
-    "@rollup/rollup-linux-arm-gnueabihf" "4.62.2"
-    "@rollup/rollup-linux-arm-musleabihf" "4.62.2"
-    "@rollup/rollup-linux-arm64-gnu" "4.62.2"
-    "@rollup/rollup-linux-arm64-musl" "4.62.2"
-    "@rollup/rollup-linux-loong64-gnu" "4.62.2"
-    "@rollup/rollup-linux-loong64-musl" "4.62.2"
-    "@rollup/rollup-linux-ppc64-gnu" "4.62.2"
-    "@rollup/rollup-linux-ppc64-musl" "4.62.2"
-    "@rollup/rollup-linux-riscv64-gnu" "4.62.2"
-    "@rollup/rollup-linux-riscv64-musl" "4.62.2"
-    "@rollup/rollup-linux-s390x-gnu" "4.62.2"
-    "@rollup/rollup-linux-x64-gnu" "4.62.2"
-    "@rollup/rollup-linux-x64-musl" "4.62.2"
-    "@rollup/rollup-openbsd-x64" "4.62.2"
-    "@rollup/rollup-openharmony-arm64" "4.62.2"
-    "@rollup/rollup-win32-arm64-msvc" "4.62.2"
-    "@rollup/rollup-win32-ia32-msvc" "4.62.2"
-    "@rollup/rollup-win32-x64-gnu" "4.62.2"
-    "@rollup/rollup-win32-x64-msvc" "4.62.2"
+    "@napi-rs/lzma-linux-x64-gnu" "1.5.1"
+    "@rollup/rollup-android-arm-eabi" "4.62.4"
+    "@rollup/rollup-android-arm64" "4.62.4"
+    "@rollup/rollup-darwin-arm64" "4.62.4"
+    "@rollup/rollup-darwin-x64" "4.62.4"
+    "@rollup/rollup-freebsd-arm64" "4.62.4"
+    "@rollup/rollup-freebsd-x64" "4.62.4"
+    "@rollup/rollup-linux-arm-gnueabihf" "4.62.4"
+    "@rollup/rollup-linux-arm-musleabihf" "4.62.4"
+    "@rollup/rollup-linux-arm64-gnu" "4.62.4"
+    "@rollup/rollup-linux-arm64-musl" "4.62.4"
+    "@rollup/rollup-linux-loong64-gnu" "4.62.4"
+    "@rollup/rollup-linux-loong64-musl" "4.62.4"
+    "@rollup/rollup-linux-ppc64-gnu" "4.62.4"
+    "@rollup/rollup-linux-ppc64-musl" "4.62.4"
+    "@rollup/rollup-linux-riscv64-gnu" "4.62.4"
+    "@rollup/rollup-linux-riscv64-musl" "4.62.4"
+    "@rollup/rollup-linux-s390x-gnu" "4.62.4"
+    "@rollup/rollup-linux-x64-gnu" "4.62.4"
+    "@rollup/rollup-linux-x64-musl" "4.62.4"
+    "@rollup/rollup-openbsd-x64" "4.62.4"
+    "@rollup/rollup-openharmony-arm64" "4.62.4"
+    "@rollup/rollup-win32-arm64-msvc" "4.62.4"
+    "@rollup/rollup-win32-ia32-msvc" "4.62.4"
+    "@rollup/rollup-win32-x64-gnu" "4.62.4"
+    "@rollup/rollup-win32-x64-msvc" "4.62.4"
     fsevents "~2.3.2"
 
 rsvp@^4.8.5:
@@ -9707,11 +9739,6 @@ scheduler@^0.27.0:
   version "0.27.0"
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.27.0.tgz#0c4ef82d67d1e5c1e359e8fc76d3a87f045fe5bd"
   integrity sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==
-
-secure-json-parse@^2.7.0:
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/secure-json-parse/-/secure-json-parse-2.7.0.tgz#5a5f9cd6ae47df23dba3151edd06855d47e09862"
-  integrity sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==
 
 semver@^6.3.0, semver@^6.3.1:
   version "6.3.1"
@@ -10655,7 +10682,7 @@ undici-types@~6.21.0:
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.21.0.tgz#691d00af3909be93a7faa13be61b3a5b50ef12cb"
   integrity sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==
 
-undici@^7.12.0, undici@^7.25.0, undici@^7.28.0:
+undici@^5.29.0, undici@^7.12.0, undici@^7.25.0, undici@^7.28.0:
   version "7.29.0"
   resolved "https://registry.yarnpkg.com/undici/-/undici-7.29.0.tgz#ae0f6f62e06e057a9cbb7b2b5fde2bb74f791b8f"
   integrity sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==
@@ -11278,11 +11305,6 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
-
-zod-to-json-schema@^3.24.1:
-  version "3.25.1"
-  resolved "https://registry.yarnpkg.com/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz#7f24962101a439ddade2bf1aeab3c3bfec7d84ba"
-  integrity sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==
 
 "zod-validation-error@^3.5.0 || ^4.0.0":
   version "4.0.2"


### PR DESCRIPTION
## Purpose

The chat client was pinned to version 4 of the Vercel AI SDK, whicht has since been superseded by threes major releases. Version 5 replaces the streaming wire format and the message model, so the frontend could not move forward without the backnd using the new protocol.

This upgrade putts the client on version 5 and leaves the server emitting a format that later majors keep unchanged, so the next upgrades becomes frontendwork only.

(No need to use real sse.)

## Proposal

- [ ] Emit the chat stream in the version 5 format, translating at the encoding      boundary so the agent code that produces events stays untouched
- [ ] Convert stored conversations to the new message model when they are read,      with no database migration and no backfill, so conversations written      before this change keep opening and replying correctly
- [ ] Accept both the old and the new request shapes, so a client that has not      reloaded yet keeps working
- [ ] Move the chat client to the new transport, message parts and streaming      callbacks, keeping attachments, sources, tool progress, titles, cooldown      and the carbon impact badge working as before
- [ ] Drop the unused text streaming protocol and its query parameter
- [ ] Cover the wire format with golden tests on the server and a test that      replays real server frames through the upgraded client

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Upgraded chat streaming to the Vercel AI SDK v5 UI message format.
  * Added structured support for tool calls, source URLs, files, reasoning, metadata, and transient events.
  * Preserved compatibility with previously stored messages through automatic conversion.
  * Chat attachments and image-skip details now appear directly in message parts.
  * Removed the activation code requirement while preserving historical activation records.
* **Bug Fixes**
  * Improved stream completion, keepalive, error handling, and tool-result delivery.
  * CO₂ impact information is now retained in message metadata.
  * Removed the unused text streaming protocol.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->