### PR TITLE
⚡️(ci) shard e2e tests across browsers

### DIFF
--- a/.github/workflows/conversations-frontend.yml
+++ b/.github/workflows/conversations-frontend.yml
@@ -75,10 +75,16 @@ jobs:
       - name: Check linting
         run: cd src/frontend/ && yarn lint
 
-  test-e2e-chromium:
+  test-e2e:
     runs-on: ubuntu-latest
     needs: install-dependencies
     timeout-minutes: 40
+    strategy:
+      # One browser suite failing must not cancel the others.
+      fail-fast: false
+      matrix:
+        browser: [chromium, firefox, webkit]
+        shard: ["1/3", "2/3", "3/3"]
     steps:
       - name: Checkout repository
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
@@ -104,63 +110,63 @@ jobs:
       - name: Set e2e env variables
         run: cat env.d/development/common.e2e.dist >> env.d/development/common.dist
 
-      - name: Install Playwright Browsers
-        run: cd src/frontend/apps/e2e && yarn install --frozen-lockfile && yarn install-playwright chromium
+      - name: Get Playwright version
+        id: playwright-version
+        run: |
+          V=$(node -p "require('./src/frontend/apps/e2e/package.json').devDependencies['@playwright/test']")
+          echo "version=${V}" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve the browsers to install
+        id: browsers
+        # The auth global setup drives the Keycloak login with chromium whatever
+        # the project under test, so every leg needs chromium on top of its own
+        # browser.
+        run: |
+          if [ "${{ matrix.browser }}" = "chromium" ]; then
+            BROWSERS="chromium"
+          else
+            BROWSERS="chromium ${{ matrix.browser }}"
+          fi
+          echo "list=${BROWSERS}" >> "$GITHUB_OUTPUT"
+          echo "key=${BROWSERS// /-}" >> "$GITHUB_OUTPUT"
+
+      - name: Restore the Playwright browser cache
+        id: playwright-cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.browsers.outputs.key }}-${{ steps.playwright-version.outputs.version }}
+
+      - name: Install Playwright browsers and system dependencies
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: cd src/frontend/apps/e2e && yarn install-playwright ${{ steps.browsers.outputs.list }}
+
+      - name: Install Playwright system dependencies only
+        # The browsers themselves come from the cache, their apt dependencies do not.
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: cd src/frontend/apps/e2e && npx playwright install-deps ${{ steps.browsers.outputs.list }}
 
       - name: Start Docker services
         run: make bootstrap-e2e FLUSH_ARGS='--no-input'
 
       - name: Run e2e tests
-        run: cd src/frontend/ && yarn e2e:test --project='chromium'
+        run: cd src/frontend/ && yarn e2e:test --project=${{ matrix.browser }} --shard=${{ matrix.shard }}
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
-          name: playwright-chromium-report
+          # job-index keeps the name unique: the shard value contains a "/".
+          name: playwright-report-${{ matrix.browser }}-${{ strategy.job-index }}
           path: src/frontend/apps/e2e/report/
           retention-days: 7
 
-  test-e2e-other-browser:
+  test-e2e-all:
+    # Single stable context for branch protection: the matrix reports one check
+    # per browser and shard, and those names change whenever the matrix does.
+    if: always()
     runs-on: ubuntu-latest
-    needs: test-e2e-chromium
-    timeout-minutes: 40
+    needs: test-e2e
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
-        with:
-          persist-credentials: false
-
-      - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-        with:
-          node-version: "22.x"
-
-      - name: Install yarn
-        # Exact version pin, scripts disabled; corepack pinning is separate.
-        run: npm install -g yarn@1.22.22 --ignore-scripts # zizmor: ignore[adhoc-packages]
-
-      - name: Restore the frontend cache
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        with:
-          path: "src/frontend/**/node_modules"
-          key: front-node_modules-${{ hashFiles('src/frontend/**/yarn.lock') }}
-          fail-on-cache-miss: true
-
-      - name: Set e2e env variables
-        run: cat env.d/development/common.e2e.dist >> env.d/development/common.dist
-
-      - name: Install Playwright Browsers
-        run: cd src/frontend/apps/e2e && yarn install --frozen-lockfile && yarn install-playwright firefox webkit chromium
-
-      - name: Start Docker services
-        run: make bootstrap-e2e FLUSH_ARGS='--no-input'
-
-      - name: Run e2e tests
-        run: cd src/frontend/ && yarn e2e:test --project=firefox --project=webkit
-
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        if: always()
-        with:
-          name: playwright-other-report
-          path: src/frontend/apps/e2e/report/
-          retention-days: 7
+      - name: Fail if any e2e shard did not succeed
+        if: needs.test-e2e.result != 'success'
+        run: exit 1

