### PR TITLE
🐛(front) fix translation hide source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- 🐛(front) fix translation hide source
+
 ## [0.0.23] - 2026-09-07
 
 ### Added

--- a/src/frontend/apps/conversations/src/features/chat/components/MessageItem.tsx
+++ b/src/frontend/apps/conversations/src/features/chat/components/MessageItem.tsx
@@ -601,7 +601,7 @@ const MessageItemComponent: React.FC<MessageItemProps> = ({
                       }`}
                     >
                       <Text $theme="neutral" $variation="tertiary">
-                        {isSourceOpen !== message.id ? t('Show') : t('Hidden')}{' '}
+                        {isSourceOpen !== message.id ? t('Show') : t('Hide')}{' '}
                         {isSourceOpen !== message.id
                           ? `${sourceParts.length} `
                           : ''}


### PR DESCRIPTION
fix "hidden" to "hide"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the translation sources toggle label to display **“Hide”** when the sources panel is open.
  - Improved clarity when showing or hiding translation sources for a message.

- **Documentation**
  - Added a changelog entry documenting the translation source visibility fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->