### PR TITLE
🔒️(ci) pin all actions and installs against supply-chain tampering

### DIFF
--- a/.github/workflows/conversations-frontend.yml
+++ b/.github/workflows/conversations-frontend.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - "*"
 
+permissions:
+  contents: read
+
 jobs:
 
   install-dependencies:
@@ -21,10 +24,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "22.x"
 
@@ -32,7 +37,7 @@ jobs:
         run: npm install -g yarn@1.22.22
 
       - name: Restore the frontend cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: "src/frontend/**/node_modules"
           key: front-node_modules-${{ hashFiles('src/frontend/**/yarn.lock') }}
@@ -46,10 +51,12 @@ jobs:
     needs: install-dependencies
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "22.x"
 
@@ -57,7 +64,7 @@ jobs:
         run: npm install -g yarn@1.22.22
 
       - name: Restore the frontend cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: "src/frontend/**/node_modules"
           key: front-node_modules-${{ hashFiles('src/frontend/**/yarn.lock') }}
@@ -72,10 +79,12 @@ jobs:
     timeout-minutes: 40
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "22.x"
 
@@ -83,7 +92,7 @@ jobs:
         run: npm install -g yarn@1.22.22
 
       - name: Restore the frontend cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: "src/frontend/**/node_modules"
           key: front-node_modules-${{ hashFiles('src/frontend/**/yarn.lock') }}
@@ -101,7 +110,7 @@ jobs:
       - name: Run e2e tests
         run: cd src/frontend/ && yarn e2e:test --project='chromium'
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
           name: playwright-chromium-report
@@ -114,10 +123,12 @@ jobs:
     timeout-minutes: 40
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "22.x"
 
@@ -125,7 +136,7 @@ jobs:
         run: npm install -g yarn@1.22.22
 
       - name: Restore the frontend cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: "src/frontend/**/node_modules"
           key: front-node_modules-${{ hashFiles('src/frontend/**/yarn.lock') }}
@@ -143,7 +154,7 @@ jobs:
       - name: Run e2e tests
         run: cd src/frontend/ && yarn e2e:test --project=firefox --project=webkit
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
           name: playwright-other-report

--- a/.github/workflows/conversations-frontend.yml
+++ b/.github/workflows/conversations-frontend.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - "*"
 
+permissions:
+  contents: read
+
 jobs:
 
   install-dependencies:
@@ -21,18 +24,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "22.x"
 
       - name: Install yarn
-        run: npm install -g yarn@1.22.22
+        # Exact version pin, scripts disabled; corepack pinning is separate.
+        run: npm install -g yarn@1.22.22 --ignore-scripts # zizmor: ignore[adhoc-packages]
 
       - name: Restore the frontend cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: "src/frontend/**/node_modules"
           key: front-node_modules-${{ hashFiles('src/frontend/**/yarn.lock') }}
@@ -46,18 +52,21 @@ jobs:
     needs: install-dependencies
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "22.x"
 
       - name: Install yarn
-        run: npm install -g yarn@1.22.22
+        # Exact version pin, scripts disabled; corepack pinning is separate.
+        run: npm install -g yarn@1.22.22 --ignore-scripts # zizmor: ignore[adhoc-packages]
 
       - name: Restore the frontend cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: "src/frontend/**/node_modules"
           key: front-node_modules-${{ hashFiles('src/frontend/**/yarn.lock') }}
@@ -72,18 +81,21 @@ jobs:
     timeout-minutes: 40
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "22.x"
 
       - name: Install yarn
-        run: npm install -g yarn@1.22.22
+        # Exact version pin, scripts disabled; corepack pinning is separate.
+        run: npm install -g yarn@1.22.22 --ignore-scripts # zizmor: ignore[adhoc-packages]
 
       - name: Restore the frontend cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: "src/frontend/**/node_modules"
           key: front-node_modules-${{ hashFiles('src/frontend/**/yarn.lock') }}
@@ -101,7 +113,7 @@ jobs:
       - name: Run e2e tests
         run: cd src/frontend/ && yarn e2e:test --project='chromium'
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
           name: playwright-chromium-report
@@ -114,18 +126,21 @@ jobs:
     timeout-minutes: 40
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "22.x"
 
       - name: Install yarn
-        run: npm install -g yarn@1.22.22
+        # Exact version pin, scripts disabled; corepack pinning is separate.
+        run: npm install -g yarn@1.22.22 --ignore-scripts # zizmor: ignore[adhoc-packages]
 
       - name: Restore the frontend cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: "src/frontend/**/node_modules"
           key: front-node_modules-${{ hashFiles('src/frontend/**/yarn.lock') }}
@@ -143,7 +158,7 @@ jobs:
       - name: Run e2e tests
         run: cd src/frontend/ && yarn e2e:test --project=firefox --project=webkit
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
           name: playwright-other-report

--- a/.github/workflows/conversations.yml
+++ b/.github/workflows/conversations.yml
@@ -8,6 +8,13 @@ on:
     branches:
       - "*"
 
