### PR TITLE
Enhance admin and fix dev container perms

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -35,5 +35,8 @@ db.sqlite3
 .pytest_cache
 
 # Frontend
-node_modules
-.next
+# Patterns are matched from the context root, so `node_modules` alone would leave
+# `src/frontend/apps/conversations/node_modules` in the context, where the COPY of the
+# app directory lands it in the image on top of the one `yarn install` just built.
+**/node_modules
+**/.next

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ and this project adheres to
 - ⚡️(ci) run e2e tests in parallel across browsers and shards
 - ✨(back) sort conversations by stored size in the admin list
 
+### Fixed
+
+- 🐛(front) fix the frontend dev container failing to start
+
 ### Removed
 
 - 🔥(back) remove the unused Albert web search manager and its tool

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to
 - ⬆️(back) update django, pypdf, sqlparse and pydantic-settings
 - 🔒️(ci) pin CI actions and installed packages to immutable versions
 - ⚡️(ci) run e2e tests in parallel across browsers and shards
+- ✨(back) sort conversations by stored size in the admin list
 
 ### Removed
 

--- a/src/backend/chat/admin.py
+++ b/src/backend/chat/admin.py
@@ -1,10 +1,28 @@
 """Admin classes and registrations for chat application."""
 
 from django.contrib import admin
-from django.db.models import Exists, OuterRef, Subquery
+from django.db.models import BigIntegerField, Exists, F, Func, OuterRef, Subquery, Value
+from django.db.models.functions import Coalesce
+from django.template.defaultfilters import filesizeformat
 
 from . import models
 from .model_health import set_model_health
+
+
+def _stored_size(field_name):
+    """
+    Bytes this column occupies on disk, as stored.
+
+    `pg_column_size` reads the size out of the tuple (or, for an out-of-line value, out
+    of its TOAST pointer) instead of fetching and decompressing the value, so it stays
+    cheap on the very rows we are looking for. The counterpart is that it reports the
+    *compressed* size: JSON text compresses several times over, so the number is a
+    ranking signal, not the payload size an API response would carry.
+    """
+    return Coalesce(
+        Func(F(field_name), function="pg_column_size", output_field=BigIntegerField()),
+        Value(0),
+    )
 
 
 class ChatConversationAttachmentInline(admin.TabularInline):
@@ -73,6 +91,7 @@ class ChatConversationAdmin(admin.ModelAdmin):
         "owner",
         "project",
         "has_files",
+        "stored_size",
         "collection_id",
         "created_at",
         "updated_at",
@@ -94,6 +113,9 @@ class ChatConversationAdmin(admin.ModelAdmin):
         `Count("attachments")` would need a GROUP BY over the whole table before the
         page's LIMIT could apply, while EXISTS is evaluated per returned row against
         the attachment foreign key index.
+
+        `stored_size` sums the deferred columns without selecting them, so heavy
+        conversations can be sorted to the top of the page they are hiding in.
         """
         return (
             super()
@@ -108,7 +130,14 @@ class ChatConversationAdmin(admin.ModelAdmin):
             .annotate(
                 has_files=Exists(
                     models.ChatConversationAttachment.objects.filter(conversation=OuterRef("pk"))
-                )
+                ),
+                stored_size=(
+                    _stored_size("messages")
+                    + _stored_size("pydantic_messages")
+                    + _stored_size("ui_messages")
+                    + _stored_size("agent_usage")
+                    + _stored_size("history_summary")
+                ),
             )
         )
 
@@ -116,6 +145,11 @@ class ChatConversationAdmin(admin.ModelAdmin):
     def has_files(self, obj):
         """Whether the conversation has attachments, without opening it."""
         return obj.has_files
+
+    @admin.display(description="Stored size", ordering="stored_size")
+    def stored_size(self, obj):
+        """Compressed weight of the conversation payloads, sortable to find the outliers."""
+        return filesizeformat(obj.stored_size)
 
 
 @admin.register(models.ChatConversationAttachment)

--- a/src/backend/chat/tests/test_admin.py
+++ b/src/backend/chat/tests/test_admin.py
@@ -5,9 +5,13 @@ from django.core.cache import cache
 
 import pytest
 
-from chat.admin import ModelHealthAdmin
+from chat.admin import ChatConversationAdmin, ModelHealthAdmin
+from chat.factories import ChatConversationFactory
 from chat.model_health import model_health_cache_key
-from chat.models import ModelHealth
+from chat.models import ChatConversation, ModelHealth
+
+# Big enough for the stored size to stand out from a short conversation's.
+HEAVY_HISTORY = [{"role": "user", "content": f"message number {i} " * 40} for i in range(5000)]
 
 
 @pytest.mark.django_db
@@ -23,3 +27,19 @@ def test_model_health_admin_save_updates_cache(clear_cache):  # pylint: disable=
 
     assert ModelHealth.objects.get(pk=obj.pk).status == "red"
     assert cache.get(key) == "red"
+
+
+@pytest.mark.django_db
+def test_conversation_admin_changelist_ranks_by_stored_size():
+    """The changelist sizes each conversation from the columns it does not select."""
+    light = ChatConversationFactory(pydantic_messages=[{"content": "hi"}])
+    heavy = ChatConversationFactory(pydantic_messages=HEAVY_HISTORY)
+
+    queryset = ChatConversationAdmin(ChatConversation, AdminSite()).get_queryset(request=None)
+    sizes = {conversation.pk: conversation.stored_size for conversation in queryset}
+
+    assert sizes[heavy.pk] > sizes[light.pk] > 0
+    assert list(queryset.order_by("-stored_size").values_list("pk", flat=True)) == [
+        heavy.pk,
+        light.pk,
+    ]


### PR DESCRIPTION
## Purpose

Very large conversations exist in production, but nothing in the admin makes them  visible: the list gives no clue about how much text a conversation carries, so the heavy ones can only be found by opening them one by one. This adds that signal.

While working on it, the frontend dev container turned out to be unable to startat all since the move to the new build tooling, so the fix is included here.

## Proposal

- [ ] Add a size column to the conversation admin list, sortable, so the heaviest conversations can be brought to the top in one click
- [ ] Compute that size straight from the database without loading the message payloads, keeping the list page as cheap as it was
- [ ] Cover the new column with a test
- [ ] Let the frontend dev container start again by making the directory its dev server writes to writable by the user the container runs as
- [ ] Stop the local build artifacts of the host from being copied into the images,  which also unblocks building the production frontend image locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stored conversation size to the admin conversation list.
  * Enabled sorting conversations by their stored size.
  * Displayed sizes in a human-readable format.

* **Bug Fixes**
  * Fixed the frontend development container failing to start.
  * Improved handling of nested dependency and build directories in Docker contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->