### PR TITLE
👷(ci) fix the CHANGELOG check on newly opened pull requests

### DIFF
--- a/.github/workflows/conversations.yml
+++ b/.github/workflows/conversations.yml
@@ -68,8 +68,8 @@ jobs:
       - name: Check that the CHANGELOG has been modified in the current branch
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.after }}
-        run: git diff --name-only "${BASE_SHA}" "${HEAD_SHA}" | grep 'CHANGELOG.md'
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: git diff --name-only "${BASE_SHA}...${HEAD_SHA}" | grep 'CHANGELOG.md'
 
   lint-changelog:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- 🐛(ci) fix the CHANGELOG check failing when a pull request is opened
+
 ## [0.0.24] - 2026-09-08
 
 ### Fixed


### PR DESCRIPTION
## Purpose

  The `check-changelog` job fails on every **newly opened** pull request with:

  ```
  fatal: ambiguous argument '': unknown revision or path not in the working tree.
  ```

  The step read the head commit from `github.event.after`, a field GitHub only
  sends on the `synchronize` pull request action (a push to an already-open PR).
  On `opened` / `reopened` the field is absent, so `HEAD_SHA` expanded to the
  empty string and `git diff BASE ""` aborted.

  This is why the check turns green as soon as you push another commit — the
  second event *is* a `synchronize`.

  `base.sha` was never at fault: it resolves to the base branch tip, verified
  against live PRs (#723 `base=4f73043f` / `head=16d6fff2`).

  ## Proposal

  - [x] Read the head from `github.event.pull_request.head.sha`, which is present
        on every pull request event. The commit is already fetched — the checkout
        resolves `refs/pull/N/merge`, whose second parent is the head.
  - [x] Diff from the merge base (`BASE...HEAD`) rather than the base branch tip.
        The two-dot form compares *snapshots*, so a `CHANGELOG.md` entry landed on
        the base branch after the branch point makes the paths differ and passes
        the check even when the PR never touched the file.

  `fetch-depth` stays at **50**. The merge base is currently at most 8 commits
  behind the head across the last 10 merged PRs, and a shallow fetch walks both
  parents of the merge ref, so the margin is ample — no full clone needed.

  ## Verification

  Only CI can verify the actual regression: this PR must show `check-changelog`
  green on its **first** run, before any follow-up commit.

  Negative case: a commit touching only the workflow file (no changelog entry)
  should turn the job red.

  ## Notes

  Pre-existing, not addressed here: `lint-changelog` fails at `-ge 80` and
  `CHANGELOG.md` already contains an 80-column line in the released `0.0.23`
  section (`- 🏗️ (front) rename frontend build var from the NEXT_PUBLIC_ prefix to
  VITE_`). Fixing it would mean editing a shipped release section.

  Two things I'd flag before you post it: the "at most 8 commits" figure comes from the last
  10 merged PRs I sampled, not the full history. And I never ran the three-dot behavior as
  a test — my scratch-repo demo was blocked by a permission hook, so that claim rests on git
  semantics (A...B ≡ diff $(merge-base A B) B), not on output I observed.