+permissions:
+  contents: read
+
+env:
+  UV_LOCKED: "1" # fail if uv.lock is stale instead of re-resolving from PyPI
+  UV_NO_SYNC: "1" # `uv run` uses the venv as-is; never installs implicitly
+
 jobs:
   install-dependencies:
     uses: ./.github/workflows/dependencies.yml
@@ -19,8 +26,9 @@ jobs:
     if: github.event_name == 'pull_request' # Makes sense only for pull requests
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
+          persist-credentials: false
           fetch-depth: 0
       - name: show
         run: git log
@@ -34,7 +42,7 @@ jobs:
           ! git log | grep 'fixup!'
       - name: Install gitlint
         if: always()
-        run: pip install --user requests gitlint
+        run: pip install --user requests==2.34.2 gitlint==0.19.1
       - name: Lint commit messages added to main
         if: always()
         run: ~/.local/bin/gitlint --commits origin/${{ github.event.pull_request.base.ref }}..HEAD
@@ -46,8 +54,9 @@ jobs:
       github.event_name == 'pull_request'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
+          persist-credentials: false
           fetch-depth: 50
       - name: Check that the CHANGELOG has been modified in the current branch
         run: git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.event.after }} | grep 'CHANGELOG.md'
@@ -56,7 +65,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
       - name: Check CHANGELOG max line length
         run: |
           max_line_length=$(cat CHANGELOG.md | grep -Ev "^\[.*\]: https://github.com" | wc -L)
@@ -70,9 +81,11 @@ jobs:
     if: github.event_name == 'pull_request'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
       - name: Install codespell
-        run: pip install --user codespell
+        run: pip install --user codespell==2.4.3
       - name: Check for typos
         run: codespell
 
@@ -83,9 +96,11 @@ jobs:
         working-directory: src/backend
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
       - name: Install Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.13"
       - name: Install system dependencies for lxml
@@ -93,7 +108,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libxml2-dev libxslt-dev
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
       - name: Install the project
         run: uv sync --locked --all-extras
 
@@ -114,7 +129,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:16
+        image: postgres:16@sha256:e17e86066e5ef83e0952a9347f5c792b7ece00972e2aa787a6986f471b3dd3d5
         env:
           POSTGRES_DB: conversations
           POSTGRES_USER: dinum
@@ -137,7 +152,9 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
 
       - name: Create writable /data
         run: |
@@ -145,7 +162,7 @@ jobs:
           sudo mkdir -p /data/static
 
       - name: Restore the mail templates
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         id: mail-templates
         with:
           path: "src/backend/core/templates/mail"
@@ -154,18 +171,21 @@ jobs:
 
       - name: Start MinIO
         run: |
-          docker pull minio/minio
+          docker pull minio/minio@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e
           docker run -d --name minio \
             -p 9000:9000 \
             -e "MINIO_ACCESS_KEY=conversations" \
             -e "MINIO_SECRET_KEY=password" \
             -v /data/media:/data \
-            minio/minio server --console-address :9001 /data
+            minio/minio@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e server --console-address :9001 /data
 
       # Tool to wait for a service to be ready
       - name: Install Dockerize
         run: |
-          curl -sSL https://github.com/jwilder/dockerize/releases/download/v0.8.0/dockerize-linux-amd64-v0.8.0.tar.gz | sudo tar -C /usr/local/bin -xzv
+          curl -sSL -o dockerize.tar.gz https://github.com/jwilder/dockerize/releases/download/v0.8.0/dockerize-linux-amd64-v0.8.0.tar.gz
+          echo "56c8acdd6ddcc1e3196f3d94a83ad3332b70d686846c909e08179b19e05fe5cd  dockerize.tar.gz" | sha256sum -c -
+          sudo tar -C /usr/local/bin -xzvf dockerize.tar.gz
+          rm dockerize.tar.gz
 
       - name: Wait for MinIO to be ready
         run: |
@@ -173,15 +193,14 @@ jobs:
 
       - name: Configure MinIO
         run: |
-          MINIO=$(docker ps | grep minio/minio | sed -E 's/.*\s+([a-zA-Z0-9_-]+)$/\1/')
-          docker exec ${MINIO} sh -c \
+          docker exec minio sh -c \
             "mc alias set conversations http://localhost:9000 conversations password && \
             mc alias ls && \
             mc mb conversations/conversations-media-storage && \
             mc version enable conversations/conversations-media-storage"
 
       - name: Install Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.13"
       - name: Install system dependencies for lxml
@@ -189,7 +208,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libxml2-dev libxslt-dev
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
       - name: Install the dependencies
         run: uv sync --locked --all-extras
 
@@ -212,7 +231,7 @@ jobs:
     steps:
       - name: Run Trivy analysis for critical vulnerabilities
         # We use main branch while we might still iterate on the action
