### PR TITLE
Conversation and project creation throttling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to
 - 💄(settings) move analytics settings to general
 - 📈(posthog) track projects, Docs export, summarization and co2 footprint
 - 👷(ci) audit GitHub Actions workflows with zizmor on push and pull request
+- 🔒️(back) throttle conversation and project creation per user
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to
 - 📈(posthog) track projects, Docs export, summarization and co2 footprint
 - 👷(ci) audit GitHub Actions workflows with zizmor on push and pull request
 - 🔒️(back) throttle conversation and project creation per user
+- 🚸(front) explain the wait when a creation rate limit is reached
 
 ### Changed
 

--- a/docs/env.md
+++ b/docs/env.md
@@ -112,6 +112,13 @@ These are the environment variables you can set for the `conversations-backend` 
 | DOCS_BASE_URL                                   | Base URL of the La Suite Docs instance. Enables the "Edit in Docs" feature (the button only appears when set). Requires `OIDC_STORE_ACCESS_TOKEN=true`. See [Interoperability](interoperabilities.md). |                                                         |
 | DOCS_API_TIMEOUT                                | Timeout (seconds) for HTTP calls to the Docs external API                                                                          | 30                                                      |
 | OIDC_ALLOWED_ROLES                              | Comma-separated roles; restrict login to users whose OIDC `roles` claim contains one of them. Empty disables. See "Access control modes" below. | [] (empty, disabled)                                    |
