### PR TITLE
👷(ci) audit GitHub Actions workflows with zizmor on push and pull req…

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,25 @@
+name: Security analysis
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - "**"
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Audit GitHub Actions workflows
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # upload the SARIF report to code scanning
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to
 
 - 💄(settings) move analytics settings to general
 - 📈(posthog) track projects, Docs export, summarization and co2 footprint
+- 👷(ci) audit GitHub Actions workflows with zizmor on push and pull request
 
 ### Changed
 


### PR DESCRIPTION
## Purpose

Set up zizmor, a static analyzer for GitHub Actions, so that workflow security issues are caught automatically instead of by hand. It covers the class of problems the recent CI hardening work addressed manually: unpinned actions, credential persistence, cache poisoning, template injection and overly broad permissions.

Heavily inspired from https://github.com/suitenumerique/menshen/

## Proposal

- [ ] Add a security analysis workflow running zizmor on pushes to main and on pull requests
- [ ] Report findings to GitHub code scanning as SARIF, with no job-level permissions beyond what the upload needs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Added automated auditing for CI workflows on pushes and pull requests, helping identify potential workflow security issues earlier.

* **Documentation**
  * Documented the new workflow security auditing in the unreleased changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->