-        uses: numerique-gouv/action-trivy-cache/security-trivy-critical@main
+        uses: numerique-gouv/action-trivy-cache/security-trivy-critical@d6e94cfb488f03a0b3e8b8739aad94e74d24d8da # main as of 2026-08-20
         with:
           skip-files: src/mail/yarn.lock
 
@@ -223,6 +242,6 @@ jobs:
     steps:
       - name: Run Trivy analysis for vulnerabilities
         # We use main branch while we might still iterate on the action
-        uses: numerique-gouv/action-trivy-cache/security-trivy@main
+        uses: numerique-gouv/action-trivy-cache/security-trivy@d6e94cfb488f03a0b3e8b8739aad94e74d24d8da # main as of 2026-08-20
         with:
           skip-files: src/mail/yarn.lock

--- a/.github/workflows/conversations.yml
+++ b/.github/workflows/conversations.yml
@@ -8,6 +8,13 @@ on:
     branches:
       - "*"
 
+permissions:
+  contents: read
+
+env:
+  UV_LOCKED: "1" # fail if uv.lock is stale instead of re-resolving from PyPI
+  UV_NO_SYNC: "1" # `uv run` uses the venv as-is; never installs implicitly
+
 jobs:
   install-dependencies:
     uses: ./.github/workflows/dependencies.yml
@@ -19,25 +26,33 @@ jobs:
     if: github.event_name == 'pull_request' # Makes sense only for pull requests
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
+          persist-credentials: false
           fetch-depth: 0
       - name: show
         run: git log
       - name: Enforce absence of print statements in code
         if: always()
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
-          ! git diff origin/${{ github.event.pull_request.base.ref }}..HEAD -- . ':(exclude)**/conversations.yml' | grep "print("
+          ! git diff "origin/${BASE_REF}..HEAD" -- . ':(exclude)**/conversations.yml' | grep "print("
       - name: Check absence of fixup commits
         if: always()
         run: |
           ! git log | grep 'fixup!'
       - name: Install gitlint
         if: always()
-        run: pip install --user requests gitlint
+        # Wheel-only except sh, which gitlint pins to 1.14.3 - the only
+        # version with no wheel, so its setup script is the one that still runs.
+        run: |
+          pip install --user --only-binary :all: --no-binary sh requests==2.34.2 gitlint==0.19.1
       - name: Lint commit messages added to main
         if: always()
-        run: ~/.local/bin/gitlint --commits origin/${{ github.event.pull_request.base.ref }}..HEAD
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: ~/.local/bin/gitlint --commits "origin/${BASE_REF}..HEAD"
 
   check-changelog:
     runs-on: ubuntu-latest
@@ -46,17 +61,23 @@ jobs:
       github.event_name == 'pull_request'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
+          persist-credentials: false
           fetch-depth: 50
       - name: Check that the CHANGELOG has been modified in the current branch
-        run: git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.event.after }} | grep 'CHANGELOG.md'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.after }}
+        run: git diff --name-only "${BASE_SHA}" "${HEAD_SHA}" | grep 'CHANGELOG.md'
 
   lint-changelog:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
       - name: Check CHANGELOG max line length
         run: |
           max_line_length=$(cat CHANGELOG.md | grep -Ev "^\[.*\]: https://github.com" | wc -L)
@@ -70,9 +91,12 @@ jobs:
     if: github.event_name == 'pull_request'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
       - name: Install codespell
-        run: pip install --user codespell
+        run: |
+          pip install --user --only-binary :all: codespell==2.4.3
       - name: Check for typos
         run: codespell
 
@@ -83,17 +107,19 @@ jobs:
         working-directory: src/backend
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
-      - name: Install Python
-        uses: actions/setup-python@v6
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
-          python-version: "3.13"
+          persist-credentials: false
+      - name: Install Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version-file: "src/backend/pyproject.toml"
       - name: Install system dependencies for lxml
         run: |
           sudo apt-get update
           sudo apt-get install -y libxml2-dev libxslt-dev
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
       - name: Install the project
         run: uv sync --locked --all-extras
 
@@ -114,7 +140,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:16
+        image: postgres:16@sha256:e17e86066e5ef83e0952a9347f5c792b7ece00972e2aa787a6986f471b3dd3d5
         env:
           POSTGRES_DB: conversations
           POSTGRES_USER: dinum
@@ -137,7 +163,9 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
 
       - name: Create writable /data
         run: |
@@ -145,7 +173,7 @@ jobs:
           sudo mkdir -p /data/static
 
       - name: Restore the mail templates
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         id: mail-templates
         with:
           path: "src/backend/core/templates/mail"
@@ -153,19 +181,24 @@ jobs:
           fail-on-cache-miss: true
 
       - name: Start MinIO
+        env:
+          MINIO_IMAGE: minio/minio@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e
         run: |
-          docker pull minio/minio
+          docker pull "${MINIO_IMAGE}"
           docker run -d --name minio \
             -p 9000:9000 \
             -e "MINIO_ACCESS_KEY=conversations" \
             -e "MINIO_SECRET_KEY=password" \
             -v /data/media:/data \
