### PR TITLE
🚸(back)show 200 conversations per admin list page for bulk actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,10 +25,12 @@ and this project adheres to
 - 🔒️(ci) pin CI actions and installed packages to immutable versions
 - ⚡️(ci) run e2e tests in parallel across browsers and shards
 - ✨(back) sort conversations by stored size in the admin list
+- 🚸(back) show 200 conversations per admin list page for bulk actions
 
 ### Fixed
 
 - 🐛(front) fix the frontend dev container failing to start
+
 
 ### Removed
 

--- a/src/backend/chat/admin.py
+++ b/src/backend/chat/admin.py
@@ -73,7 +73,11 @@ class ChatConversationAdmin(admin.ModelAdmin):
 
     search_fields = ("id", "title", "owner__email", "owner__sub", "project__title")
     ordering = ("-updated_at",)
-    list_per_page = 50
+    # Sized for bulk selection: the page costs ~0.25ms of template rendering per row
+    # and a flat 2 queries, since the blobs are deferred and the COUNT(*) is off below.
+    # 200 keeps the render under ~75ms while quadrupling how many rows can be deleted
+    # in one pass; beyond that the browser, not the backend, becomes the bottleneck.
+    list_per_page = 200
     # Skip the extra unfiltered COUNT(*) over the whole table on every changelist load.
     show_full_result_count = False
 


### PR DESCRIPTION
## Purpose

We have to manually bulk delete conversations, the 50 rows per page pagination slows us.


## Proposal

Display longer admin pages to ease bulk deletion
 