### PR TITLE
Providenz/fix frontend

### DIFF
--- a/src/frontend/apps/conversations/src/features/chat/components/Chat.tsx
+++ b/src/frontend/apps/conversations/src/features/chat/components/Chat.tsx
@@ -396,11 +396,14 @@ export const Chat = ({
 
     const { input: lastInput, files: lastFiles } = lastSubmissionRef.current;
 
-    const lastAssistantIndex = messages.findLastIndex(
-      (msg) => msg.role === 'assistant',
-    );
-    if (lastAssistantIndex !== -1) {
-      setMessages(messages.filter((_, index) => index !== lastAssistantIndex));
+    // Drop the whole failed turn - the last user message and anything the
+    // failed attempt produced after it - because the resubmit below adds the
+    // question back. Removing just the last assistant message deleted the
+    // *previous*, successful answer whenever the attempt failed before
+    // producing one, and left the question on screen twice.
+    const lastUserIndex = messages.findLastIndex((msg) => msg.role === 'user');
+    if (lastUserIndex !== -1) {
+      setMessages(messages.slice(0, lastUserIndex));
     }
 
     retryOriginalInputRef.current = input;

--- a/src/frontend/apps/conversations/src/features/chat/components/Chat.tsx
+++ b/src/frontend/apps/conversations/src/features/chat/components/Chat.tsx
@@ -226,9 +226,10 @@ export const Chat = ({
     input: string;
     files: FileList | null;
   } | null>(null);
-  // Read from the async fetch below, which resolves long after its closure was
-  // created and must not act on a stale `messages`.
-  const messagesRef = useRef<UIMessage[]>([]);
+  // Whether anything has been sent into the conversation currently loaded. Once
+  // it has, the client is authoritative and a fetched snapshot must not replace
+  // it. Reset when the conversation changes, below.
+  const hasSentRef = useRef(false);
   // The history fetch currently in flight, so a submission can wait for it
   // instead of racing it. Never rejects: fetchInitialMessages catches.
   const historyFetchRef = useRef<Promise<void> | null>(null);
@@ -361,8 +362,6 @@ export const Chat = ({
     onError: onErrorChat,
     onImagesSkipped,
   });
-
-  messagesRef.current = messages;
 
   const stopGeneration = async () => {
     await stopChat();
@@ -782,6 +781,7 @@ export const Chat = ({
     // user submits in that window, posted to its endpoint.
     if (loadedConversationIdRef.current !== initialConversationId) {
       loadedConversationIdRef.current = initialConversationId;
+      hasSentRef.current = false;
       setInitialConversationMessages(undefined);
       setMessages([]);
     }
@@ -821,8 +821,10 @@ export const Chat = ({
             // also re-runs when `pendingInput` clears at the end of the
             // new-conversation handoff, and back then the message that was just
             // sent is not persisted yet: applying the snapshot there wiped the
-            // user's question until the next reload.
-            if (messagesRef.current.length === 0) {
+            // user's question until the next reload. Keying on the send rather
+            // than on the message list keeps that true no matter which of the
+            // two lands first.
+            if (!hasSentRef.current) {
               setMessages(conversation.messages);
             }
             setImagesSkipped(conversation.images_skipped ?? false);
@@ -906,6 +908,7 @@ export const Chat = ({
     }));
 
   const send = (text: string, attachments: Attachment[]) => {
+    hasSentRef.current = true;
     void sendMessage({ text, files: toFileParts(attachments) });
     setInput('');
   };

--- a/src/frontend/apps/conversations/src/features/chat/components/Chat.tsx
+++ b/src/frontend/apps/conversations/src/features/chat/components/Chat.tsx
@@ -229,6 +229,9 @@ export const Chat = ({
   // Read from the async fetch below, which resolves long after its closure was
   // created and must not act on a stale `messages`.
   const messagesRef = useRef<UIMessage[]>([]);
+  // The history fetch currently in flight, so a submission can wait for it
+  // instead of racing it. Never rejects: fetchInitialMessages catches.
+  const historyFetchRef = useRef<Promise<void> | null>(null);
 
   const { mutate: createChatConversation } = useCreateChatConversation();
   const queryClient = useQueryClient();
@@ -836,7 +839,7 @@ export const Chat = ({
         }
       }
     }
-    void fetchInitialMessages();
+    historyFetchRef.current = fetchInitialMessages();
     return () => {
       ignore = true;
     };
@@ -909,6 +912,11 @@ export const Chat = ({
 
   // Custom submit to include attachments and handle chat creation
   const submitMessage = async () => {
+    // Sending before the history lands would leave the fetched messages
+    // unapplied: the snapshot below is only taken as initial state, and the
+    // conversation would look empty apart from this new exchange.
+    await historyFetchRef.current;
+
     // Inference-load cooldown: block new messages until the wait elapses.
     if (cooldownUntil && Date.now() < cooldownUntil) {
       return;

--- a/src/frontend/apps/conversations/src/features/chat/components/Chat.tsx
+++ b/src/frontend/apps/conversations/src/features/chat/components/Chat.tsx
@@ -233,6 +233,9 @@ export const Chat = ({
   // The history fetch currently in flight, so a submission can wait for it
   // instead of racing it. Never rejects: fetchInitialMessages catches.
   const historyFetchRef = useRef<Promise<void> | null>(null);
+  // Held while a submission is on its way to a send. Until that send starts the
+  // status stays `ready`, so the composer still accepts Enter.
+  const submitLockRef = useRef(false);
 
   const { mutate: createChatConversation } = useCreateChatConversation();
   const queryClient = useQueryClient();
@@ -919,11 +922,23 @@ export const Chat = ({
 
   // Custom submit to include attachments and handle chat creation
   const submitMessage = async () => {
-    // Sending before the history lands would leave the fetched messages
-    // unapplied: the snapshot below is only taken as initial state, and the
-    // conversation would look empty apart from this new exchange.
-    await historyFetchRef.current;
+    if (submitLockRef.current) {
+      return;
+    }
+    submitLockRef.current = true;
+    try {
+      // Sending before the history lands would leave the fetched messages
+      // unapplied: the snapshot below is only taken as initial state, and the
+      // conversation would look empty apart from this new exchange. Two
+      // submissions would otherwise wait here and resume on the same input.
+      await historyFetchRef.current;
+      await runSubmit();
+    } finally {
+      submitLockRef.current = false;
+    }
+  };
 
+  const runSubmit = async () => {
     // Inference-load cooldown: block new messages until the wait elapses.
     if (cooldownUntil && Date.now() < cooldownUntil) {
       return;

--- a/src/frontend/apps/conversations/src/features/chat/components/Chat.tsx
+++ b/src/frontend/apps/conversations/src/features/chat/components/Chat.tsx
@@ -835,7 +835,11 @@ export const Chat = ({
           // Optionally handle error (e.g., setInitialConversationMessages([]) or show error)
           if (!ignore) {
             setInitialConversationMessages([]);
-            setMessages([]);
+            // Same rule as the success branch above: a failed refetch must not
+            // clear a conversation the client has already sent into.
+            if (!hasSentRef.current) {
+              setMessages([]);
+            }
             setHasInitialized(true);
           }
         }

--- a/src/frontend/apps/conversations/src/features/chat/components/Chat.tsx
+++ b/src/frontend/apps/conversations/src/features/chat/components/Chat.tsx
@@ -226,6 +226,9 @@ export const Chat = ({
     input: string;
     files: FileList | null;
   } | null>(null);
+  // Read from the async fetch below, which resolves long after its closure was
+  // created and must not act on a stale `messages`.
+  const messagesRef = useRef<UIMessage[]>([]);
 
   const { mutate: createChatConversation } = useCreateChatConversation();
   const queryClient = useQueryClient();
@@ -355,6 +358,8 @@ export const Chat = ({
     onError: onErrorChat,
     onImagesSkipped,
   });
+
+  messagesRef.current = messages;
 
   const stopGeneration = async () => {
     await stopChat();
@@ -806,7 +811,14 @@ export const Chat = ({
             // v5 keeps the messages inside the chat instance, which was built
             // when the id changed — before this fetch resolved.
             setInitialConversationMessages(conversation.messages);
-            setMessages(conversation.messages);
+            // The server snapshot is only ever the *initial* state. This effect
+            // also re-runs when `pendingInput` clears at the end of the
+            // new-conversation handoff, and back then the message that was just
+            // sent is not persisted yet: applying the snapshot there wiped the
+            // user's question until the next reload.
+            if (messagesRef.current.length === 0) {
+              setMessages(conversation.messages);
+            }
             setImagesSkipped(conversation.images_skipped ?? false);
             setConversationProjectId(conversation.project?.id ?? null);
             setHasInitialized(true);

--- a/src/frontend/apps/conversations/src/features/chat/components/MessageItem.tsx
+++ b/src/frontend/apps/conversations/src/features/chat/components/MessageItem.tsx
@@ -277,6 +277,15 @@ const MessageItemComponent: React.FC<MessageItemProps> = ({
 
   const hasTextContent = textContent.trim().length > 0;
 
+  // v5 creates the assistant message as soon as the response starts, before any
+  // content has arrived. That empty bubble must not carry the copy/feedback bar:
+  // it put the thumbs up/down on screen ahead of the answer.
+  const hasAssistantOutput =
+    hasTextContent ||
+    message.parts.some(
+      (part) => part.type !== 'text' && part.type !== 'step-start',
+    );
+
   const hasNonDocumentParsingTool = React.useMemo(
     () =>
       toolInvocationParts.some(
@@ -543,6 +552,7 @@ const MessageItemComponent: React.FC<MessageItemProps> = ({
           </Box>
 
           {message.role === 'assistant' &&
+            hasAssistantOutput &&
             !(isLastAssistantMessage && status === 'streaming') && (
               <Box
                 $css="color: #222631; font-size: 12px;"

--- a/src/frontend/apps/conversations/src/features/chat/components/__tests__/Chat.test.tsx
+++ b/src/frontend/apps/conversations/src/features/chat/components/__tests__/Chat.test.tsx
@@ -1,0 +1,272 @@
+/* eslint-disable testing-library/no-unnecessary-act, @typescript-eslint/require-await, testing-library/no-node-access */
+import { ReadableStream } from 'node:stream/web';
+import { TextDecoder, TextEncoder } from 'node:util';
+import { deserialize, serialize } from 'node:v8';
+
+import { CunninghamProvider } from '@gouvfr-lasuite/cunningham-react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Suspense } from 'react';
+import { MemoryRouter } from 'react-router';
+import type { Mock } from 'vitest';
+
+import { fetchAPI } from '@/api';
+import { ToastProvider } from '@/components/ToastProvider';
+import { getConversation } from '@/features/chat/api/useConversation';
+import { usePendingChatStore } from '@/features/chat/stores/usePendingChatStore';
+
+import { Chat } from '../Chat';
+
+// jsdom implements no scrolling; the component scrolls to the latest message.
+Element.prototype.scrollTo = () => {};
+
+// jsdom ships none of the globals the SDK uses to read a streamed response.
+Object.assign(globalThis, {
+  ReadableStream,
+  TextDecoder,
+  TextEncoder,
+  structuredClone: <T,>(value: T): T => deserialize(serialize(value)) as T,
+});
+
+vi.mock('@/api', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/api')>()),
+  fetchAPI: vi.fn(),
+}));
+
+vi.mock('@/features/chat/api/useConversation', () => ({
+  getConversation: vi.fn(),
+  KEY_CONVERSATION: 'conversation',
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+// The markdown stack is ESM-only and irrelevant here: the assertions are about
+// which messages are on screen, not how their text is rendered.
+vi.mock('react-markdown', () => ({
+  MarkdownHooks: ({ children }: { children: string }) => <div>{children}</div>,
+}));
+vi.mock('@shikijs/rehype/core', () => ({ default: () => {} }));
+vi.mock('../../utils/shiki', () => ({
+  getHighlighter: () => Promise.resolve({}),
+}));
+vi.mock('rehype-katex', () => ({ default: () => {} }));
+vi.mock('remark-gfm', () => ({ default: () => {} }));
+vi.mock('remark-math', () => ({ default: () => {} }));
+
+vi.mock('@/core', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/core')>()),
+  useConfig: () => ({ data: {} }),
+}));
+vi.mock('@/core/config', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/core/config')>()),
+  useConfig: () => ({ data: {} }),
+}));
+vi.mock('@/features/chat/api/useAssistantHealth', () => ({
+  useAssistantHealth: () => ({ data: undefined }),
+}));
+vi.mock('@/features/chat/api/useLLMConfiguration', () => ({
+  useLLMConfiguration: () => ({ data: { models: [] } }),
+}));
+vi.mock('@/features/chat/api/useCreateConversation', () => ({
+  useCreateChatConversation: () => ({ mutate: vi.fn() }),
+}));
+vi.mock('@/features/attachments/api/useProjectAttachments', () => ({
+  useProjectAttachments: () => ({ data: undefined }),
+}));
+vi.mock('@/features/attachments/api/useReindexProjectAttachment', () => ({
+  useReindexProjectAttachment: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+vi.mock('@/features/attachments/hooks/useUploadFile', () => ({
+  useUploadFile: () => ({
+    uploadFile: vi.fn(),
+    isErrorAttachment: false,
+    errorAttachment: undefined,
+  }),
+}));
+vi.mock('@/features/sources-panel', () => ({
+  useSourcePanelAnchor: () => null,
+  SourcePanel: () => null,
+}));
+
+const ANSWER_STREAM = [
+  'data: {"type":"start"}\n\n',
+  'data: {"type":"text-start","id":"t1"}\n\n',
+  'data: {"type":"text-delta","id":"t1","delta":"An answer."}\n\n',
+  'data: {"type":"text-end","id":"t1"}\n\n',
+  'data: {"type":"finish"}\n\n',
+  'data: [DONE]\n\n',
+].join('');
+
+const streamOf = (payload: string) =>
+  new ReadableStream({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode(payload));
+      controller.close();
+    },
+  });
+
+const HISTORY = [
+  {
+    id: 'server-u1',
+    role: 'user' as const,
+    parts: [{ type: 'text' as const, text: 'An older question' }],
+  },
+  {
+    id: 'server-a1',
+    role: 'assistant' as const,
+    parts: [{ type: 'text' as const, text: 'An older answer' }],
+  },
+];
+
+const renderChat = (conversationId: string | undefined = 'conv-1') =>
+  render(
+    <MemoryRouter>
+      <QueryClientProvider
+        client={
+          new QueryClient({ defaultOptions: { queries: { retry: false } } })
+        }
+      >
+        <CunninghamProvider>
+          <ToastProvider>
+            <Suspense fallback={null}>
+              <Chat initialConversationId={conversationId} />
+            </Suspense>
+          </ToastProvider>
+        </CunninghamProvider>
+      </QueryClientProvider>
+    </MemoryRouter>,
+  );
+
+const messageTexts = () =>
+  [...document.querySelectorAll('[data-message-id]')].map((el) =>
+    el.textContent?.replace(/\s+/g, ' ').trim(),
+  );
+
+const ask = async (text: string) => {
+  const box = screen.getByRole('textbox');
+  await userEvent.type(box, text);
+  await userEvent.keyboard('{Enter}');
+};
+
+describe('Chat message ownership', () => {
+  const fetchAPIMock = vi.mocked(fetchAPI) as unknown as Mock;
+  const getConversationMock = vi.mocked(getConversation) as unknown as Mock;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    usePendingChatStore.setState({ input: '', files: null });
+    fetchAPIMock.mockImplementation((url: string) => {
+      if (url.startsWith('chat-cooldown')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ cooldown_seconds: 0 }),
+        });
+      }
+      return Promise.resolve({ ok: true, body: streamOf(ANSWER_STREAM) });
+    });
+  });
+
+  it('keeps the question on screen when a stale snapshot resolves mid-turn', async () => {
+    // The real new-conversation handoff: the component auto-submits the carried
+    // message, clears the pending input, and that re-runs the effect below.
+    // Its snapshot was taken before the message was stored, and applying it
+    // used to wipe the question until the next reload.
+    usePendingChatStore.setState({ input: 'Carried question' });
+    getConversationMock.mockResolvedValue({ messages: [] });
+
+    renderChat();
+
+    await waitFor(() => expect(getConversationMock).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(messageTexts()).toEqual([
+        'You said: Carried question',
+        'Assistant IA replied: An answer.',
+      ]),
+    );
+  });
+
+  it('replaces only the failed turn when retrying', async () => {
+    // Retry used to remove the last assistant message, which is the previous
+    // successful answer whenever the attempt failed before producing one, and
+    // it left the question on screen twice.
+    getConversationMock.mockResolvedValue({ messages: HISTORY });
+
+    renderChat();
+    await waitFor(() =>
+      expect(messageTexts()).toEqual([
+        'You said: An older question',
+        'Assistant IA replied: An older answer',
+      ]),
+    );
+
+    const cooldown = {
+      ok: true,
+      json: () => Promise.resolve({ cooldown_seconds: 0 }),
+    };
+    fetchAPIMock.mockImplementation((url: string) =>
+      url.startsWith('chat-cooldown')
+        ? Promise.resolve(cooldown)
+        : Promise.resolve({ ok: false, status: 500 }),
+    );
+
+    await act(async () => {
+      await ask('Second question');
+    });
+
+    const retry = await screen.findByRole('button', { name: 'Retry' });
+
+    fetchAPIMock.mockImplementation((url: string) =>
+      url.startsWith('chat-cooldown')
+        ? Promise.resolve(cooldown)
+        : Promise.resolve({ ok: true, body: streamOf(ANSWER_STREAM) }),
+    );
+
+    await act(async () => {
+      await userEvent.click(retry);
+    });
+
+    await waitFor(() =>
+      expect(messageTexts()).toEqual([
+        'You said: An older question',
+        'Assistant IA replied: An older answer',
+        'You said: Second question',
+        'Assistant IA replied: An answer.',
+      ]),
+    );
+  });
+
+  it('applies the fetched history even when a message is sent while it loads', async () => {
+    // Switching conversations clears the messages and fetches the new history.
+    // Sending inside that window used to leave the history unapplied, so the
+    // conversation looked empty apart from the new exchange until a reload.
+    let resolveFetch: (value: { messages: typeof HISTORY }) => void = () => {};
+    getConversationMock.mockReturnValue(
+      new Promise((resolve) => {
+        resolveFetch = resolve;
+      }),
+    );
+
+    renderChat();
+
+    // The submission is fully initiated while the fetch is still in flight.
+    await act(async () => {
+      await ask('Sent while loading');
+    });
+
+    await act(async () => {
+      resolveFetch({ messages: HISTORY });
+    });
+
+    await waitFor(() =>
+      expect(messageTexts()).toEqual([
+        'You said: An older question',
+        'Assistant IA replied: An older answer',
+        'You said: Sent while loading',
+        'Assistant IA replied: An answer.',
+      ]),
+    );
+  });
+});

--- a/src/frontend/apps/conversations/src/features/chat/components/__tests__/Chat.test.tsx
+++ b/src/frontend/apps/conversations/src/features/chat/components/__tests__/Chat.test.tsx
@@ -140,6 +140,10 @@ const renderChat = (conversationId: string | undefined = 'conv-1') =>
     </MemoryRouter>,
   );
 
+const chatPostCount = (mock: Mock) =>
+  mock.mock.calls.filter((call) => String(call[0]).includes('/conversation/'))
+    .length;
+
 const messageTexts = () =>
   [...document.querySelectorAll('[data-message-id]')].map((el) =>
     el.textContent?.replace(/\s+/g, ' ').trim(),
@@ -203,6 +207,37 @@ describe('Chat message ownership', () => {
         'Assistant IA replied: An answer.',
       ]),
     );
+  });
+
+  it('sends once when submitted twice before the history resolves', async () => {
+    // Submission waits for the in-flight history fetch, and until a send
+    // actually starts the status stays `ready`, so the composer still accepts
+    // Enter. Both submissions would otherwise resume on the same input.
+    let resolveFetch: (value: { messages: [] }) => void = () => {};
+    getConversationMock.mockReturnValue(
+      new Promise((resolve) => {
+        resolveFetch = resolve;
+      }),
+    );
+
+    renderChat();
+
+    const box = screen.getByRole('textbox');
+    await userEvent.type(box, 'Double send');
+    await userEvent.keyboard('{Enter}');
+    await userEvent.keyboard('{Enter}');
+
+    await act(async () => {
+      resolveFetch({ messages: [] });
+    });
+
+    await waitFor(() =>
+      expect(messageTexts()).toEqual([
+        'You said: Double send',
+        'Assistant IA replied: An answer.',
+      ]),
+    );
+    expect(chatPostCount(fetchAPIMock)).toBe(1);
   });
 
   it('replaces only the failed turn when retrying', async () => {

--- a/src/frontend/apps/conversations/src/features/chat/components/__tests__/Chat.test.tsx
+++ b/src/frontend/apps/conversations/src/features/chat/components/__tests__/Chat.test.tsx
@@ -188,6 +188,23 @@ describe('Chat message ownership', () => {
     );
   });
 
+  it('keeps the question on screen when the history request fails', async () => {
+    // Same rule as a resolved snapshot: a failed refetch must not clear a
+    // conversation the client has already sent into.
+    usePendingChatStore.setState({ input: 'Carried question' });
+    getConversationMock.mockRejectedValue(new Error('boom'));
+
+    renderChat();
+
+    await waitFor(() => expect(getConversationMock).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(messageTexts()).toEqual([
+        'You said: Carried question',
+        'Assistant IA replied: An answer.',
+      ]),
+    );
+  });
+
   it('replaces only the failed turn when retrying', async () => {
     // Retry used to remove the last assistant message, which is the previous
     // successful answer whenever the attempt failed before producing one, and

--- a/src/frontend/apps/conversations/src/features/chat/components/__tests__/MessageItem.test.tsx
+++ b/src/frontend/apps/conversations/src/features/chat/components/__tests__/MessageItem.test.tsx
@@ -486,6 +486,60 @@ describe('MessageItem', () => {
       ).not.toBeInTheDocument();
     });
 
+    it('does not render the action bar before the answer has content', async () => {
+      // v5 creates the assistant message as soon as the response starts, with
+      // no parts yet. The bar used to render on that empty bubble, putting the
+      // rating controls on screen ahead of the answer.
+      await act(async () => {
+        renderWithProviders(
+          <MessageItem
+            {...defaultProps}
+            message={{ ...defaultProps.message, parts: [] }}
+            status="submitted"
+            isLastAssistantMessage={true}
+          />,
+        );
+      });
+
+      expect(
+        screen.queryByRole('button', { name: 'Copy' }),
+      ).not.toBeInTheDocument();
+    });
+
+    it('does not render the action bar for a text part that is still empty', async () => {
+      await act(async () => {
+        renderWithProviders(
+          <MessageItem
+            {...defaultProps}
+            message={{
+              ...defaultProps.message,
+              parts: [{ type: 'text' as const, text: '' }],
+            }}
+            status="submitted"
+            isLastAssistantMessage={true}
+          />,
+        );
+      });
+
+      expect(
+        screen.queryByRole('button', { name: 'Copy' }),
+      ).not.toBeInTheDocument();
+    });
+
+    it('renders the action bar once the answer has content', async () => {
+      await act(async () => {
+        renderWithProviders(
+          <MessageItem
+            {...defaultProps}
+            status="ready"
+            isLastAssistantMessage={true}
+          />,
+        );
+      });
+
+      expect(screen.getByRole('button', { name: 'Copy' })).toBeInTheDocument();
+    });
+
     it('hides copy text on mobile', async () => {
       await act(async () => {
         renderWithProviders(<MessageItem {...defaultProps} isMobile={true} />);


### PR DESCRIPTION
## Purpose

The AI SDK v5 upgrade introduced three regressions in the chat view, none of which reached production. Sending a question made it vanish from the screen until a reload, the rating controls appeared before the answer did, and retrying a failed question deleted the previous answer while duplicating the question.

## Proposal

- [ ] Treat the conversation history fetch as initial state only, so it no longer replaces a chat that is already live
- [ ] Withhold the copy and feedback controls until the assistant message actually has content
- [ ] Make retry replace the failed exchange rather than removing an unrelated answer, so the view matches what is stored

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Retrying a response now removes the entire failed conversation turn.
  * Newly sent questions are preserved while conversation history loads.
  * Conversation history is applied reliably when messages are sent during loading.
  * Copy and feedback actions no longer appear on empty assistant messages.
  * Previous assistant responses remain visible when a later response fails and is retried.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->