-            minio/minio server --console-address :9001 /data
+            "${MINIO_IMAGE}" server --console-address :9001 /data
 
       # Tool to wait for a service to be ready
       - name: Install Dockerize
         run: |
-          curl -sSL https://github.com/jwilder/dockerize/releases/download/v0.8.0/dockerize-linux-amd64-v0.8.0.tar.gz | sudo tar -C /usr/local/bin -xzv
+          curl -sSL -o dockerize.tar.gz https://github.com/jwilder/dockerize/releases/download/v0.8.0/dockerize-linux-amd64-v0.8.0.tar.gz
+          echo "56c8acdd6ddcc1e3196f3d94a83ad3332b70d686846c909e08179b19e05fe5cd  dockerize.tar.gz" | sha256sum -c -
+          sudo tar -C /usr/local/bin -xzvf dockerize.tar.gz
+          rm dockerize.tar.gz
 
       - name: Wait for MinIO to be ready
         run: |
@@ -173,23 +206,22 @@ jobs:
 
       - name: Configure MinIO
         run: |
-          MINIO=$(docker ps | grep minio/minio | sed -E 's/.*\s+([a-zA-Z0-9_-]+)$/\1/')
-          docker exec ${MINIO} sh -c \
+          docker exec minio sh -c \
             "mc alias set conversations http://localhost:9000 conversations password && \
             mc alias ls && \
             mc mb conversations/conversations-media-storage && \
             mc version enable conversations/conversations-media-storage"
 
       - name: Install Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
-          python-version: "3.13"
+          python-version-file: "src/backend/pyproject.toml"
       - name: Install system dependencies for lxml
         run: |
           sudo apt-get update
           sudo apt-get install -y libxml2-dev libxslt-dev
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
       - name: Install the dependencies
         run: uv sync --locked --all-extras
 
@@ -211,8 +243,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run Trivy analysis for critical vulnerabilities
-        # We use main branch while we might still iterate on the action
-        uses: numerique-gouv/action-trivy-cache/security-trivy-critical@main
+        # Tracks the action's main branch; the digest is bumped automatically.
+        uses: numerique-gouv/action-trivy-cache/security-trivy-critical@d6e94cfb488f03a0b3e8b8739aad94e74d24d8da # main
         with:
           skip-files: src/mail/yarn.lock
 
@@ -222,7 +254,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run Trivy analysis for vulnerabilities
-        # We use main branch while we might still iterate on the action
-        uses: numerique-gouv/action-trivy-cache/security-trivy@main
+        # Tracks the action's main branch; the digest is bumped automatically.
+        uses: numerique-gouv/action-trivy-cache/security-trivy@d6e94cfb488f03a0b3e8b8739aad94e74d24d8da # main
         with:
           skip-files: src/mail/yarn.lock

--- a/.github/workflows/crowdin_download.yml
+++ b/.github/workflows/crowdin_download.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - 'release/**'
 
+permissions:
+  contents: read
+
 jobs:
   install-dependencies:
     uses: ./.github/workflows/dependencies.yml
@@ -20,7 +23,9 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
       - name: Create empty source files
         run: |
           touch src/backend/locale/django.pot
@@ -28,7 +33,7 @@ jobs:
           touch src/frontend/packages/i18n/locales/conversations/translations-crowdin.json
       # crowdin workflow
       - name: crowdin action
-        uses: crowdin/github-action@v2
+        uses: crowdin/github-action@8f01d54f70f1713ee3f09d82c2bbb2daeac28689 # v2.17.1
         with:
           config: crowdin/config.yml
           upload_sources: false
@@ -47,14 +52,17 @@ jobs:
 
           CROWDIN_BASE_PATH: "../src/"
       # frontend i18n
+      # Cache entries are branch-scoped and this workflow only runs on release
+      # branches, so poisoning the cache needs push access to one of them.
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0 # zizmor: ignore[cache-poisoning]
         with:
           node-version: "22.x"
       - name: Install yarn
-        run: npm install -g yarn@1.22.22
+        # Exact version pin, scripts disabled; corepack pinning is separate.
+        run: npm install -g yarn@1.22.22 --ignore-scripts # zizmor: ignore[adhoc-packages]
       - name: Restore the frontend cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0 # zizmor: ignore[cache-poisoning]
         with:
           path: "src/frontend/**/node_modules"
           key: front-node_modules-${{ hashFiles('src/frontend/**/yarn.lock') }}
@@ -64,7 +72,7 @@ jobs:
         run: yarn i18n:deploy
       # Create a new PR
       - name: Create a new Pull Request with new translated strings
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
         with:
           commit-message: |
             🌐(i18n) update translated strings

--- a/.github/workflows/crowdin_download.yml
+++ b/.github/workflows/crowdin_download.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - 'release/**'
 
+permissions:
+  contents: read
+
 jobs:
   install-dependencies:
     uses: ./.github/workflows/dependencies.yml