--- a/.github/workflows/conversations-frontend.yml
+++ b/.github/workflows/conversations-frontend.yml
@@ -75,15 +75,50 @@ jobs:
       - name: Check linting
         run: cd src/frontend/ && yarn lint
 
-  test-e2e:
+  build-e2e-images:
     runs-on: ubuntu-latest
-    needs: install-dependencies
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
+
+      - name: Set e2e env variables
+        run: cat env.d/development/common.e2e.dist >> env.d/development/common.dist
+
+      - name: Build the e2e images
+        run: make pre-bootstrap build-e2e
+
+      - name: Export the e2e images
+        # gzip -1 trades a little size for speed; the artifact upload is told not
+        # to compress again on top of it.
+        run: |
+          set -o pipefail
+          docker save \
+            conversations:backend-development \
+            conversations:frontend-production \
+            conversations:openmockllm-mistral \
+            | gzip -1 > e2e-images.tar.gz
+
+      - name: Upload the e2e images
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: e2e-images
+          path: e2e-images.tar.gz
+          retention-days: 1
+          compression-level: 0
+          if-no-files-found: error
+
+  test-e2e-chromium:
+    runs-on: ubuntu-latest
+    needs: [install-dependencies, build-e2e-images]
     timeout-minutes: 40
     strategy:
       # One browser suite failing must not cancel the others.
       fail-fast: false
       matrix:
-        browser: [chromium, firefox, webkit]
+        browser: [chromium]
         shard: ["1/3", "2/3", "3/3"]
     steps:
       - name: Checkout repository
@@ -146,8 +181,109 @@ jobs:
         if: steps.playwright-cache.outputs.cache-hit == 'true'
         run: cd src/frontend/apps/e2e && npx playwright install-deps ${{ steps.browsers.outputs.list }}
 
+      - name: Download the e2e images
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: e2e-images
+
+      - name: Load the e2e images
+        run: docker load --input e2e-images.tar.gz
+
       - name: Start Docker services
-        run: make bootstrap-e2e FLUSH_ARGS='--no-input'
+        run: make bootstrap-e2e-no-build FLUSH_ARGS='--no-input'
+
+      - name: Run e2e tests
+        run: cd src/frontend/ && yarn e2e:test --project=${{ matrix.browser }} --shard=${{ matrix.shard }}
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        if: always()
+        with:
+          # job-index keeps the name unique: the shard value contains a "/".
+          name: playwright-report-${{ matrix.browser }}-${{ strategy.job-index }}
+          path: src/frontend/apps/e2e/report/
+          retention-days: 7
+
+  test-e2e-other-browsers:
+    runs-on: ubuntu-latest
+    needs: [install-dependencies, build-e2e-images]
+    timeout-minutes: 40
+    strategy:
+      # One browser suite failing must not cancel the others.
+      fail-fast: false
+      matrix:
+        browser: [firefox, webkit]
+        shard: ["1/3", "2/3", "3/3"]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: "22.x"
+
+      - name: Install yarn
+        # Exact version pin, scripts disabled; corepack pinning is separate.
+        run: npm install -g yarn@1.22.22 --ignore-scripts # zizmor: ignore[adhoc-packages]
+
+      - name: Restore the frontend cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: "src/frontend/**/node_modules"
+          key: front-node_modules-${{ hashFiles('src/frontend/**/yarn.lock') }}
+          fail-on-cache-miss: true
+
+      - name: Set e2e env variables
+        run: cat env.d/development/common.e2e.dist >> env.d/development/common.dist
+
+      - name: Get Playwright version
+        id: playwright-version
+        run: |
+          V=$(node -p "require('./src/frontend/apps/e2e/package.json').devDependencies['@playwright/test']")
+          echo "version=${V}" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve the browsers to install
+        id: browsers
+        # The auth global setup drives the Keycloak login with chromium whatever
+        # the project under test, so every leg needs chromium on top of its own
+        # browser.
+        run: |
+          if [ "${{ matrix.browser }}" = "chromium" ]; then
+            BROWSERS="chromium"
+          else
+            BROWSERS="chromium ${{ matrix.browser }}"
+          fi
+          echo "list=${BROWSERS}" >> "$GITHUB_OUTPUT"
+          echo "key=${BROWSERS// /-}" >> "$GITHUB_OUTPUT"
+
+      - name: Restore the Playwright browser cache
+        id: playwright-cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.browsers.outputs.key }}-${{ steps.playwright-version.outputs.version }}
+
+      - name: Install Playwright browsers and system dependencies
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: cd src/frontend/apps/e2e && yarn install-playwright ${{ steps.browsers.outputs.list }}
+
+      - name: Install Playwright system dependencies only
+        # The browsers themselves come from the cache, their apt dependencies do not.
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: cd src/frontend/apps/e2e && npx playwright install-deps ${{ steps.browsers.outputs.list }}
+
+      - name: Download the e2e images
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: e2e-images
+
+      - name: Load the e2e images
+        run: docker load --input e2e-images.tar.gz
+
+      - name: Start Docker services
+        run: make bootstrap-e2e-no-build FLUSH_ARGS='--no-input'
 
       - name: Run e2e tests
         run: cd src/frontend/ && yarn e2e:test --project=${{ matrix.browser }} --shard=${{ matrix.shard }}