+| API_ATTACHMENT_UPLOAD_THROTTLE_RATE             | Rate limit on the attachment upload endpoint, per user                                                                            | 60/minute                                               |
+| API_ATTACHMENT_AUTH_THROTTLE_RATE               | Rate limit on the attachment authorization endpoint, per user                                                                     | 60/minute                                               |
+| API_FILE_STREAM_THROTTLE_RATE                   | Rate limit on the file streaming endpoint, per user                                                                               | 60/minute                                               |
+| API_CONVERSATION_CREATE_HOURLY_THROTTLE_RATE    | Hourly limit on conversation creation, per user. See [Rate limiting](#rate-limiting)                                              | 20/hour                                                 |
+| API_CONVERSATION_CREATE_DAILY_THROTTLE_RATE     | Daily limit on conversation creation, per user. See [Rate limiting](#rate-limiting)                                               | 100/day                                                 |
+| API_PROJECT_CREATE_HOURLY_THROTTLE_RATE         | Hourly limit on project creation, per user. See [Rate limiting](#rate-limiting)                                                   | 10/hour                                                 |
+| API_PROJECT_CREATE_DAILY_THROTTLE_RATE          | Daily limit on project creation, per user. See [Rate limiting](#rate-limiting)                                                    | 100/day                                                 |
 
 
 ## Access control
@@ -129,6 +136,28 @@ Access can be gated on the OIDC role claim:
 The activation-code gate that used to be configured here has been removed. The
 `activation_codes` Django admin section survives read-only so past redemptions stay
 consultable.
+
+
+## Rate limiting
+
+Conversation and project creation are each bounded by **two** limits at once, an
+hourly one and a daily one: both must allow a request for it to go through. A single
+rate cannot express both, and the two answer different questions - the hourly rate
+stops a runaway client or a retry loop, while the daily rate bounds how much a single
+account can accumulate in the database over time. Raising one without the other only
+moves the ceiling.
+
+Values use the Django REST framework format, `<number>/<period>`, where the period is
+one of `second`, `minute`, `hour` or `day`. Counting is per authenticated user and
+stored in Redis, so the limits hold across every backend replica.
+
+Only creation is limited. Reading conversations, renaming them and posting new messages
+to an existing one are unaffected, so a user who reaches the limit keeps full use of the
+conversations they already have and is only stopped from opening new ones (HTTP 429,
+with a `Retry-After` header).
+
+Rates are read when the process starts, so changing one of these variables takes effect
+on the next restart of the backend.
 
 
 ## conversations-frontend image

--- a/src/backend/chat/rate_limiting.py
+++ b/src/backend/chat/rate_limiting.py
@@ -1,10 +1,15 @@
-"""Per-user token-rate tracking and model-health-aware cooldown heuristic.
+"""Per-user rate limiting: model-load cooldown and resource-creation throttles.
 
 To mitigate concurrent load on the inference infrastructure we track each
 user's total token usage (input + output) over a trailing window. When the
 model they are using is known to be degraded (yellow or red health) and they
 have spent more than a threshold over that window, the client is asked to
 wait a cooldown period before the next request. See ``compute_cooldown_seconds``.
+
+Separately, the throttles at the bottom of this module bound how fast an
+account can create conversations and projects. Those are storage controls
+rather than load controls: nothing else caps how many rows a single
+authenticated client can write.
 """
 
 import logging
@@ -13,7 +18,7 @@ import time
 
 from django.core.cache import cache
 
-from rest_framework.throttling import BaseThrottle
+from rest_framework.throttling import BaseThrottle, UserRateThrottle
 
 from core.models import ChatCooldownSettings
 
@@ -176,3 +181,97 @@ class ChatCooldownThrottle(BaseThrottle):
 
     def wait(self):
         return self._wait_seconds or None
+
+
+# --------------------------------------------------------------------------- #
+# Resource-creation throttles
+# --------------------------------------------------------------------------- #
+# A single DRF rate string carries one window, so bounding both bursts and
+# daily totals takes two throttles per resource. Each scope keeps its own
+# cache key and both must allow a request for it to go through; the rates
+# themselves live in ``DEFAULT_THROTTLE_RATES`` and are settable per
+# environment.
+
+
+class AtomicWindowThrottle(UserRateThrottle):
+    """A ``UserRateThrottle`` whose count holds under concurrency.
+
+    DRF's ``SimpleRateThrottle`` reads the request history, filters it and
+    writes it back. That read-modify-write is not atomic, so requests arriving
+    together all read the same history and all pass: a client firing N requests
+    in parallel creates N rows whatever the rate says. Counting a fixed window
+    with ``add`` + ``incr`` removes the read-modify-write -- both are atomic on
+    Redis and on the local-memory cache -- so the count is exact however many
+    requests arrive at once.
+
+    The trade-off is the usual fixed-window one: a client can spend its whole
+    allowance at the end of one window and again at the start of the next. For
+    a storage ceiling that bounded 2x burst is a much smaller hole than the
+    unbounded concurrent overshoot it replaces.
+    """
+
+    # Declared here rather than only in ``allow_request``: DRF instantiates a
+    # throttle per request, and ``wait`` may be called before either is set.
+    key = None
+    _wait = None
+
+    def allow_request(self, request, view):
+        """Count this request in the current window and allow it if it fits."""
+        if self.rate is None:
+            return True
+
+        self.key = self.get_cache_key(request, view)
+        if self.key is None:
+            return True
+
+        now = time.time()
+        # Windows are aligned on the epoch rather than on a first request, so
+        # every process agrees on which window a request falls in.
+        window_key = f"{self.key}:{int(now) // self.duration}"
+        self._wait = self.duration - (now % self.duration)
+
+        # ``add`` seeds the window only if no request has opened it yet, so a
+        # burst elects exactly one opener and every other request increments
+        # what is already there. Both calls are atomic -- ``SET NX`` on Redis,
+        # lock-guarded in local memory -- so no count is ever overwritten.
+        if self.cache.add(window_key, 1, timeout=self.duration):
+            count = 1
+        else:
+            try:
+                count = self.cache.incr(window_key)
+            except ValueError:
+                # The window is gone between the two calls, which takes an
+                # eviction or a flush: its TTL outlives the window itself.
+                # Reseeding here would overwrite whatever a concurrent request
+                # has since put there, so leave the cache to them.
+                count = 1
+
+        return count <= self.num_requests
+
+    def wait(self):
+        """Seconds until the current window ends, for the ``Retry-After`` header."""
+        return self._wait
+
+
+class ConversationCreateHourlyThrottle(AtomicWindowThrottle):
+    """Hourly ceiling on conversation creation, per user."""
+
+    scope = "conversation_create_hourly"
+
+
+class ConversationCreateDailyThrottle(AtomicWindowThrottle):
+    """Daily ceiling on conversation creation, per user."""
+
+    scope = "conversation_create_daily"
+
+
+class ProjectCreateHourlyThrottle(AtomicWindowThrottle):
+    """Hourly ceiling on project creation, per user."""
+
+    scope = "project_create_hourly"
+
+
+class ProjectCreateDailyThrottle(AtomicWindowThrottle):
+    """Daily ceiling on project creation, per user."""
+
+    scope = "project_create_daily"

--- a/src/backend/chat/tests/utils.py
+++ b/src/backend/chat/tests/utils.py
@@ -2,8 +2,10 @@
 
 import json
 import re
+from unittest.mock import patch
 
 from rest_framework import status
+from rest_framework.throttling import SimpleRateThrottle
 
 UI_MESSAGE_STREAM_HEADER = "x-vercel-ai-ui-message-stream"
 
@@ -56,3 +58,18 @@ def replace_uuids_with_placeholder(text):
     text = re.sub('"toolCallId":"pyd_ai_([a-z0-9]){32}"', '"toolCallId":"pyd_ai_YYY"', text)
     text = re.sub('"([a-z0-9-]){36}"', '"<mocked_uuid>"', text)
     return text
+
+
+def throttle_rates(**overrides):
+    """Context manager replacing throttle rates by scope, e.g. `foo="3/day"`.
+
+    DRF snapshots ``DEFAULT_THROTTLE_RATES`` into a class attribute when
+    ``rest_framework.throttling`` is imported, so ``override_settings`` on
+    ``REST_FRAMEWORK`` does not reach it; the class attribute is the only
+    place a test can change a rate.
+    """
+    return patch.object(
+        SimpleRateThrottle,
+        "THROTTLE_RATES",
+        {**SimpleRateThrottle.THROTTLE_RATES, **overrides},
+    )

--- a/src/backend/chat/tests/views/chat/conversations/test_conversation.py
+++ b/src/backend/chat/tests/views/chat/conversations/test_conversation.py
@@ -30,6 +30,7 @@ from chat.tests.utils import (
     ZERO_USAGE,
     assert_data_stream_response,
     replace_uuids_with_placeholder,
+    throttle_rates,
 )
 from chat.tools.descriptions import SELF_DOCUMENTATION_SYSTEM_PROMPT
 
@@ -1194,3 +1195,40 @@ def test_post_conversation_oidc_refresh_enabled(  # pylint: disable=unused-argum
 
     assert len(chat_conversation.messages) == 2
     assert len(chat_conversation.pydantic_messages) == 2
+
+
+@freeze_time(FROZEN_TIMESTAMP)
+@respx.mock
+def test_post_conversation_is_not_affected_by_the_creation_throttle(
+    api_client, mock_openai_stream, hello_conversation_data
+):
+    """Appending a turn updates an existing conversation, so it is not throttled.
+
+    Both are POSTs on the same viewset, which is why the throttles are keyed on
+    the action rather than the HTTP method.
+    """
+    user = UserFactory(language="en-us")
+    api_client.force_login(user)
+    chat_conversation = ChatConversationFactory(owner=user)
+
+    with throttle_rates(conversation_create_hourly="1/hour"):
+        assert (
+            api_client.post("/api/v1.0/chats/", {"title": "first"}, format="json").status_code
+            == status.HTTP_201_CREATED
+        )
+        # The creation budget is now spent for this user...
+        assert (
+            api_client.post("/api/v1.0/chats/", {"title": "second"}, format="json").status_code
+            == status.HTTP_429_TOO_MANY_REQUESTS
+        )
+
+        # ...which must not stop them from continuing an existing conversation.
+        response = api_client.post(
+            f"/api/v1.0/chats/{chat_conversation.pk}/conversation/?protocol=data",
+            hello_conversation_data,
+            format="json",
+        )
+
+    assert_data_stream_response(response)
+    assert _decode_stream(response) == HELLO_STREAM_CONTENT
+    assert mock_openai_stream.called

--- a/src/backend/chat/tests/views/chat/test_create.py
+++ b/src/backend/chat/tests/views/chat/test_create.py
@@ -1,13 +1,19 @@
 """Unit tests for chat conversation creation in the chat API view."""
 
+from unittest.mock import patch
+
+from django.core.cache import cache
+
 import pytest
 from rest_framework import status
 from rest_framework.exceptions import ErrorDetail
+from rest_framework.throttling import SimpleRateThrottle
 
 from core.factories import UserFactory
 
-from chat.factories import ChatProjectFactory
+from chat.factories import ChatConversationFactory, ChatProjectFactory
 from chat.models import ChatConversation
+from chat.tests.utils import throttle_rates
 
 pytestmark = pytest.mark.django_db
 
@@ -117,3 +123,143 @@ def test_create_conversation_anonymous(api_client):
     response = api_client.post(url, data, format="json")
 
     assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+def test_create_conversation_throttled_over_the_hourly_rate(api_client):
+    """The 21st conversation of the hour is rejected with a 429."""
+    user = UserFactory()
+    url = "/api/v1.0/chats/"
+    api_client.force_login(user)
+
+    for _ in range(20):
+        assert (
+            api_client.post(url, {"title": "ok"}, format="json").status_code
+            == status.HTTP_201_CREATED
+        )
+
+    response = api_client.post(url, {"title": "too many"}, format="json")
+
+    assert response.status_code == status.HTTP_429_TOO_MANY_REQUESTS
+    assert response.has_header("Retry-After")
+    assert ChatConversation.objects.filter(owner=user).count() == 20
+
+
+def test_create_conversation_throttled_over_the_daily_rate(api_client):
+    """The daily rate rejects a user still well under the hourly one."""
+    user = UserFactory()
+    url = "/api/v1.0/chats/"
+    api_client.force_login(user)
+
+    with throttle_rates(conversation_create_hourly="100/hour", conversation_create_daily="3/day"):
+        for _ in range(3):
+            assert (
+                api_client.post(url, {"title": "ok"}, format="json").status_code
+                == status.HTTP_201_CREATED
+            )
+        response = api_client.post(url, {"title": "too many"}, format="json")
+
+    assert response.status_code == status.HTTP_429_TOO_MANY_REQUESTS
+
+
+def test_create_conversation_throttle_is_per_user(api_client):
+    """One user exhausting their rate does not block another."""
+    url = "/api/v1.0/chats/"
+
+    with throttle_rates(conversation_create_hourly="1/hour"):
+        throttled_user = UserFactory()
+        api_client.force_login(throttled_user)
+        api_client.post(url, {"title": "ok"}, format="json")
+        assert (
+            api_client.post(url, {"title": "ok"}, format="json").status_code
+            == status.HTTP_429_TOO_MANY_REQUESTS
+        )
+
+        other_user = UserFactory()
+        api_client.force_login(other_user)
+        response = api_client.post(url, {"title": "ok"}, format="json")
+
+    assert response.status_code == status.HTTP_201_CREATED
+
+
+def test_create_conversation_throttle_does_not_apply_to_reads(api_client):
+    """Only creation is throttled: listing still works past the limit."""
+    user = UserFactory()
+    url = "/api/v1.0/chats/"
+    api_client.force_login(user)
+    ChatConversationFactory(owner=user)
+
+    with throttle_rates(conversation_create_hourly="1/hour"):
+        api_client.post(url, {"title": "ok"}, format="json")
+        assert (
+            api_client.post(url, {"title": "ok"}, format="json").status_code
+            == status.HTTP_429_TOO_MANY_REQUESTS
+        )
+
+        assert api_client.get(url).status_code == status.HTTP_200_OK
+
+
+def test_create_conversation_throttle_does_not_apply_to_updates(api_client):
+    """Renaming a conversation is an update, not a creation: never throttled."""
+    user = UserFactory()
+    url = "/api/v1.0/chats/"
+    api_client.force_login(user)
+    conversation = ChatConversationFactory(owner=user)
+
+    with throttle_rates(conversation_create_hourly="1/hour"):
+        api_client.post(url, {"title": "ok"}, format="json")
+        assert (
+            api_client.post(url, {"title": "ok"}, format="json").status_code
+            == status.HTTP_429_TOO_MANY_REQUESTS
+        )
+
+        detail_url = f"{url}{conversation.pk}/"
+        patched = api_client.patch(detail_url, {"title": "renamed"}, format="json")
+        put = api_client.put(detail_url, {"title": "renamed again"}, format="json")
+
+    assert patched.status_code == status.HTTP_200_OK
+    assert put.status_code == status.HTTP_200_OK
+    conversation.refresh_from_db()
+    assert conversation.title == "renamed again"
+
+
+class LostUpdateCache:
+    """A cache whose reads never see what an earlier request wrote back.
+
+    Two workers racing on the same window both read its state as it was before
+    either of them wrote: the second one's write is lost. Staging that
+    interleaving is the only way to cover it here, because the suite runs
+    single-process on LocMemCache, where the GIL lets a read-modify-write
+    finish inside one switch interval. Production has neither protection --
+    several worker processes, and a network round-trip to Redis sitting
+    between the read and the write.
+    """
+
+    def __init__(self, inner):
+        self._inner = inner
+
+    def get(self, key, default=None, version=None):  # pylint: disable=unused-argument
+        """Always miss, as a racing worker does before the other one writes."""
+        return default
+
+    def __getattr__(self, name):
+        return getattr(self._inner, name)
+
+
+def test_create_conversation_throttle_does_not_count_by_reading_back_its_writes(api_client):
+    """The creation ceiling must hold even when a concurrent write is lost.
+
+    A throttle that counts by reading its own history back cannot bound
+    storage: this is the regression that ``AtomicWindowThrottle`` exists for.
+    """
+    user = UserFactory()
+    url = "/api/v1.0/chats/"
+    api_client.force_login(user)
+
+    with throttle_rates(conversation_create_hourly="1/hour", conversation_create_daily="100/day"):
+        with patch.object(SimpleRateThrottle, "cache", LostUpdateCache(cache)):
+            first = api_client.post(url, {"title": "ok"}, format="json")
+            second = api_client.post(url, {"title": "too many"}, format="json")
+
+    assert first.status_code == status.HTTP_201_CREATED
+    assert second.status_code == status.HTTP_429_TOO_MANY_REQUESTS
+    assert ChatConversation.objects.filter(owner=user).count() == 1

--- a/src/backend/chat/tests/views/projects/test_create.py
+++ b/src/backend/chat/tests/views/projects/test_create.py
@@ -6,6 +6,7 @@ from rest_framework import status
 from core.factories import UserFactory
 
 from chat.models import ChatProject, ChatProjectColor, ChatProjectIcon
+from chat.tests.utils import throttle_rates
 
 pytestmark = pytest.mark.django_db
 
@@ -107,3 +108,42 @@ def test_create_project_anonymous(api_client):
     response = api_client.post(url, data, format="json")
 
     assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+def test_create_project_throttled_over_the_hourly_rate(api_client):
+    """The 11th project of the hour is rejected with a 429."""
+    user = UserFactory()
+    url = "/api/v1.0/projects/"
+    data = {
+        "title": "New Project",
+        "icon": ChatProjectIcon.FOLDER,
+        "color": ChatProjectColor.COLOR_1,
+    }
+    api_client.force_login(user)
+
+    for _ in range(10):
+        assert api_client.post(url, data, format="json").status_code == status.HTTP_201_CREATED
+
+    response = api_client.post(url, data, format="json")
+
+    assert response.status_code == status.HTTP_429_TOO_MANY_REQUESTS
+    assert ChatProject.objects.filter(owner=user).count() == 10
+
+
+def test_create_project_throttled_over_the_daily_rate(api_client):
+    """The daily rate rejects a user still well under the hourly one."""
+    user = UserFactory()
+    url = "/api/v1.0/projects/"
+    data = {
+        "title": "New Project",
+        "icon": ChatProjectIcon.FOLDER,
+        "color": ChatProjectColor.COLOR_1,
+    }
+    api_client.force_login(user)
+
+    with throttle_rates(project_create_hourly="100/hour", project_create_daily="3/day"):
+        for _ in range(3):
+            assert api_client.post(url, data, format="json").status_code == status.HTTP_201_CREATED
+        response = api_client.post(url, data, format="json")
+
+    assert response.status_code == status.HTTP_429_TOO_MANY_REQUESTS

--- a/src/backend/chat/views/conversations.py
+++ b/src/backend/chat/views/conversations.py
@@ -26,7 +26,12 @@ from chat.clients.pydantic_ai import AIAgentService
 from chat.constants import IMAGE_MIME_PREFIX, SSE_MIME_TYPE
 from chat.keepalive import stream_with_keepalive_async, stream_with_keepalive_sync
 from chat.model_routing import resolve_effective_model_hrid
-from chat.rate_limiting import ChatCooldownThrottle, get_cooldown_remaining
+from chat.rate_limiting import (
+    ChatCooldownThrottle,
+    ConversationCreateDailyThrottle,
+    ConversationCreateHourlyThrottle,
+    get_cooldown_remaining,
+)
 from chat.serializers import ChatConversationRequestSerializer
 from chat.views.edit_in_docs import EditInDocsMixin
 from chat.views.filters import ProjectFilter, TitleSearchFilter
@@ -166,9 +171,16 @@ class ChatViewSet(  # pylint: disable=too-many-ancestors, abstract-method
         return super().get_permissions()
 
     def get_throttles(self):
-        """Enforce the model-load cooldown on the chat completion endpoint."""
+        """Throttle the chat completion endpoint and conversation creation.
+
+        The completion endpoint carries the model-load cooldown; creation
+        carries an hourly and a daily rate, both of which must allow the
+        request, so that no account can fill the database on its own.
+        """
         if self.action == "post_conversation":
             return [ChatCooldownThrottle()]
+        if self.action == "create":
+            return [ConversationCreateHourlyThrottle(), ConversationCreateDailyThrottle()]
         return super().get_throttles()
 
     def perform_destroy(self, instance):

--- a/src/backend/chat/views/projects.py
+++ b/src/backend/chat/views/projects.py
@@ -12,6 +12,7 @@ from core.analytics import capture_event
 from core.api.viewsets import Pagination
 
 from chat import models, serializers
+from chat.rate_limiting import ProjectCreateDailyThrottle, ProjectCreateHourlyThrottle
 from chat.views.filters import TitleSearchFilter
 from chat.views.helpers import _bulk_delete_s3_blobs
 
@@ -41,6 +42,12 @@ class ChatProjectViewSet(viewsets.ModelViewSet):  # pylint: disable=too-many-anc
             if self.request.user.is_authenticated
             else self.queryset.none()
         )
+
+    def get_throttles(self):
+        """Bound project creation with an hourly and a daily rate, per user."""
+        if self.action == "create":
+            return [ProjectCreateHourlyThrottle(), ProjectCreateDailyThrottle()]
+        return super().get_throttles()
 
     @staticmethod
     def _event_properties(project):

--- a/src/backend/conversations/settings.py
+++ b/src/backend/conversations/settings.py
@@ -380,6 +380,30 @@ class Base(
                 environ_name="API_FILE_STREAM_THROTTLE_RATE",
                 environ_prefix=None,
             ),
+            # Conversations and projects are created without any other ceiling,
+            # so each is bounded by an hourly and a daily rate at once: the
+            # hourly one stops a runaway client, the daily one bounds how much
+            # a single account can accumulate in storage.
+            "conversation_create_hourly": values.Value(
+                default="20/hour",
+                environ_name="API_CONVERSATION_CREATE_HOURLY_THROTTLE_RATE",
+                environ_prefix=None,
+            ),
+            "conversation_create_daily": values.Value(
+                default="100/day",
+                environ_name="API_CONVERSATION_CREATE_DAILY_THROTTLE_RATE",
+                environ_prefix=None,
+            ),
+            "project_create_hourly": values.Value(
+                default="10/hour",
+                environ_name="API_PROJECT_CREATE_HOURLY_THROTTLE_RATE",
+                environ_prefix=None,
+            ),
+            "project_create_daily": values.Value(
+                default="100/day",
+                environ_name="API_PROJECT_CREATE_DAILY_THROTTLE_RATE",
+                environ_prefix=None,
+            ),
         },
     }
 
@@ -1161,6 +1185,10 @@ class Test(Base):
             "attachment_upload": "60/minute",
             "attachment_auth": "60/minute",
             "file-stream": "60/minute",
+            "conversation_create_hourly": "20/hour",
+            "conversation_create_daily": "100/day",
+            "project_create_hourly": "10/hour",
+            "project_create_daily": "100/day",
         },
     }
 

--- a/src/frontend/apps/conversations/src/api/APIError.ts
+++ b/src/frontend/apps/conversations/src/api/APIError.ts
@@ -8,6 +8,8 @@ interface IAPIError<T = unknown> {
   status: number;
   /** Optional list of error causes (e.g., validation issues) */
   cause?: string[];
+  /** Optional seconds to wait before retrying, from the `Retry-After` header */
+  retryAfter?: number;
   /** Optional extra data provided with the error */
   data?: T;
 }
@@ -22,6 +24,7 @@ interface IAPIError<T = unknown> {
 export class APIError<T = unknown> extends Error implements IAPIError<T> {
   public status: IAPIError['status'];
   public cause?: IAPIError['cause'];
+  public retryAfter?: IAPIError['retryAfter'];
   public data?: IAPIError<T>['data'];
 
   /**
@@ -30,13 +33,18 @@ export class APIError<T = unknown> extends Error implements IAPIError<T> {
    * @param message - The human-readable error message.
    * @param status - The HTTP status code or equivalent.
    * @param cause - (Optional) List of strings describing error causes.
+   * @param retryAfter - (Optional) Seconds to wait before retrying.
    * @param data - (Optional) Any additional data returned by the API.
    */
-  constructor(message: string, { status, cause, data }: IAPIError<T>) {
+  constructor(
+    message: string,
+    { status, cause, retryAfter, data }: IAPIError<T>,
+  ) {
     super(message);
     this.name = 'APIError';
     this.status = status;
     this.cause = cause;
+    this.retryAfter = retryAfter;
     this.data = data;
   }
 }

--- a/src/frontend/apps/conversations/src/api/__tests__/rateLimit.test.ts
+++ b/src/frontend/apps/conversations/src/api/__tests__/rateLimit.test.ts
@@ -1,0 +1,51 @@
+import { TFunction } from 'i18next';
+
+import { APIError, formatRetryDelay, isRateLimitError } from '@/api';
+
+// Stands in for i18next: returns the key with its interpolations applied, so
+// the assertions read as the sentence a user would see.
+const t = ((key: string, options?: Record<string, unknown>) =>
+  Object.entries(options ?? {}).reduce(
+    (text, [name, value]) => text.replace(`{{${name}}}`, String(value)),
+    key,
+  )) as unknown as TFunction;
+
+describe('rateLimit', () => {
+  describe('isRateLimitError', () => {
+    it('recognises a throttled response', () => {
+      expect(isRateLimitError(new APIError('nope', { status: 429 }))).toBe(
+        true,
+      );
+    });
+
+    it('ignores other failures', () => {
+      expect(isRateLimitError(new APIError('nope', { status: 400 }))).toBe(
+        false,
+      );
+      expect(isRateLimitError(new Error('boom'))).toBe(false);
+      expect(isRateLimitError(undefined)).toBe(false);
+    });
+  });
+
+  describe('formatRetryDelay', () => {
+    it('rounds up to the coarsest truthful unit', () => {
+      expect(formatRetryDelay(30, t)).toBe('about a minute');
+      expect(formatRetryDelay(150, t)).toBe('3 minutes');
+      expect(formatRetryDelay(3218, t)).toBe('54 minutes');
+      expect(formatRetryDelay(3600, t)).toBe('about an hour');
+      expect(formatRetryDelay(7200, t)).toBe('2 hours');
+    });
+
+    it('never interpolates a value that would need a singular form', () => {
+      // Anything under 90s takes the wordy branch, so the smallest number the
+      // minutes branch can print is 2.
+      expect(formatRetryDelay(89, t)).toBe('about a minute');
+      expect(formatRetryDelay(91, t)).toBe('2 minutes');
+    });
+
+    it('returns null without a usable delay', () => {
+      expect(formatRetryDelay(undefined, t)).toBeNull();
+      expect(formatRetryDelay(0, t)).toBeNull();
+    });
+  });
+});

--- a/src/frontend/apps/conversations/src/api/__tests__/utils.test.ts
+++ b/src/frontend/apps/conversations/src/api/__tests__/utils.test.ts
@@ -2,9 +2,14 @@ import { errorCauses, getCSRFToken } from '@/api';
 
 describe('utils', () => {
   describe('errorCauses', () => {
-    const createMockResponse = (jsonData: any, status = 400): Response => {
+    const createMockResponse = (
+      jsonData: any,
+      status = 400,
+      headers: Record<string, string> = {},
+    ): Response => {
       return {
         status,
+        headers: new Headers(headers),
         json: () => jsonData,
       } as unknown as Response;
     };
@@ -32,6 +37,27 @@ describe('utils', () => {
       expect(result.status).toBe(500);
       expect(result.cause).toBeUndefined();
       expect(result.data).toBeUndefined();
+    });
+
+    it('reads the retry delay from the Retry-After header', async () => {
+      const mockResponse = createMockResponse({ detail: 'throttled' }, 429, {
+        'Retry-After': '3218',
+      });
+
+      const result = await errorCauses(mockResponse);
+
+      expect(result.status).toBe(429);
+      expect(result.retryAfter).toBe(3218);
+    });
+
+    it('leaves the retry delay undefined without a usable header', async () => {
+      const withoutHeader = await errorCauses(createMockResponse({}, 400));
+      const withGarbage = await errorCauses(
+        createMockResponse({}, 400, { 'Retry-After': 'soon' }),
+      );
+
+      expect(withoutHeader.retryAfter).toBeUndefined();
+      expect(withGarbage.retryAfter).toBeUndefined();
     });
   });
 

--- a/src/frontend/apps/conversations/src/api/index.ts
+++ b/src/frontend/apps/conversations/src/api/index.ts
@@ -2,5 +2,6 @@ export * from './APIError';
 export * from './config';
 export * from './fetchApi';
 export * from './helpers';
+export * from './rateLimit';
 export * from './types';
 export * from './utils';

--- a/src/frontend/apps/conversations/src/api/rateLimit.ts
+++ b/src/frontend/apps/conversations/src/api/rateLimit.ts
@@ -1,0 +1,52 @@
+import { TFunction } from 'i18next';
+
+import { APIError } from './APIError';
+
+/**
+ * Type guard for a response rejected by a server-side rate limit.
+ */
+export const isRateLimitError = (error: unknown): error is APIError =>
+  error instanceof APIError && error.status === 429;
+
+/**
+ * Human-readable delay before a rate limited action can be retried.
+ *
+ * Rounds up to the coarsest unit that stays truthful, since the exact second
+ * is never actionable: someone told to wait 3218 seconds only needs to know
+ * it is about 54 minutes. Returns null when the server sent no usable delay.
+ */
+export const formatRetryDelay = (
+  seconds: number | undefined,
+  t: TFunction,
+): string | null => {
+  if (!seconds || seconds <= 0) {
+    return null;
+  }
+  // Phrased so that every interpolated value is plural, which keeps these as
+  // ordinary strings: the codebase has no plural-form translation keys.
+  if (seconds < 90) {
+    return t('about a minute');
+  }
+  const minutes = Math.ceil(seconds / 60);
+  if (minutes < 60) {
+    return t('{{minutes}} minutes', { minutes });
+  }
+  const hours = Math.ceil(minutes / 60);
+  return hours === 1 ? t('about an hour') : t('{{hours}} hours', { hours });
+};
+
+/**
+ * Message shown when the user hits a creation rate limit.
+ *
+ * The API answers with the framework default wording, which talks about
+ * requests being throttled and counts in raw seconds; this states what
+ * happened in product terms instead, and adds the delay when we know it.
+ */
+export const rateLimitMessage = (error: APIError, t: TFunction): string => {
+  const delay = formatRetryDelay(error.retryAfter, t);
+  return delay
+    ? t('You have made too many requests. Please try again in {{delay}}.', {
+        delay,
+      })
+    : t('You have made too many requests. Please try again later.');
+};

--- a/src/frontend/apps/conversations/src/api/utils.ts
+++ b/src/frontend/apps/conversations/src/api/utils.ts
@@ -9,6 +9,8 @@
  * @returns An object containing:
  *   - `status`: HTTP status code from the response
  *   - `cause`: A flattened list of error messages, or undefined if no body
+ *   - `retryAfter`: Seconds to wait, from the `Retry-After` header, when the
+ *     server sent one (rate limited responses do)
  *   - `data`: The optional data passed in
  */
 export const errorCauses = async (response: Response, data?: unknown) => {
@@ -23,9 +25,13 @@ export const errorCauses = async (response: Response, data?: unknown) => {
         .flat()
     : undefined;
 
+  const retryAfter = Number(response.headers.get('Retry-After'));
+
   return {
     status: response.status,
     cause: causes,
+    retryAfter:
+      Number.isFinite(retryAfter) && retryAfter > 0 ? retryAfter : undefined,
     data,
   };
 };

--- a/src/frontend/apps/conversations/src/features/chat/components/Chat.tsx
+++ b/src/frontend/apps/conversations/src/features/chat/components/Chat.tsx
@@ -20,7 +20,13 @@ import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router';
 
-import { APIError, errorCauses, fetchAPI } from '@/api';
+import {
+  APIError,
+  errorCauses,
+  fetchAPI,
+  isRateLimitError,
+  rateLimitMessage,
+} from '@/api';
 import { Box, HorizontalSeparator, Icon, Loader, Text } from '@/components';
 import { useConfig } from '@/core';
 import { useProjectAttachments } from '@/features/attachments/api/useProjectAttachments';
@@ -966,6 +972,30 @@ export const Chat = ({
                 setPendingFirstMessage(null);
               }
             }, 0);
+          },
+          onError: (error) => {
+            // The pending store was primed for a navigation that is not going
+            // to happen. It has to be cleared: the mount effect above submits
+            // whatever it finds there, so leaving the message behind would
+            // auto-send it into the next conversation the user opens. The
+            // composer still holds the text (this path returns before the
+            // message is handed over), so trying again just works.
+            clearPendingInput();
+            setPendingFirstMessage(null);
+            setChatErrorModal({
+              title: isRateLimitError(error)
+                ? t('Too many conversations')
+                : t('Error'),
+              message: (
+                <Text>
+                  {isRateLimitError(error)
+                    ? rateLimitMessage(error, t)
+                    : t(
+                        'Failed to start a new conversation. Please try again.',
+                      )}
+                </Text>
+              ),
+            });
           },
         },
       );

--- a/src/frontend/apps/conversations/src/features/left-panel/components/projects/ModalProjectForm.tsx
+++ b/src/frontend/apps/conversations/src/features/left-panel/components/projects/ModalProjectForm.tsx
@@ -12,6 +12,7 @@ import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router';
 import { css } from 'styled-components';
 
+import { isRateLimitError, rateLimitMessage } from '@/api';
 import FileDocIcon from '@/assets/icons/uikit-custom/file-doc.svg?react';
 import FileGenericIcon from '@/assets/icons/uikit-custom/file-filled.svg?react';
 import FileImageIcon from '@/assets/icons/uikit-custom/file-image.svg?react';
@@ -597,11 +598,14 @@ export const ModalProjectForm = ({
         setProjectId(created.id);
         void navigate('/chat');
       } catch (error) {
+        // A rate limited creation reports the framework default wording, which
+        // counts in raw seconds: replace it with the product message.
         const err = error as { cause?: string[]; message?: string };
-        const errorMessage =
-          err.cause?.[0] ||
-          err.message ||
-          t('An error occurred while creating the project');
+        const errorMessage = isRateLimitError(error)
+          ? rateLimitMessage(error, t)
+          : err.cause?.[0] ||
+            err.message ||
+            t('An error occurred while creating the project');
         showToast('error', errorMessage, undefined, 4000);
       }
     }


### PR DESCRIPTION
## Purpose

Staging ran out of database disk after an authorized security company ran automated conversation creation against the assistant. Nothing they did was out of scope: the application simply had no ceiling on how fast a single authenticated account could create rows. Conversation and project creation were not rate limited at all, and the
one throttle on the chat endpoint only engages when a model is reported as degraded, so it never applies in normal operation. The same traffic shape will eventually arrive from a buggy client or an integration retry loop, so this is treated as a capacity control rather than an abuse one.


https://github.com/orgs/suitenumerique/projects/13/views/3?filterQuery=&pane=issue&itemId=238038000&issue=suitenumerique%7Cconversations%7C697


https://github.com/orgs/suitenumerique/projects/13/views/3?filterQuery=&pane=issue&itemId=238038000&issue=suitenumerique%7Cconversations%7C697

 ## Proposal

- [ ] Rate limit conversation creation and project creation for each authenticated user
- [ ] Apply an hourly and a daily limit together on each
- [ ] Make every rate configurable per environment
- [ ] Leave every other operation untouched
- [ ] Document the new settings t
- [ ] Add tests for both limits, for isolation between users, and for the paths that must stay unthrottled


 

 
<img width="1202" height="808" alt="Capture d’écran 2026-09-01 à 09 31 23" src="https://github.com/user-attachments/assets/03cac160-9275-4a08-a1d2-55d30cf4d258" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-user hourly and daily limits for creating conversations and projects.
  * Default limits are 20 conversations/hour, 100/day, 10 projects/hour, and 100/day.
  * Limits can be configured through environment settings.
* **Bug Fixes**
  * Existing conversation updates and message posting remain unaffected.
  * Rate-limit messages now include estimated retry timing when available.
* **Documentation**
  * Added guidance on rate formats, counting behavior, and when settings take effect.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->