@@ -20,7 +23,9 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
       - name: Create empty source files
         run: |
           touch src/backend/locale/django.pot
@@ -28,7 +33,7 @@ jobs:
           touch src/frontend/packages/i18n/locales/conversations/translations-crowdin.json
       # crowdin workflow
       - name: crowdin action
-        uses: crowdin/github-action@v2
+        uses: crowdin/github-action@8f01d54f70f1713ee3f09d82c2bbb2daeac28689 # v2.17.1
         with:
           config: crowdin/config.yml
           upload_sources: false
@@ -48,13 +53,13 @@ jobs:
           CROWDIN_BASE_PATH: "../src/"
       # frontend i18n
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "22.x"
       - name: Install yarn
         run: npm install -g yarn@1.22.22
       - name: Restore the frontend cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: "src/frontend/**/node_modules"
           key: front-node_modules-${{ hashFiles('src/frontend/**/yarn.lock') }}
@@ -64,7 +69,7 @@ jobs:
         run: yarn i18n:deploy
       # Create a new PR
       - name: Create a new Pull Request with new translated strings
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
         with:
           commit-message: |
             🌐(i18n) update translated strings

--- a/.github/workflows/crowdin_upload.yml
+++ b/.github/workflows/crowdin_upload.yml
@@ -6,6 +6,13 @@ on:
     branches: 
       - main
 
+permissions:
+  contents: read
+
+env:
+  UV_LOCKED: "1" # fail if uv.lock is stale instead of re-resolving from PyPI
+  UV_NO_SYNC: "1" # `uv run` uses the venv as-is; never installs implicitly
+
 jobs:
   install-dependencies:
     uses: ./.github/workflows/dependencies.yml
@@ -20,19 +27,21 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
       # Backend i18n
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version-file: "src/backend/pyproject.toml"
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
       - name: Install the project
         run: uv sync --locked --all-extras
         working-directory: src/backend
       - name: Restore the mail templates
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         id: mail-templates
         with:
           path: "src/backend/core/templates/mail"
@@ -48,13 +57,13 @@ jobs:
           DJANGO_CONFIGURATION=Build uv run python manage.py makemessages -a --keep-pot
       # frontend i18n
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "22.x"
       - name: Install yarn
         run: npm install -g yarn@1.22.22
       - name: Restore the frontend cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: "src/frontend/**/node_modules"
           key: front-node_modules-${{ hashFiles('src/frontend/**/yarn.lock') }}
@@ -64,7 +73,7 @@ jobs:
         run: yarn i18n:extract
       # crowdin workflow
       - name: crowdin action
-        uses: crowdin/github-action@v2
+        uses: crowdin/github-action@8f01d54f70f1713ee3f09d82c2bbb2daeac28689 # v2.17.1
         with:
           config: crowdin/config.yml
           upload_sources: true

--- a/.github/workflows/crowdin_upload.yml
+++ b/.github/workflows/crowdin_upload.yml
@@ -6,6 +6,13 @@ on:
     branches: 
       - main
 
+permissions:
+  contents: read
+
+env:
+  UV_LOCKED: "1" # fail if uv.lock is stale instead of re-resolving from PyPI
+  UV_NO_SYNC: "1" # `uv run` uses the venv as-is; never installs implicitly
+
 jobs:
   install-dependencies:
     uses: ./.github/workflows/dependencies.yml
@@ -20,19 +27,21 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
       # Backend i18n
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version-file: "src/backend/pyproject.toml"
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
       - name: Install the project
         run: uv sync --locked --all-extras
         working-directory: src/backend
       - name: Restore the mail templates
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         id: mail-templates
         with:
           path: "src/backend/core/templates/mail"
@@ -48,13 +57,14 @@ jobs:
           DJANGO_CONFIGURATION=Build uv run python manage.py makemessages -a --keep-pot
       # frontend i18n
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "22.x"
       - name: Install yarn
-        run: npm install -g yarn@1.22.22
+        # Exact version pin, scripts disabled; corepack pinning is separate.
+        run: npm install -g yarn@1.22.22 --ignore-scripts # zizmor: ignore[adhoc-packages]
       - name: Restore the frontend cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: "src/frontend/**/node_modules"
           key: front-node_modules-${{ hashFiles('src/frontend/**/yarn.lock') }}
@@ -64,7 +74,7 @@ jobs:
         run: yarn i18n:extract
       # crowdin workflow
       - name: crowdin action
-        uses: crowdin/github-action@v2
+        uses: crowdin/github-action@8f01d54f70f1713ee3f09d82c2bbb2daeac28689 # v2.17.1
         with:
           config: crowdin/config.yml
           upload_sources: true

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -14,16 +14,21 @@ on:
         type: boolean
         default: false
 