@@ -163,10 +299,12 @@ jobs:
   test-e2e-all:
     # Single stable context for branch protection: the matrix reports one check
     # per browser and shard, and those names change whenever the matrix does.
+    # Only chromium gates a merge; firefox and webkit run and report, but their
+    # failures are advisory.
     if: always()
     runs-on: ubuntu-latest
-    needs: test-e2e
+    needs: test-e2e-chromium
     steps:
-      - name: Fail if any e2e shard did not succeed
-        if: needs.test-e2e.result != 'success'
+      - name: Fail if any chromium e2e shard did not succeed
+        if: needs.test-e2e-chromium.result != 'success'
         run: exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to
 - ♻️(back) use httpx as the single HTTP client for outbound calls
 - ⬆️(back) update django, pypdf, sqlparse and pydantic-settings
 - 🔒️(ci) pin CI actions and installed packages to immutable versions
+- ⚡️(ci) run e2e tests in parallel across browsers and shards
 
 ### Removed
 

--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,13 @@ bootstrap-e2e: \
 	run-e2e
 .PHONY: bootstrap-e2e
 
+bootstrap-e2e-no-build: ## Same as bootstrap-e2e, for images built elsewhere (CI)
+bootstrap-e2e-no-build: \
+	pre-bootstrap \
+	post-bootstrap \
+	run-e2e
+.PHONY: bootstrap-e2e-no-build
+
 # -- Docker/compose
 build: cache ?=
 build: ## build the project containers


### PR DESCRIPTION
## Purpose

The e2e suite is the slowest part of the frontend pipeline. Firefox and WebKit only start once the Chromium suite has finished, and each of those two browsers then runs one after the other inside a single job. Every run also downloads all browser binaries from scratch.
Splitting the suite into shards multiplies the numbers of jobs, and each one was rebuilding the same container images from scrach.

## Proposal

- [ ] Replace the two sequential e2e jobs with a single matrix that runs each browser suite in parallel, split into shards
- [ ] Keep a failure in one browser from cancelling the others
- [ ] Cache the browser binaries between runs, keyed on the runner platform, the browser and the exact test runner version, so only the system packages are installed on a cache hit
- [ ] Publish one report per matrix leg
- [ ] Build the test images once per run and share them across the matrix, instead of rebuilding them in every job

https://github.com/orgs/suitenumerique/projects/13/views/3?filterQuery=&pane=issue&itemId=234666338&issue=suitenumerique%7Cconversations%7C688

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Tests**
  - End-to-end tests now run in parallel across Chromium, Firefox, and WebKit.
  - Tests are split into multiple shards to improve execution efficiency.
  - Test artifacts are stored with unique names for easier identification.
  - Shared test images reduce repeated builds and speed up test execution.

- **Documentation**
  - Added an unreleased changelog entry describing the parallelized browser test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->