+permissions:
+  contents: read
+
 jobs:
   front-dependencies-installation:
     if: ${{ inputs.with-front-dependencies-installation == true }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
 
       - name: Restore the frontend cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         id: front-node_modules
         with:
           path: "src/frontend/**/node_modules"
@@ -31,13 +36,14 @@ jobs:
 
       - name: Setup Node.js
         if: steps.front-node_modules.outputs.cache-hit != 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ inputs.node_version }}
 
       - name: Install yarn
         if: steps.front-node_modules.outputs.cache-hit != 'true'
-        run: npm install -g yarn@1.22.22
+        # Exact version pin, scripts disabled; corepack pinning is separate.
+        run: npm install -g yarn@1.22.22 --ignore-scripts # zizmor: ignore[adhoc-packages]
 
       - name: Install dependencies
         if: steps.front-node_modules.outputs.cache-hit != 'true'
@@ -45,7 +51,7 @@ jobs:
 
       - name: Cache install frontend
         if: steps.front-node_modules.outputs.cache-hit != 'true'
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: "src/frontend/**/node_modules"
           key: front-node_modules-${{ hashFiles('src/frontend/**/yarn.lock') }}
@@ -58,10 +64,12 @@ jobs:
         working-directory: src/mail
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
 
       - name: Restore the mail templates
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         id: mail-templates
         with:
           path: "src/backend/core/templates/mail"
@@ -69,13 +77,14 @@ jobs:
 
       - name: Setup Node.js
         if: steps.mail-templates.outputs.cache-hit != 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ inputs.node_version }}
 
       - name: Install yarn
         if: steps.mail-templates.outputs.cache-hit != 'true'
-        run: npm install -g yarn@1.22.22
+        # Exact version pin, scripts disabled; corepack pinning is separate.
+        run: npm install -g yarn@1.22.22 --ignore-scripts # zizmor: ignore[adhoc-packages]
 
       - name: Install node dependencies
         if: steps.mail-templates.outputs.cache-hit != 'true'
@@ -87,7 +96,7 @@ jobs:
 
       - name: Cache mail templates
         if: steps.mail-templates.outputs.cache-hit != 'true'
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: "src/backend/core/templates/mail"
           key: mail-templates-${{ hashFiles('src/mail/mjml') }}

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -14,16 +14,21 @@ on:
         type: boolean
         default: false
 
+permissions:
+  contents: read
+
 jobs:
   front-dependencies-installation:
     if: ${{ inputs.with-front-dependencies-installation == true }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
 
       - name: Restore the frontend cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         id: front-node_modules
         with:
           path: "src/frontend/**/node_modules"
@@ -31,7 +36,7 @@ jobs:
 
       - name: Setup Node.js
         if: steps.front-node_modules.outputs.cache-hit != 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ inputs.node_version }}
 
@@ -45,7 +50,7 @@ jobs:
 
       - name: Cache install frontend
         if: steps.front-node_modules.outputs.cache-hit != 'true'
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: "src/frontend/**/node_modules"
           key: front-node_modules-${{ hashFiles('src/frontend/**/yarn.lock') }}
@@ -58,10 +63,12 @@ jobs:
         working-directory: src/mail
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
 
       - name: Restore the mail templates
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         id: mail-templates
         with:
           path: "src/backend/core/templates/mail"
@@ -69,7 +76,7 @@ jobs:
 
       - name: Setup Node.js
         if: steps.mail-templates.outputs.cache-hit != 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ inputs.node_version }}
 
@@ -87,7 +94,7 @@ jobs:
 
       - name: Cache mail templates
         if: steps.mail-templates.outputs.cache-hit != 'true'
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: "src/backend/core/templates/mail"
           key: mail-templates-${{ hashFiles('src/mail/mjml') }}

--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -13,6 +13,9 @@ on:
       - 'main'
       - 'ci/trivy-fails'
 
+permissions:
+  contents: read
+
 env:
   DOCKER_USER: 1001:127
 
@@ -22,33 +25,35 @@ jobs:
     steps:
       -
         name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
       -
         name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
         with:
           images: lasuite/conversations-backend
       -
         name: Login to DockerHub
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}
       -
         name: Run trivy scan
-        uses: numerique-gouv/action-trivy-cache@main
+        uses: numerique-gouv/action-trivy-cache@d6e94cfb488f03a0b3e8b8739aad94e74d24d8da # main
         with:
           docker-build-args: '--target backend-production -f Dockerfile'
           docker-image-name: 'docker.io/lasuite/conversations-backend:${{ github.sha }}'
       -
         name: Build and push
         if: always()
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           target: backend-production
@@ -62,33 +67,35 @@ jobs:
     steps:
       -
         name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
       -
         name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
         with:
           images: lasuite/conversations-frontend
       -
         name: Login to DockerHub
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}
       -
         name: Run trivy scan
-        uses: numerique-gouv/action-trivy-cache@main
+        uses: numerique-gouv/action-trivy-cache@d6e94cfb488f03a0b3e8b8739aad94e74d24d8da # main
         with:
           docker-build-args: '-f src/frontend/Dockerfile --target frontend-production'
           docker-image-name: 'docker.io/lasuite/conversations-frontend:${{ github.sha }}'
       -
         name: Build and push
         if: always()
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           file: ./src/frontend/Dockerfile
@@ -106,7 +113,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name != 'pull_request'
     steps:
-      - uses: numerique-gouv/action-argocd-webhook-notification@main
+      - uses: numerique-gouv/action-argocd-webhook-notification@cac2ee67896eb13e84e804f60c4271370424eaa8 # main
         id: notify
         with:
           deployment_repo_path: "${{ secrets.DEPLOYMENT_REPO_URL }}"

--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -13,6 +13,9 @@ on:
       - 'main'
       - 'ci/trivy-fails'
 
+permissions:
+  contents: read
+
 env:
   DOCKER_USER: 1001:127
 
@@ -22,33 +25,35 @@ jobs:
     steps:
       -
         name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
       -
         name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
         with:
           images: lasuite/conversations-backend
       -
         name: Login to DockerHub
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}
       -
         name: Run trivy scan
-        uses: numerique-gouv/action-trivy-cache@main
+        uses: numerique-gouv/action-trivy-cache@d6e94cfb488f03a0b3e8b8739aad94e74d24d8da # main as of 2026-08-20
         with:
           docker-build-args: '--target backend-production -f Dockerfile'
           docker-image-name: 'docker.io/lasuite/conversations-backend:${{ github.sha }}'
       -
         name: Build and push
         if: always()
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           target: backend-production
@@ -62,33 +67,35 @@ jobs:
     steps:
       -
         name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
       -
         name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
         with:
           images: lasuite/conversations-frontend
       -
         name: Login to DockerHub
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}
       -
         name: Run trivy scan
-        uses: numerique-gouv/action-trivy-cache@main
+        uses: numerique-gouv/action-trivy-cache@d6e94cfb488f03a0b3e8b8739aad94e74d24d8da # main as of 2026-08-20
         with:
           docker-build-args: '-f src/frontend/Dockerfile --target frontend-production'
           docker-image-name: 'docker.io/lasuite/conversations-frontend:${{ github.sha }}'
       -
         name: Build and push
         if: always()
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           file: ./src/frontend/Dockerfile
@@ -106,7 +113,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name != 'pull_request'
     steps:
-      - uses: numerique-gouv/action-argocd-webhook-notification@main
+      - uses: numerique-gouv/action-argocd-webhook-notification@cac2ee67896eb13e84e804f60c4271370424eaa8 # main as of 2026-08-20
         id: notify
         with:
           deployment_repo_path: "${{ secrets.DEPLOYMENT_REPO_URL }}"

--- a/.github/workflows/helmfile-linter.yaml
+++ b/.github/workflows/helmfile-linter.yaml
@@ -7,15 +7,20 @@ on:
     branches:
       - 'main'
 
+permissions:
+  contents: read
+
 jobs:
   helmfile-lint:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/helmfile/helmfile:v0.171.0
+      image: ghcr.io/helmfile/helmfile:v0.171.0@sha256:1b1d83b5db69c3bb9e8f6855a8076bdc18c816332af1208c43b4e294a74dd33f
     steps:
     -
       name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      with:
+        persist-credentials: false
     -
       name: Helmfile lint
       shell: bash

--- a/.github/workflows/release-helm-chart.yaml
+++ b/.github/workflows/release-helm-chart.yaml
@@ -6,6 +6,9 @@ on:
     paths:
       - src/helm/conversations/**
 
+permissions:
+  contents: read
+
 jobs:
   release:
     # depending on default permission settings for your org (contents being read-only or read-write for workloads), you will have to add permissions
@@ -15,20 +18,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Cleanup
         run: rm -rf ./src/helm/extra
 
       - name: Install Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Publish Helm charts
-        uses: numerique-gouv/helm-gh-pages@add-overwrite-option
+        uses: numerique-gouv/helm-gh-pages@2cf477ae49d7c70037ceb1685803f4f7bad9b981 # add-overwrite-option
         with:
           charts_dir: ./src/helm
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-helm-chart.yaml
+++ b/.github/workflows/release-helm-chart.yaml
@@ -6,6 +6,9 @@ on:
     paths:
       - src/helm/conversations/**
 
+permissions:
+  contents: read
+
 jobs:
   release:
     # depending on default permission settings for your org (contents being read-only or read-write for workloads), you will have to add permissions
@@ -15,20 +18,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Cleanup
         run: rm -rf ./src/helm/extra
 
       - name: Install Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Publish Helm charts
-        uses: numerique-gouv/helm-gh-pages@add-overwrite-option
+        uses: numerique-gouv/helm-gh-pages@2cf477ae49d7c70037ceb1685803f4f7bad9b981 # add-overwrite-option as of 2026-08-20
         with:
           charts_dir: ./src/helm
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to
 - 💄(front) correct icon Docs button
 - ♻️(back) use httpx as the single HTTP client for outbound calls
 - ⬆️(back) update django, pypdf and pydantic-settings
+- 🔒️(ci) pin CI actions and installed packages to immutable versions
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to
 - 💄(front) correct icon Docs button
 - ♻️(back) use httpx as the single HTTP client for outbound calls
 - ⬆️(back) update django, pypdf, sqlparse and pydantic-settings
+- 🔒️(ci) pin CI actions and installed packages to immutable versions
 
 ### Removed
 

--- a/renovate.json
+++ b/renovate.json
@@ -2,13 +2,9 @@
   "extends": ["github>numerique-gouv/renovate-configuration"],
   "dependencyDashboard": true,
   "labels": ["dependencies", "noChangeLog", "automated"],
+  "prConcurrentLimit": 4,
+  "branchConcurrentLimit": 4,
   "packageRules": [
-    {
-      "enabled": false,
-      "groupName": "ignored python dependencies",
-      "matchManagers": ["pep621"],
-      "matchPackageNames": []
-    },
     {
       "groupName": "allowed redis versions",
       "matchManagers": ["pep621"],
@@ -22,27 +18,13 @@
       "allowedVersions": "==0.0.2"
     },
     {
-      "groupName": "ignore recent lxml versions not supported by htmldate==1.9.3",
-      "matchManagers": ["pep621"],
-      "matchPackageNames": ["lxml"],
-      "allowedVersions": "<6"
-    },
-    {
-      "groupName": "ignore recent pylint versions not supported by pylint-django",
-      "matchManagers": ["pep621"],
-      "matchPackageNames": ["pylint"],
-      "allowedVersions": "<4"
-    },
-    {
       "enabled": false,
       "groupName": "ignored js dependencies",
       "matchManagers": ["npm"],
       "matchPackageNames": [
         "eslint",
         "fetch-mock",
-        "node",
-        "node-fetch",
-        "workbox-webpack-plugin"
+        "node"
       ]
     },
     {

--- a/src/frontend/.yarnrc
+++ b/src/frontend/.yarnrc
@@ -1,1 +1,2 @@
 ignore-scripts true
+--install.frozen-lockfile true

--- a/src/frontend/.yarnrc
+++ b/src/frontend/.yarnrc
@@ -1,1 +1,4 @@
 ignore-scripts true
+# Applies to every install, including a bare `yarn`: change dependencies with
+# `yarn add`/`yarn upgrade` rather than editing package.json by hand.
+--install.frozen-lockfile true

--- a/src/mail/.yarnrc
+++ b/src/mail/.yarnrc
@@ -1,1 +1,2 @@
 ignore-scripts true
+--install.frozen-lockfile true

--- a/src/mail/.yarnrc
+++ b/src/mail/.yarnrc
@@ -1,1 +1,4 @@
 ignore-scripts true
+# Applies to every install, including a bare `yarn`: change dependencies with
+# `yarn add`/`yarn upgrade` rather than editing package.json by hand.
+--install.frozen-lockfile true


### PR DESCRIPTION
## Purpose

Our CI pipelines resolved almost everything they executed through mutable references: actions pointed at branch names and floating tags, container images at rolling tags, and several packages were installed with no version at all. Whoever controls one of those references can move it, and most of them sit outside our organisation. A moved reference means attacker-chosen code running inside our pipelines, alongside a repository token and our registry and translation credentials.

This pull request removes that exposure. Everything CI executes is now resolved to an exact, immutable artifact, and the permissions available to that code are cut back to what each job actually needs.

The change is mechanical and touches no application code. A workflow security scanner that reported 118 findings against these files now reports none, with ten reviewed and accepted in place rather than quietly silenced.

cf. https://github.com/orgs/suitenumerique/projects/13/views/3?filterQuery=&pane=issue&itemId=232013229&issue=suitenumerique%7Cconversations%7C682


## Proposal

- [x] Resolve every third-party action to an immutable commit, with the human readable version kept alongside as a comment
- [x] Pin the container images and the downloaded binary used by the test jobs, and verify that download against a known checksum
- [x] Pin the packages installed during linting, and install them from pre-built artifacts so that nothing runs a build script at setup time
- [x] Give every workflow read-only repository access by default, leaving the two jobs that genuinely publish with their existing elevated scope
- [x] Stop the checkout step from leaving a usable credential behind in the workspace, since no job pushes through it
- [x] Make lockfile enforcement the default for package installs instead of relying on each call site to pass the flag
- [x] Keep branch names supplied by a pull request out of the shell that lints commits
- [x] Record a written justification beside each finding left open, so that it reads as accepted rather than missed
- [x] Unblock the automated dependency updater so that the new pins are kept current, and remove stale update rules that had silently frozen two packages at old versions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security & Reliability**
  * Strengthened CI workflows with read-only permissions, pinned action and tool versions, disabled credential persistence, and verified downloads.
  * Standardized locked dependency installation for frontend and mail packages.
* **Maintenance**
  * Improved automated dependency update controls and tracking.
  * Updated the unreleased changelog to document dependency and CI security improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->